### PR TITLE
minor bug fixes to Tag Search Box

### DIFF
--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -68,7 +68,6 @@ class TagSearchPanel(PanelWidget):
 
 		self.root_layout.addWidget(self.search_field)
 		self.root_layout.addWidget(self.scroll_area)
-		self.update_tags('')
 
 	# def reset(self):
 	# 	self.search_field.setText('')
@@ -80,12 +79,12 @@ class TagSearchPanel(PanelWidget):
 			# callback(self.first_tag_id)
 			self.tag_chosen.emit(self.first_tag_id)
 			self.search_field.setText('')
-			self.update_tags('')
+			self.update_tags()
 		else:
 			self.search_field.setFocus()
 			self.parentWidget().hide()
 
-	def update_tags(self, query:str):
+	def update_tags(self, query:str =''):
 		# for c in self.scroll_layout.children():
 		# 	c.widget().deleteLater()
 		while self.scroll_layout.count():

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -64,7 +64,7 @@ class TagBoxWidget(FieldWidget):
 		tsp = TagSearchPanel(self.lib)
 		tsp.tag_chosen.connect(lambda x: self.add_tag_callback(x))
 		self.add_modal = PanelModal(tsp, title, 'Add Tags')
-		self.add_button.clicked.connect(self.add_modal.show)
+		self.add_button.clicked.connect(lambda: (tsp.update_tags() ,self.add_modal.show()))
 
 		self.set_tags(tags)
 		# self.add_button.setHidden(True)


### PR DESCRIPTION
There was a bug if you added a tag and then directly afterwards (without selecting another element) wanted to add a tag to a field, the tag was not displayed at first, only when the `update_tag` function was called once.

and I gave the `update_tag` function an empty query as default so you don`t have to pass an empty string when you call it.