### PR TITLE
Patch Bug that prevents loading ts_library.json fields ids as integers

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -692,7 +692,7 @@ class Library:
 							fields = []
 							if 'fields' in entry:
 								# Cast JSON str keys to ints
-								for f in fields:
+								for f in entry['fields']:
 									f[int(list(f.keys())[0])
 										] = f[list(f.keys())[0]]
 									del f[list(f.keys())[0]]


### PR DESCRIPTION
https://github.com/TagStudioDev/TagStudio/blob/93177dd696aaeacb1041013dd9a4b0c1d77066e3/tagstudio/src/core/library.py#L690-L699
causes fields to load into memory as `list[dict[str,list[int]]]` instead of list[dict[int,list[int]]]

This causes #93 and leads to unintended cases of #92

Fixes #93