### PR TITLE
show all tags in Add Tags panel by default

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -1577,7 +1577,8 @@ class Library:
 
 		# NOTE: I'd expect a blank query to return all with the other implementation, but
 		# it misses stuff like Archive (id 0) so here's this as a catch-all.
-		if query == '':
+		query = query.strip()
+		if not query:
 			all: list[int] = []
 			for tag in self.tags:
 				if ignore_builtin and tag.id >= 1000:

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -27,7 +27,7 @@ class TagSearchPanel(PanelWidget):
 		super().__init__()
 		self.lib: Library = library
 		# self.callback = callback
-		self.first_tag_id = -1
+		self.first_tag_id = None
 		self.tag_limit = 30
 		# self.selected_tag: int = 0
 		self.setMinimumSize(300, 400)
@@ -68,6 +68,7 @@ class TagSearchPanel(PanelWidget):
 
 		self.root_layout.addWidget(self.search_field)
 		self.root_layout.addWidget(self.scroll_area)
+		self.update_tags('')
 
 	# def reset(self):
 	# 	self.search_field.setText('')
@@ -75,7 +76,7 @@ class TagSearchPanel(PanelWidget):
 	# 	self.search_field.setFocus()
 	
 	def on_return(self, text:str):
-		if text and self.first_tag_id >= 0:
+		if text and self.first_tag_id is not None:
 			# callback(self.first_tag_id)
 			self.tag_chosen.emit(self.first_tag_id)
 			self.search_field.setText('')
@@ -87,57 +88,52 @@ class TagSearchPanel(PanelWidget):
 	def update_tags(self, query:str):
 		# for c in self.scroll_layout.children():
 		# 	c.widget().deleteLater()
-		while self.scroll_layout.itemAt(0):
+		while self.scroll_layout.count():
 			# logging.info(f"I'm deleting { self.scroll_layout.itemAt(0).widget()}")
 			self.scroll_layout.takeAt(0).widget().deleteLater()
-		
-		if query:
-			first_id_set = False
-			for tag_id in self.lib.search_tags(query, include_cluster=True)[:self.tag_limit-1]:
-				if not first_id_set:
-					self.first_tag_id = tag_id
-					first_id_set = True
 
-				c = QWidget()
-				l = QHBoxLayout(c)
-				l.setContentsMargins(0,0,0,0)
-				l.setSpacing(3)
-				tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, False)
-				ab = QPushButton()
-				ab.setMinimumSize(23, 23)
-				ab.setMaximumSize(23, 23)
-				ab.setText('+')
-				ab.setStyleSheet(
-								f'QPushButton{{'
-									f'background: {get_tag_color(ColorType.PRIMARY, self.lib.get_tag(tag_id).color)};'
-									# f'background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 {get_tag_color(ColorType.PRIMARY, tag.color)}, stop:1.0 {get_tag_color(ColorType.BORDER, tag.color)});'
-									# f"border-color:{get_tag_color(ColorType.PRIMARY, tag.color)};"
-									f"color: {get_tag_color(ColorType.TEXT, self.lib.get_tag(tag_id).color)};"
-									f'font-weight: 600;'
-									f"border-color:{get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
-									f'border-radius: 6px;'
-									f'border-style:solid;'
-									f'border-width: {math.ceil(1*self.devicePixelRatio())}px;'
-									# f'padding-top: 1.5px;'
-									# f'padding-right: 4px;'
-									f'padding-bottom: 5px;'
-									# f'padding-left: 4px;'
-									f'font-size: 20px;'
-									f'}}'
-									f'QPushButton::hover'
-									f'{{'
-									f"border-color:{get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
-									f"color: {get_tag_color(ColorType.DARK_ACCENT, self.lib.get_tag(tag_id).color)};"
-									f'background: {get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};'
-									f'}}')
+		found_tags = self.lib.search_tags(query, include_cluster=True)[:self.tag_limit - 1]
+		self.first_tag_id = found_tags[0] if found_tags else None
 
-				ab.clicked.connect(lambda checked=False, x=tag_id: self.tag_chosen.emit(x))
+		for tag_id in found_tags:
+			c = QWidget()
+			l = QHBoxLayout(c)
+			l.setContentsMargins(0, 0, 0, 0)
+			l.setSpacing(3)
+			tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, False)
+			ab = QPushButton()
+			ab.setMinimumSize(23, 23)
+			ab.setMaximumSize(23, 23)
+			ab.setText('+')
+			ab.setStyleSheet(
+							f'QPushButton{{'
+								f'background: {get_tag_color(ColorType.PRIMARY, self.lib.get_tag(tag_id).color)};'
+								# f'background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 {get_tag_color(ColorType.PRIMARY, tag.color)}, stop:1.0 {get_tag_color(ColorType.BORDER, tag.color)});'
+								# f"border-color:{get_tag_color(ColorType.PRIMARY, tag.color)};"
+								f"color: {get_tag_color(ColorType.TEXT, self.lib.get_tag(tag_id).color)};"
+								f'font-weight: 600;'
+								f"border-color:{get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
+								f'border-radius: 6px;'
+								f'border-style:solid;'
+								f'border-width: {math.ceil(1*self.devicePixelRatio())}px;'
+								# f'padding-top: 1.5px;'
+								# f'padding-right: 4px;'
+								f'padding-bottom: 5px;'
+								# f'padding-left: 4px;'
+								f'font-size: 20px;'
+								f'}}'
+								f'QPushButton::hover'
+								f'{{'
+								f"border-color:{get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
+								f"color: {get_tag_color(ColorType.DARK_ACCENT, self.lib.get_tag(tag_id).color)};"
+								f'background: {get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};'
+								f'}}')
 
-				l.addWidget(tw)
-				l.addWidget(ab)
-				self.scroll_layout.addWidget(c)
-		else:
-			self.first_tag_id = -1
+			ab.clicked.connect(lambda checked=False, x=tag_id: self.tag_chosen.emit(x))
+
+			l.addWidget(tw)
+			l.addWidget(ab)
+			self.scroll_layout.addWidget(c)
 
 		self.search_field.setFocus()
 	


### PR DESCRIPTION
Right now when I want to add new tag to file via the "Add Tag" panel window, I have to trigger update of tags manually via typing into the search input. Is there any actual reason behind this? If I have a trivial number of tags, I want to see them straight away without typing anything. That's the change this PR introduces.


Beside that the empty value for `self.first_tag_id` is now `None` instead of `-1` to see better it's actually non-tag value, plus it will fail loudly in case the it would get passed somewhere it shouldnt.