### PR TITLE
refactoring: centralize field IDs

### DIFF
--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -163,3 +163,6 @@ TAG_COLORS = [
     "cool gray",
     "olive",
 ]
+
+TAG_FAVORITE = 1
+TAG_ARCHIVED = 0

--- a/tagstudio/src/core/enums.py
+++ b/tagstudio/src/core/enums.py
@@ -24,3 +24,16 @@ class SearchMode(int, enum.Enum):
 
     AND = 0
     OR = 1
+
+
+class FieldID(int, enum.Enum):
+    TITLE = 0
+    AUTHOR = 1
+    ARTIST = 2
+    DESCRIPTION = 4
+    NOTES = 5
+    TAGS = 6
+    CONTENT_TAGS = 7
+    META_TAGS = 8
+    DATE_PUBLISHED = 14
+    SOURCE = 21

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -5,7 +5,6 @@
 """The Library object and related methods for TagStudio."""
 
 import datetime
-import json
 import logging
 import os
 import time
@@ -17,8 +16,6 @@ from enum import Enum
 from pathlib import Path
 from typing import cast, Generator
 from typing_extensions import Self
-
-import ujson
 
 from src.core.enums import FieldID
 from src.core.json_typing import JsonCollation, JsonEntry, JsonLibary, JsonTag

--- a/tagstudio/src/core/ts_core.py
+++ b/tagstudio/src/core/ts_core.py
@@ -7,6 +7,7 @@
 import json
 import os
 from pathlib import Path
+from enum import Enum
 
 from src.core.library import Entry, Library
 from src.core.constants import TS_FOLDER_NAME, TEXT_FIELDS

--- a/tagstudio/src/qt/modals/folders_to_tags.py
+++ b/tagstudio/src/qt/modals/folders_to_tags.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
     QFrame,
 )
 
+from src.core.enums import FieldID
 from src.core.library import Library, Tag
 from src.core.palette import ColorType, get_tag_color
 from src.qt.flowlayout import FlowLayout
@@ -73,7 +74,7 @@ def folders_to_tags(library: Library):
         tag = add_folders_to_tree(folders)
         if tag:
             if not entry.has_tag(library, tag.id):
-                entry.add_tag(library, tag.id, 6)
+                entry.add_tag(library, tag.id, FieldID.TAGS)
 
     logging.info("Done")
 

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -64,6 +64,8 @@ from src.core.constants import (
     TS_FOLDER_NAME,
     VERSION_BRANCH,
     VERSION,
+    TAG_FAVORITE,
+    TAG_ARCHIVED,
 )
 from src.core.utils.web import strip_web_protocol
 from src.qt.flowlayout import FlowLayout

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1252,8 +1252,8 @@ class QtDriver(QObject):
                     filepath = self.lib.library_dir / entry.path / entry.filename
 
                     item_thumb.set_item_id(entry.id)
-                    item_thumb.assign_archived(entry.has_tag(self.lib, 0))
-                    item_thumb.assign_favorite(entry.has_tag(self.lib, 1))
+                    item_thumb.assign_archived(entry.has_tag(self.lib, TAG_ARCHIVED))
+                    item_thumb.assign_favorite(entry.has_tag(self.lib, TAG_FAVORITE))
                     # ctrl_down = True if QGuiApplication.keyboardModifiers() else False
                     # TODO: Change how this works. The click function
                     # for collations a few lines down should NOT be allowed during modifier keys.

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -7,7 +7,6 @@ import logging
 import os
 import time
 import typing
-from types import FunctionType
 from pathlib import Path
 from typing import Optional
 
@@ -25,7 +24,13 @@ from PySide6.QtWidgets import (
 
 from src.core.enums import FieldID
 from src.core.library import ItemType, Library, Entry
-from src.core.constants import AUDIO_TYPES, VIDEO_TYPES, IMAGE_TYPES
+from src.core.constants import (
+    AUDIO_TYPES,
+    VIDEO_TYPES,
+    IMAGE_TYPES,
+    TAG_FAVORITE,
+    TAG_ARCHIVED,
+)
 from src.qt.flowlayout import FlowWidget
 from src.qt.helpers.file_opener import FileOpenerHelper
 from src.qt.widgets.thumb_renderer import ThumbRenderer
@@ -38,8 +43,6 @@ ERROR = f"[ERROR]"
 WARNING = f"[WARNING]"
 INFO = f"[INFO]"
 
-TAG_FAVORITE = 1
-TAG_ARCHIVED = 0
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -23,7 +23,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
 )
 
-
+from src.core.enums import FieldID
 from src.core.library import ItemType, Library, Entry
 from src.core.constants import AUDIO_TYPES, VIDEO_TYPES, IMAGE_TYPES
 from src.qt.flowlayout import FlowWidget
@@ -38,7 +38,6 @@ ERROR = f"[ERROR]"
 WARNING = f"[WARNING]"
 INFO = f"[INFO]"
 
-DEFAULT_META_TAG_FIELD = 8
 TAG_FAVORITE = 1
 TAG_ARCHIVED = 0
 
@@ -405,8 +404,12 @@ class ItemThumb(FlowWidget):
         if self.mode == ItemType.ENTRY:
             # logging.info(f'[UPDATE BADGES] ENTRY: {self.lib.get_entry(self.item_id)}')
             # logging.info(f'[UPDATE BADGES] ARCH: {self.lib.get_entry(self.item_id).has_tag(self.lib, 0)}, FAV: {self.lib.get_entry(self.item_id).has_tag(self.lib, 1)}')
-            self.assign_archived(self.lib.get_entry(self.item_id).has_tag(self.lib, 0))
-            self.assign_favorite(self.lib.get_entry(self.item_id).has_tag(self.lib, 1))
+            self.assign_archived(
+                self.lib.get_entry(self.item_id).has_tag(self.lib, TAG_ARCHIVED)
+            )
+            self.assign_favorite(
+                self.lib.get_entry(self.item_id).has_tag(self.lib, TAG_FAVORITE)
+            )
 
     def set_item_id(self, id: int):
         """
@@ -475,7 +478,7 @@ class ItemThumb(FlowWidget):
                 entry.add_tag(
                     self.panel.driver.lib,
                     tag_id,
-                    field_id=DEFAULT_META_TAG_FIELD,
+                    field_id=FieldID.META_TAGS,
                     field_index=-1,
                 )
             else:

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -141,7 +141,7 @@ class TagBoxWidget(FieldWidget):
         # panel.tag_updated.connect(lambda tag: self.lib.update_tag(tag))
         self.edit_modal.show()
 
-    def add_tag_callback(self, tag_id):
+    def add_tag_callback(self, tag_id: int):
         # self.base_layout.addWidget(TagWidget(self.lib, self.lib.get_tag(tag), True))
         # self.tags.append(tag)
         logging.info(
@@ -154,7 +154,7 @@ class TagBoxWidget(FieldWidget):
                 self.driver.lib, tag_id, field_id=id, field_index=-1
             )
             self.updated.emit()
-        if tag_id == 0 or tag_id == 1:
+        if tag_id in (TAG_FAVORITE, TAG_ARCHIVED):
             self.driver.update_badges()
 
         # if type((x[0]) == ThumbButton):
@@ -180,7 +180,7 @@ class TagBoxWidget(FieldWidget):
                 self.driver.lib, tag_id, field_index=index[0]
             )
             self.updated.emit()
-        if tag_id == 0 or tag_id == 1:
+        if tag_id in (TAG_FAVORITE, TAG_ARCHIVED):
             self.driver.update_badges()
 
     # def show_add_button(self, value:bool):

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -10,6 +10,7 @@ import typing
 from PySide6.QtCore import Signal, Qt
 from PySide6.QtWidgets import QPushButton
 
+from src.core.constants import TAG_FAVORITE, TAG_ARCHIVED
 from src.core.library import Library, Tag
 from src.qt.flowlayout import FlowLayout
 from src.qt.widgets.fields import FieldWidget


### PR DESCRIPTION
this PR puts all field IDs into one enum, and use that instead of numbers directly or ad-hoc created variables with given values.