### PR TITLE
Add "Delete Tag" menu option to tags in the Tag Database and tag box

### DIFF
--- a/tagstudio/src/qt/modals/build_tag.py
+++ b/tagstudio/src/qt/modals/build_tag.py
@@ -185,7 +185,7 @@ class BuildTagPanel(PanelWidget):
 		l.setContentsMargins(0,0,0,0)
 		l.setSpacing(3)
 		for tag_id in self.tag.subtag_ids:
-			tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, True)
+			tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, True, False)
 			tw.on_remove.connect(lambda checked=False, t=tag_id: self.remove_subtag_callback(t))
 			l.addWidget(tw)
 		self.scroll_layout.addWidget(c)

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -100,7 +100,7 @@ class TagSearchPanel(PanelWidget):
 			l = QHBoxLayout(c)
 			l.setContentsMargins(0, 0, 0, 0)
 			l.setSpacing(3)
-			tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, False)
+			tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, False, False)
 			ab = QPushButton()
 			ab.setMinimumSize(23, 23)
 			ab.setMaximumSize(23, 23)

--- a/tagstudio/src/qt/widgets/tag.py
+++ b/tagstudio/src/qt/widgets/tag.py
@@ -29,8 +29,9 @@ class TagWidget(QWidget):
 	on_remove = Signal()
 	on_click = Signal()
 	on_edit = Signal()
+	on_delete = Signal()
 
-	def __init__(self, library:Library, tag:Tag, has_edit:bool, has_remove:bool, on_remove_callback:FunctionType=None, on_click_callback:FunctionType=None, on_edit_callback:FunctionType=None) -> None:
+	def __init__(self, library:Library, tag:Tag, has_edit:bool, has_remove:bool, has_delete:bool, on_remove_callback:FunctionType=None, on_click_callback:FunctionType=None, on_edit_callback:FunctionType=None) -> None:
 		super().__init__()
 		self.lib = library
 		self.tag = tag
@@ -66,6 +67,11 @@ class TagWidget(QWidget):
 		self.bg_button.addAction(search_for_tag_action)
 		add_to_search_action = QAction('Add to Search', self)
 		self.bg_button.addAction(add_to_search_action)
+		
+		if has_delete:
+			delete_action = QAction('Delete Tag', self)
+			delete_action.triggered.connect(self.on_delete.emit)
+			self.bg_button.addAction(delete_action)
 
 		self.inner_layout = QHBoxLayout()
 		self.inner_layout.setObjectName('innerLayout')


### PR DESCRIPTION
I added this menu option to the tag database and tag boxes. It will prompt the user and if they say yes, delete the tags and remove all references to it

![grafik](https://github.com/TagStudioDev/TagStudio/assets/38355282/077f0e54-51b1-412a-b2c5-df4eaf6fc3e3)

One thing I added is that when you hold shift while clicking Delete Tag, the prompt and popup after it was deleted will be skipped. I figured this would be useful when deleting a lot of tags at the same time.