### PR TITLE
dont run job threads needlessly

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -549,6 +549,11 @@ class QtDriver(QObject):
         for _ in self.thumb_threads:
             self.thumb_job_queue.put(Consumer.MARKER_QUIT)
 
+        # wait for threads to quit
+        for thread in self.thumb_threads:
+            thread.quit()
+            thread.wait()
+
         QApplication.quit()
 
     def save_library(self, show_status=True):

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -132,19 +132,20 @@ class NavigationState:
 
 
 class Consumer(QThread):
+    MARKER_QUIT = "MARKER_QUIT"
+
     def __init__(self, queue) -> None:
         self.queue = queue
         QThread.__init__(self)
 
     def run(self):
-        self.active = True
-        while self.active:
+        while True:
             try:
-                job = self.queue.get(timeout=0.2)
-                # print('Running job...')
-                # logging.info(*job[1])
+                job = self.queue.get()
+                if job == self.MARKER_QUIT:
+                    break
                 job[0](*job[1])
-            except (Empty, RuntimeError):
+            except RuntimeError:
                 pass
 
     def set_page_count(self, count: int):
@@ -179,7 +180,7 @@ class QtDriver(QObject):
         # self.title_text: str = self.base_title
         # self.buffer = {}
         self.thumb_job_queue: Queue = Queue()
-        self.thumb_threads = []
+        self.thumb_threads: list[Consumer] = []
         self.thumb_cutoff: float = time.time()
         # self.selected: list[tuple[int,int]] = [] # (Thumb Index, Page Index)
         self.selected: list[tuple[ItemType, int]] = []  # (Item Type, Item ID)
@@ -545,10 +546,9 @@ class QtDriver(QObject):
             self.settings.setValue("last_library", self.lib.library_dir)
             self.settings.sync()
         logging.info("[SHUTDOWN] Ending Thumbnail Threads...")
-        for thread in self.thumb_threads:
-            thread.active = False
-            thread.quit()
-            thread.wait()
+        for _ in self.thumb_threads:
+            self.thumb_job_queue.put(Consumer.MARKER_QUIT)
+
         QApplication.quit()
 
     def save_library(self, show_status=True):


### PR DESCRIPTION
Currently the worker threads are running in a loop and raise `Empty` error each time when `queue.get()` in there timeouts (ie. every 0.2 seconds) and repeat the same thing again, which is not very clean.

This PR makes call of `queue.get()` blocking, so there's no need for the exception-raising mumbo jumbo. Previously there was problem with this approach on application shutdown. So now when the app is quitting, there's a marker put into the queue to notify the thread it should terminate itself.

Tested on macOS only.