### PR TITLE
add code formatting & Github Action via ruff

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,11 @@
+name: Ruff
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1
+        with:
+          version: 0.4.2
+          args: 'format --check'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.2
+    hooks:
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -276,4 +276,4 @@ As of right now, no. However, I _did_ have a CLI version in the recent past befo
 
 **Yes!!** I recommend taking a look at the [Priority Features](#priority-features), [Future Features](#future-features), and [Features I Won't Pull](#features-i-likely-wont-addpull) lists, as well as the project issues to see what’s currently being worked on. Please do not submit pull requests with new feature additions without opening up an issue with a feature request first.
 
-As of writing I don’t have a concrete style guide, just try to stay within or close enough to the [PEP 8](https://peps.python.org/pep-0008/) style guide and/or match the style of the existing code.
+Code formatting is automatically checked via [ruff](https://docs.astral.sh/ruff/). To format your code, install ruff via `pip install -r requirements-dev.txt` and run `ruff format` 

--- a/README.md
+++ b/README.md
@@ -276,4 +276,8 @@ As of right now, no. However, I _did_ have a CLI version in the recent past befo
 
 **Yes!!** I recommend taking a look at the [Priority Features](#priority-features), [Future Features](#future-features), and [Features I Won't Pull](#features-i-likely-wont-addpull) lists, as well as the project issues to see what’s currently being worked on. Please do not submit pull requests with new feature additions without opening up an issue with a feature request first.
 
-Code formatting is automatically checked via [ruff](https://docs.astral.sh/ruff/). To format your code, install ruff via `pip install -r requirements-dev.txt` and run `ruff format` 
+Code formatting is automatically checked via [ruff](https://docs.astral.sh/ruff/). 
+
+To format the code manually, install ruff via `pip install -r requirements-dev.txt` and then run `ruff format` 
+
+To format the code automatically before each commit, there's a configured action available for `pre-commit` hook. Install it by running `pre-commit install`. The hook will be executed each time on running `git commit`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+exclude = ["main_window.py", "home_ui.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+ruff==0.4.2
+pre-commit==3.7.0


### PR DESCRIPTION
The current PR is quite huge, as the code has totally different styling all across the places (mixing tabs/spaces, single/double quotes, inconsistent spacing etc.), but having unified coding style is benefit in a long term.

Currently there are no enforced code styling rules other than a mild recommendation "something like pep8" in README. 
Nitpicking and bikeshedding about code formatting in PRs is not very productive, and if something can be automated then let's automate it. 

This PR is adding a job for automatic check of code formatting. If the style doesnt follow what ruff expects, it will show failing badge in PR. See example here: https://github.com/yedpodtrzitko/TagStudio/pull/1

But to make the action pass, we need to format all existing files to match the style.

To format the code, dev only needs to run `ruff format` before commiting their changes.

