### PR TITLE
Build Script for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,9 +251,7 @@ compile_commands.json
 .TagStudio
 TagStudio.ini
 
-build
-dist
-TagStudio.spec
+
 
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,python,qt

--- a/.gitignore
+++ b/.gitignore
@@ -251,4 +251,9 @@ compile_commands.json
 .TagStudio
 TagStudio.ini
 
+build
+dist
+TagStudio.spec
+
+
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,python,qt

--- a/Build_win.bat
+++ b/Build_win.bat
@@ -1,0 +1,15 @@
+@echo off
+echo Building windows executable...
+
+
+set TAGSTUDIO_NAME=TagStudio
+set TAGSTUDIO_DIR=tagstudio
+set TAGSTUDIO_DIR_RESOURCES=%TAGSTUDIO_DIR%/resources
+set TAGSTUDIO_ICON=%TAGSTUDIO_DIR%/resources/icon.ico
+set TAGSTUDIO_SRC=%TAGSTUDIO_DIR%/src
+set TAGSTUDIO_MAIN=%TAGSTUDIO_DIR%/tag_studio.py
+
+set COMMAND=PyInstaller --name "%TAGSTUDIO_NAME%" --icon "%TAGSTUDIO_ICON%" --add-data "%TAGSTUDIO_DIR_RESOURCES%:./resources" --add-data "%TAGSTUDIO_SRC%:./src" --distpath "%DIST_PATH%" -p "%TAGSTUDIO_DIR%" --console --onefile "%TAGSTUDIO_MAIN%" -y
+call .venv\Scripts\activate.bat
+%COMMAND%
+deactivate

--- a/Build_win.bat
+++ b/Build_win.bat
@@ -1,15 +1,31 @@
 @echo off
-echo Building windows executable...
-
-
 set TAGSTUDIO_NAME=TagStudio
 set TAGSTUDIO_DIR=tagstudio
 set TAGSTUDIO_DIR_RESOURCES=%TAGSTUDIO_DIR%/resources
 set TAGSTUDIO_ICON=%TAGSTUDIO_DIR%/resources/icon.ico
 set TAGSTUDIO_SRC=%TAGSTUDIO_DIR%/src
 set TAGSTUDIO_MAIN=%TAGSTUDIO_DIR%/tag_studio.py
+set BUILD_MODE=--onedir
 
-set COMMAND=PyInstaller --name "%TAGSTUDIO_NAME%" --icon "%TAGSTUDIO_ICON%" --add-data "%TAGSTUDIO_DIR_RESOURCES%:./resources" --add-data "%TAGSTUDIO_SRC%:./src" --distpath "%DIST_PATH%" -p "%TAGSTUDIO_DIR%" --console --onedir "%TAGSTUDIO_MAIN%" -y
+
+if "%1" == "--help" (
+    echo run "%~nx0" for normal Build
+    echo run "%~nx0 --portable" for Build packaged into one file
+    goto end
+)
+if "%1" == "--portable" (
+    echo Building portable executable...
+    set BUILD_MODE=--onefile
+    goto run
+)
+if not "%1" == "" (
+    echo Invalid argument run "%~nx0 --help" for help
+    goto end
+)
+:run
+echo Building executable...
+set COMMAND=PyInstaller --name "%TAGSTUDIO_NAME%" --icon "%TAGSTUDIO_ICON%" --add-data "%TAGSTUDIO_DIR_RESOURCES%:./resources" --add-data "%TAGSTUDIO_SRC%:./src" -p "%TAGSTUDIO_DIR%" --console %BUILD_MODE% "%TAGSTUDIO_MAIN%" -y
 call .venv\Scripts\activate.bat
 %COMMAND%
 deactivate
+:end

--- a/Build_win.bat
+++ b/Build_win.bat
@@ -9,7 +9,7 @@ set TAGSTUDIO_ICON=%TAGSTUDIO_DIR%/resources/icon.ico
 set TAGSTUDIO_SRC=%TAGSTUDIO_DIR%/src
 set TAGSTUDIO_MAIN=%TAGSTUDIO_DIR%/tag_studio.py
 
-set COMMAND=PyInstaller --name "%TAGSTUDIO_NAME%" --icon "%TAGSTUDIO_ICON%" --add-data "%TAGSTUDIO_DIR_RESOURCES%:./resources" --add-data "%TAGSTUDIO_SRC%:./src" --distpath "%DIST_PATH%" -p "%TAGSTUDIO_DIR%" --console --onefile "%TAGSTUDIO_MAIN%" -y
+set COMMAND=PyInstaller --name "%TAGSTUDIO_NAME%" --icon "%TAGSTUDIO_ICON%" --add-data "%TAGSTUDIO_DIR_RESOURCES%:./resources" --add-data "%TAGSTUDIO_SRC%:./src" --distpath "%DIST_PATH%" -p "%TAGSTUDIO_DIR%" --console --onedir "%TAGSTUDIO_MAIN%" -y
 call .venv\Scripts\activate.bat
 %COMMAND%
 deactivate

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PySide6_Addons>=6.5.1.1,<=6.6.3.1
 PySide6_Essentials>=6.5.1.1,<=6.6.3.1
 typing_extensions>=3.10.0.0,<=4.11.0
 ujson>=5.8.0,<=5.9.0
+Pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ PySide6_Addons>=6.5.1.1,<=6.6.3.1
 PySide6_Essentials>=6.5.1.1,<=6.6.3.1
 typing_extensions>=3.10.0.0,<=4.11.0
 ujson>=5.8.0,<=5.9.0
-Pyinstaller
+Pyinstaller==6.6.0


### PR DESCRIPTION
Adds a build script for a windows executable
It intentionally doesn't hide the console for the exe because windows defender then complains that it is a malicious programm.
Also i oriented the build script of of the mac os build script from @williamtcastro