### PR TITLE
fix: strip leading slash in library items

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -808,7 +808,7 @@ class Library:
 					f'{entry.path}/{entry.filename}')).lower().lstrip('\\').lstrip('/')] = entry.id
 			else:
 				self.filename_to_entry_id_map[str(
-					os.path.normpath(f'{entry.path}/{entry.filename}'))] = entry.id
+					os.path.normpath(f'{entry.path}/{entry.filename}')).lstrip('/')] = entry.id
 	
 	# def _map_filenames_to_entry_ids(self):
 	# 	"""Maps the file paths of entries to their index in the library list."""


### PR DESCRIPTION
I dont know where exactly the issue occurs, but for now this is good enough to fix the issue.

The issue is where files are inserted into library with leading slash, eg. "/photo.jpg" instead of "photo.jpg". That's because when `entry.path` is empty, the result is just the slash + filename.

Then when I refresh the library, `photo.jpg` isnt there apparently there (only `/photo.jpg`), so it gets inserted again as a duplicity.

