### PR TITLE
Improved TagStudio.sh

### DIFF
--- a/TagStudio.sh
+++ b/TagStudio.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
-python3 -m venv .venv
+set -e
+cd "$(dirname "$0")"
+! [ -d .venv ] && python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 python tagstudio/tag_studio.py


### PR DESCRIPTION
"set -e" to abort on error
"cd …" to prevent creating .venv if script is launched from outside git dir
"[ … ]" to skip creating venv when it already exists