### PR TITLE
use list widget for selecting fields to add

### DIFF
--- a/tagstudio/src/qt/modals/add_field.py
+++ b/tagstudio/src/qt/modals/add_field.py
@@ -75,5 +75,4 @@ class AddFieldModal(QWidget):
         self.root_layout.addWidget(self.title_widget)
         self.root_layout.addWidget(self.list_widget)
 
-        self.root_layout.addStretch(1)
         self.root_layout.addWidget(self.button_container)

--- a/tagstudio/src/qt/modals/add_field.py
+++ b/tagstudio/src/qt/modals/add_field.py
@@ -10,14 +10,14 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QPushButton,
-    QComboBox,
+    QListWidget,
 )
 
 from src.core.library import Library
 
 
 class AddFieldModal(QWidget):
-    done = Signal(int)
+    done = Signal(list)
 
     def __init__(self, library: "Library"):
         # [Done]
@@ -37,30 +37,24 @@ class AddFieldModal(QWidget):
         self.title_widget.setStyleSheet(
             # 'background:blue;'
             # 'text-align:center;'
-            "font-weight:bold;" "font-size:14px;" "padding-top: 6px" ""
+            "font-weight:bold;" "font-size:14px;" "padding-top: 6px"
         )
         self.title_widget.setText("Add Field")
         self.title_widget.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.combo_box = QComboBox()
-        self.combo_box.setEditable(False)
-        # self.combo_box.setMaxVisibleItems(5)
-        self.combo_box.setStyleSheet("combobox-popup:0;")
-        self.combo_box.view().setVerticalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAsNeeded
-        )
+        self.list_widget = QListWidget()
+        self.list_widget.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+
+        items = []
         for df in self.lib.default_fields:
-            self.combo_box.addItem(
-                f'{df["name"]} ({df["type"].replace("_", " ").title()})'
-            )
+            items.append(f'{df["name"]} ({df["type"].replace("_", " ").title()})')
+
+        self.list_widget.addItems(items)
 
         self.button_container = QWidget()
         self.button_layout = QHBoxLayout(self.button_container)
         self.button_layout.setContentsMargins(6, 6, 6, 6)
         self.button_layout.addStretch(1)
-
-        # self.cancel_button = QPushButton()
-        # self.cancel_button.setText('Cancel')
 
         self.cancel_button = QPushButton()
         self.cancel_button.setText("Cancel")
@@ -74,17 +68,12 @@ class AddFieldModal(QWidget):
         self.save_button.setDefault(True)
         self.save_button.clicked.connect(self.hide)
         self.save_button.clicked.connect(
-            lambda: self.done.emit(self.combo_box.currentIndex())
+            lambda: self.done.emit(self.list_widget.selectedIndexes())
         )
-        # self.save_button.clicked.connect(lambda: save_callback(widget.get_content()))
         self.button_layout.addWidget(self.save_button)
 
-        # self.returnPressed.connect(lambda: self.done.emit(self.combo_box.currentIndex()))
-
-        # self.done.connect(lambda x: callback(x))
-
         self.root_layout.addWidget(self.title_widget)
-        self.root_layout.addWidget(self.combo_box)
-        # self.root_layout.setStretch(1,2)
+        self.root_layout.addWidget(self.list_widget)
+
         self.root_layout.addStretch(1)
         self.root_layout.addWidget(self.button_container)

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -12,7 +12,7 @@ import cv2
 import rawpy
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
-from PySide6.QtCore import Signal, Qt, QSize
+from PySide6.QtCore import QModelIndex, Signal, Qt, QSize
 from PySide6.QtGui import QResizeEvent, QAction
 from PySide6.QtWidgets import (
     QWidget,
@@ -411,13 +411,13 @@ class PreviewPanel(QWidget):
         )
         self.add_field_button.clicked.connect(self.afm.show)
 
-    def add_field_to_selected(self, field_id: int):
-        """Adds an entry field to one or more selected items."""
-        added = set()
-        for item_pair in self.selected:
-            if item_pair[0] == ItemType.ENTRY and item_pair[1] not in added:
-                self.lib.add_field_to_entry(item_pair[1], field_id)
-                added.add(item_pair[1])
+    def add_field_to_selected(self, field_list: list[QModelIndex]):
+        """Add list of entry fields to one or more selected items."""
+        for item_type, item_id in self.selected:
+            if item_type != ItemType.ENTRY:
+                continue
+            for field_item in field_list:
+                self.lib.add_field_to_entry(item_id, field_item.row())
 
     # def update_widgets(self, item: Union[Entry, Collation, Tag]):
     def update_widgets(self):


### PR DESCRIPTION
Use ListWidget instead of ComboBox, so multiple new fields can be added at the same time.

![Screenshot 2024-05-04 at 20 04 11](https://github.com/TagStudioDev/TagStudio/assets/162526/5572ff28-45e5-4bda-950a-6add3f1d5d1e)
