### PR TITLE
Fix opening to a file with spaces in path on windows / #120

### DIFF
--- a/tagstudio/src/qt/helpers/file_opener.py
+++ b/tagstudio/src/qt/helpers/file_opener.py
@@ -35,13 +35,15 @@ def open_file(path: str, file_manager: bool = False):
 		if sys.platform == "win32":
 			normpath = os.path.normpath(path)
 			if file_manager:
-				command_name = "explorer"
-				command_args = [f"/select,{normpath}"]
+				command_name = "explorer"				
+				command_args = '/select,"' + normpath + '"'
+				# If the args are passed in a list, this will error when the path has spaces, even while surrounded in doule quotes. IDK why
+				subprocess.Popen(command_name + command_args, shell=True, close_fds=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_BREAKAWAY_FROM_JOB)
 			else:
 				command_name = "start"
 				# first parameter is for title, NOT filepath
 				command_args = ["", normpath]
-			subprocess.Popen([command_name] + command_args, shell=True, close_fds=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_BREAKAWAY_FROM_JOB)
+				subprocess.Popen([command_name] + command_args, shell=True, close_fds=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_BREAKAWAY_FROM_JOB)
 		else:
 			if sys.platform == "darwin":
 				command_name = "open"

--- a/tagstudio/src/qt/helpers/file_opener.py
+++ b/tagstudio/src/qt/helpers/file_opener.py
@@ -37,7 +37,7 @@ def open_file(path: str, file_manager: bool = False):
 			if file_manager:
 				command_name = "explorer"				
 				command_args = '/select,"' + normpath + '"'
-				# If the args are passed in a list, this will error when the path has spaces, even while surrounded in doule quotes. IDK why
+				# For some reason, if the args are passed in a list, this will error when the path has spaces, even while surrounded in double quotes
 				subprocess.Popen(command_name + command_args, shell=True, close_fds=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_BREAKAWAY_FROM_JOB)
 			else:
 				command_name = "start"


### PR DESCRIPTION
Unsure if this is exactly to style, but it should resolve #120 

Simply wrapping the path in quotes did not suffice, there seems to be some weird edge case in `.Popen()` with args containing quotes
