### PR TITLE
fix image thumbnails rotation

### DIFF
--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -264,6 +264,8 @@ class ThumbRenderer(QObject):
 						image = new_bg
 					if image.mode != 'RGB':
 						image = image.convert(mode='RGB')
+					
+					image = ImageOps.exif_transpose(image)
 
 				# Videos =======================================================
 				elif extension in VIDEO_TYPES:


### PR DESCRIPTION
this fixes images rotated via EXIF orientation tag, see [ImageOps.exif_transpose](https://pillow.readthedocs.io/en/latest/reference/ImageOps.html#PIL.ImageOps.exif_transpose):

> If an image has an EXIF Orientation tag, other than 1, transpose the image accordingly, and remove the orientation data.

