### PR TITLE
Refactor ThumbRenderer to be less repetitive

### DIFF
--- a/.github/workflows/apprun.yaml
+++ b/.github/workflows/apprun.yaml
@@ -1,0 +1,50 @@
+name: PySide App Test
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install system dependencies
+        run: |
+          # dont run update, it is slow 
+          # sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxkbcommon-x11-0 \
+            x11-utils \
+            libyaml-dev \
+            libegl1-mesa \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-randr0 \
+            libxcb-render-util0 \
+            libxcb-xinerama0 \
+            libopengl0 \
+            libxcb-cursor0
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run TagStudio app and check exit code
+        run: |
+          xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset"  python tagstudio/tag_studio.py --ci -o /tmp/
+          exit_code=$?
+          if [ $exit_code -eq 0 ]; then
+            echo "TagStudio ran successfully"
+          else
+            echo "TagStudio failed with exit code $exit_code"
+            exit 1
+          fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 ruff==0.4.2
 pre-commit==3.7.0
+Pyinstaller==6.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ PySide6_Addons>=6.5.1.1,<=6.6.3.1
 PySide6_Essentials>=6.5.1.1,<=6.6.3.1
 typing_extensions>=3.10.0.0,<=4.11.0
 ujson>=5.8.0,<=5.9.0
-Pyinstaller==6.6.0

--- a/tagstudio/src/cli/ts_cli.py
+++ b/tagstudio/src/cli/ts_cli.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 from PIL import Image, ImageOps, ImageChops, UnidentifiedImageError
+from PIL.Image import DecompressionBombError
 import pillow_avif
 from pathlib import Path
 import traceback
@@ -643,8 +644,12 @@ class CliDriver:
                         # raw.thumbnail((512, 512))
                         raw.thumbnail(self.external_preview_size)
                         raw.save(external_preview_path)
-                except:
-                    print(f'{ERROR} Could not load image "{filepath}"')
+                except (
+                    UnidentifiedImageError,
+                    FileNotFoundError,
+                    DecompressionBombError,
+                ) as e:
+                    print(f'{ERROR} Could not load image "{filepath} due to {e}"')
                     if self.args.external_preview:
                         self.set_external_preview_broken()
             elif file_type in VIDEO_TYPES:
@@ -1109,24 +1114,34 @@ class CliDriver:
                             # sys.stdout.write(f'\r{INFO} Combining [{i+1}/{len(self.lib.entries)}]: {self.get_file_color(file_type)}{entry.path}{os.sep}{entry.filename}{RESET}')
                             # sys.stdout.flush()
                             if file_type in IMAGE_TYPES:
-                                with Image.open(
-                                    os.path.normpath(
-                                        f"{self.lib.library_dir}/{entry.path}/{entry.filename}"
-                                    )
-                                ) as pic:
-                                    if keep_aspect:
-                                        pic.thumbnail((thumb_size, thumb_size))
-                                    else:
-                                        pic = pic.resize((thumb_size, thumb_size))
-                                    if data_tint_mode and color:
-                                        pic = pic.convert(mode="RGB")
-                                        pic = ImageChops.hard_light(
-                                            pic,
-                                            Image.new(
-                                                "RGB", (thumb_size, thumb_size), color
-                                            ),
+                                try:
+                                    with Image.open(
+                                        os.path.normpath(
+                                            f"{self.lib.library_dir}/{entry.path}/{entry.filename}"
                                         )
-                                    collage.paste(pic, (y * thumb_size, x * thumb_size))
+                                    ) as pic:
+                                        if keep_aspect:
+                                            pic.thumbnail((thumb_size, thumb_size))
+                                        else:
+                                            pic = pic.resize((thumb_size, thumb_size))
+                                        if data_tint_mode and color:
+                                            pic = pic.convert(mode="RGB")
+                                            pic = ImageChops.hard_light(
+                                                pic,
+                                                Image.new(
+                                                    "RGB",
+                                                    (thumb_size, thumb_size),
+                                                    color,
+                                                ),
+                                            )
+                                        collage.paste(
+                                            pic, (y * thumb_size, x * thumb_size)
+                                        )
+                                except DecompressionBombError as e:
+                                    print(
+                                        f"[ERROR] One of the images was too big ({e})"
+                                    )
+
                             elif file_type in VIDEO_TYPES:
                                 video = cv2.VideoCapture(filepath)
                                 video.set(

--- a/tagstudio/src/qt/helpers/gradient.py
+++ b/tagstudio/src/qt/helpers/gradient.py
@@ -1,0 +1,46 @@
+from PIL import Image, ImageEnhance, ImageChops
+
+
+def four_corner_gradient_background(image: Image.Image, adj_size, mask, hl):
+    if image.size != (adj_size, adj_size):
+        # Old 1 color method.
+        # bg_col = image.copy().resize((1, 1)).getpixel((0,0))
+        # bg = Image.new(mode='RGB',size=(adj_size,adj_size),color=bg_col)
+        # bg.thumbnail((1, 1))
+        # bg = bg.resize((adj_size,adj_size), resample=Image.Resampling.NEAREST)
+
+        # Small gradient background. Looks decent, and is only a one-liner.
+        # bg = image.copy().resize((2, 2), resample=Image.Resampling.BILINEAR).resize((adj_size,adj_size),resample=Image.Resampling.BILINEAR)
+
+        # Four-Corner Gradient Background.
+        # Not exactly a one-liner, but it's (subjectively) really cool.
+        tl = image.getpixel((0, 0))
+        tr = image.getpixel(((image.size[0] - 1), 0))
+        bl = image.getpixel((0, (image.size[1] - 1)))
+        br = image.getpixel(((image.size[0] - 1), (image.size[1] - 1)))
+        bg = Image.new(mode="RGB", size=(2, 2))
+        bg.paste(tl, (0, 0, 2, 2))
+        bg.paste(tr, (1, 0, 2, 2))
+        bg.paste(bl, (0, 1, 2, 2))
+        bg.paste(br, (1, 1, 2, 2))
+        bg = bg.resize((adj_size, adj_size), resample=Image.Resampling.BICUBIC)
+
+        bg.paste(
+            image,
+            box=(
+                (adj_size - image.size[0]) // 2,
+                (adj_size - image.size[1]) // 2,
+            ),
+        )
+
+        bg.putalpha(mask)
+        final = bg
+
+    else:
+        image.putalpha(mask)
+        final = image
+
+    hl_soft = hl.copy()
+    hl_soft.putalpha(ImageEnhance.Brightness(hl.getchannel(3)).enhance(0.5))
+    final.paste(ImageChops.soft_light(final, hl_soft), mask=hl_soft.getchannel(3))
+    return final

--- a/tagstudio/src/qt/helpers/gradient.py
+++ b/tagstudio/src/qt/helpers/gradient.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2024 Travis Abendshien (CyanVoxel).
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
 from PIL import Image, ImageEnhance, ImageChops
 
 

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -191,6 +191,9 @@ class QtDriver(QObject):
         )
 
         max_threads = os.cpu_count()
+        if args.ci:
+            # spawn only single worker in CI environment
+            max_threads = 1
         for i in range(max_threads):
             # thread = threading.Thread(target=self.consumer, name=f'ThumbRenderer_{i}',args=(), daemon=True)
             # thread.start()
@@ -234,6 +237,7 @@ class QtDriver(QObject):
 
         # Handle OS signals
         self.setup_signals()
+        # allow to process input from console, eg. SIGTERM
         timer = QTimer()
         timer.start(500)
         timer.timeout.connect(lambda: None)
@@ -524,7 +528,11 @@ class QtDriver(QObject):
             )
             self.open_library(lib)
 
-        app.exec_()
+        if self.args.ci:
+            # gracefully terminate the app in CI environment
+            self.thumb_job_queue.put((self.SIGTERM.emit, []))
+
+        app.exec()
 
         self.shutdown()
 

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -11,6 +11,7 @@ from datetime import datetime as dt
 
 import cv2
 from PIL import Image, UnidentifiedImageError
+from PIL.Image import DecompressionBombError
 from PySide6.QtCore import Signal, Qt, QSize
 from PySide6.QtGui import QResizeEvent, QAction
 from PySide6.QtWidgets import (
@@ -403,8 +404,15 @@ class PreviewPanel(QWidget):
                             )
                             raise UnidentifiedImageError
 
-                    except (UnidentifiedImageError, FileNotFoundError, cv2.error):
-                        pass
+                    except (
+                        UnidentifiedImageError,
+                        FileNotFoundError,
+                        cv2.error,
+                        DecompressionBombError,
+                    ) as e:
+                        logging.info(
+                            f"[PreviewPanel][ERROR] Couldn't Render thumbnail for {filepath} (because of {e})"
+                        )
 
                     try:
                         self.preview_img.clicked.disconnect()

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -12,12 +12,10 @@ from pathlib import Path
 import cv2
 from PIL import (
     Image,
-    ImageChops,
     UnidentifiedImageError,
     ImageQt,
     ImageDraw,
     ImageFont,
-    ImageEnhance,
     ImageOps,
     ImageFile,
 )

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -23,7 +23,7 @@ from PIL.Image import DecompressionBombError
 from PySide6.QtCore import QObject, Signal, QSize
 from PySide6.QtGui import QPixmap
 from src.core.ts_core import PLAINTEXT_TYPES, VIDEO_TYPES, IMAGE_TYPES
-from src.qt.helpers import four_corner_gradient_background
+from src.qt.helpers.gradient import four_corner_gradient_background
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -25,6 +25,7 @@ from PIL.Image import DecompressionBombError
 from PySide6.QtCore import QObject, Signal, QSize
 from PySide6.QtGui import QPixmap
 from src.core.ts_core import PLAINTEXT_TYPES, VIDEO_TYPES, IMAGE_TYPES
+from src.qt.helpers import four_corner_gradient_background
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
@@ -91,201 +92,17 @@ class ThumbRenderer(QObject):
         math.floor(12 * font_pixel_ratio),
     )
 
-    def render(
+    def _render(
         self,
         timestamp: float,
         filepath,
         base_size: tuple[int, int],
         pixelRatio: float,
         isLoading=False,
+        gradient=False,
+        update_on_ratio_change=False,
     ):
-        """Renders an entry/element thumbnail for the GUI."""
-        adj_size: int = 1
-        image = None
-        pixmap = None
-        final = None
-        extension: str = None
-        broken_thumb = False
-        # adj_font_size = math.floor(12 * pixelRatio)
-        if ThumbRenderer.font_pixel_ratio != pixelRatio:
-            ThumbRenderer.font_pixel_ratio = pixelRatio
-            ThumbRenderer.ext_font = ImageFont.truetype(
-                os.path.normpath(
-                    f"{Path(__file__).parents[3]}/resources/qt/fonts/Oxanium-Bold.ttf"
-                ),
-                math.floor(12 * ThumbRenderer.font_pixel_ratio),
-            )
-
-        if isLoading or filepath:
-            adj_size = math.ceil(base_size[0] * pixelRatio)
-
-        if isLoading:
-            li: Image.Image = ThumbRenderer.thumb_loading_512.resize(
-                (adj_size, adj_size), resample=Image.Resampling.BILINEAR
-            )
-            qim = ImageQt.ImageQt(li)
-            pixmap = QPixmap.fromImage(qim)
-            pixmap.setDevicePixelRatio(pixelRatio)
-        elif filepath:
-            mask: Image.Image = ThumbRenderer.thumb_mask_512.resize(
-                (adj_size, adj_size), resample=Image.Resampling.BILINEAR
-            ).getchannel(3)
-            hl: Image.Image = ThumbRenderer.thumb_mask_hl_512.resize(
-                (adj_size, adj_size), resample=Image.Resampling.BILINEAR
-            )
-
-            extension = os.path.splitext(filepath)[1][1:].lower()
-
-            try:
-                # Images =======================================================
-                if extension in IMAGE_TYPES:
-                    try:
-                        image = Image.open(filepath)
-                        # image = self.thumb_debug
-                        if image.mode == "RGBA":
-                            # logging.info(image.getchannel(3).tobytes())
-                            new_bg = Image.new("RGB", image.size, color="#1e1e1e")
-                            new_bg.paste(image, mask=image.getchannel(3))
-                            image = new_bg
-                        if image.mode != "RGB":
-                            image = image.convert(mode="RGB")
-
-                        image = ImageOps.exif_transpose(image)
-                    except DecompressionBombError as e:
-                        logging.info(
-                            f"[ThumbRenderer][ERROR] Couldn't Render thumbnail for {filepath} (because of {e})"
-                        )
-
-                # Videos =======================================================
-                elif extension in VIDEO_TYPES:
-                    video = cv2.VideoCapture(filepath)
-                    video.set(
-                        cv2.CAP_PROP_POS_FRAMES,
-                        (video.get(cv2.CAP_PROP_FRAME_COUNT) // 2),
-                    )
-                    success, frame = video.read()
-                    if not success:
-                        # Depending on the video format, compression, and frame
-                        # count, seeking halfway does not work and the thumb
-                        # must be pulled from the earliest available frame.
-                        video.set(cv2.CAP_PROP_POS_FRAMES, 0)
-                        success, frame = video.read()
-                    frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                    image = Image.fromarray(frame)
-
-                # Plain Text ===================================================
-                elif extension in PLAINTEXT_TYPES:
-                    try:
-                        text: str = extension
-                        with open(filepath, "r", encoding="utf-8") as text_file:
-                            text = text_file.read(256)
-                        bg = Image.new("RGB", (256, 256), color="#1e1e1e")
-                        draw = ImageDraw.Draw(bg)
-                        draw.text((16, 16), text, file=(255, 255, 255))
-                        image = bg
-                    except:
-                        logging.info(
-                            f"[ThumbRenderer][ERROR]: Coulnd't render thumbnail for {filepath}"
-                        )
-                # No Rendered Thumbnail ========================================
-                else:
-                    image = ThumbRenderer.thumb_file_default_512.resize(
-                        (adj_size, adj_size), resample=Image.Resampling.BILINEAR
-                    )
-
-                if not image:
-                    raise UnidentifiedImageError
-
-                orig_x, orig_y = image.size
-                new_x, new_y = (adj_size, adj_size)
-
-                if orig_x > orig_y:
-                    new_x = adj_size
-                    new_y = math.ceil(adj_size * (orig_y / orig_x))
-                elif orig_y > orig_x:
-                    new_y = adj_size
-                    new_x = math.ceil(adj_size * (orig_x / orig_y))
-
-                # img_ratio = new_x / new_y
-                image = image.resize((new_x, new_y), resample=Image.Resampling.BILINEAR)
-
-                if image.size != (adj_size, adj_size):
-                    # Old 1 color method.
-                    # bg_col = image.copy().resize((1, 1)).getpixel((0,0))
-                    # bg = Image.new(mode='RGB',size=(adj_size,adj_size),color=bg_col)
-                    # bg.thumbnail((1, 1))
-                    # bg = bg.resize((adj_size,adj_size), resample=Image.Resampling.NEAREST)
-
-                    # Small gradient background. Looks decent, and is only a one-liner.
-                    # bg = image.copy().resize((2, 2), resample=Image.Resampling.BILINEAR).resize((adj_size,adj_size),resample=Image.Resampling.BILINEAR)
-
-                    # Four-Corner Gradient Background.
-                    # Not exactly a one-liner, but it's (subjectively) really cool.
-                    tl = image.getpixel((0, 0))
-                    tr = image.getpixel(((image.size[0] - 1), 0))
-                    bl = image.getpixel((0, (image.size[1] - 1)))
-                    br = image.getpixel(((image.size[0] - 1), (image.size[1] - 1)))
-                    bg = Image.new(mode="RGB", size=(2, 2))
-                    bg.paste(tl, (0, 0, 2, 2))
-                    bg.paste(tr, (1, 0, 2, 2))
-                    bg.paste(bl, (0, 1, 2, 2))
-                    bg.paste(br, (1, 1, 2, 2))
-                    bg = bg.resize(
-                        (adj_size, adj_size), resample=Image.Resampling.BICUBIC
-                    )
-
-                    bg.paste(
-                        image,
-                        box=(
-                            (adj_size - image.size[0]) // 2,
-                            (adj_size - image.size[1]) // 2,
-                        ),
-                    )
-
-                    bg.putalpha(mask)
-                    final = bg
-
-                else:
-                    image.putalpha(mask)
-                    final = image
-
-                hl_soft = hl.copy()
-                hl_soft.putalpha(ImageEnhance.Brightness(hl.getchannel(3)).enhance(0.5))
-                final.paste(
-                    ImageChops.soft_light(final, hl_soft), mask=hl_soft.getchannel(3)
-                )
-
-                # hl_add = hl.copy()
-                # hl_add.putalpha(ImageEnhance.Brightness(hl.getchannel(3)).enhance(.25))
-                # final.paste(hl_add, mask=hl_add.getchannel(3))
-
-            except (UnidentifiedImageError, FileNotFoundError, cv2.error):
-                broken_thumb = True
-                final = ThumbRenderer.thumb_broken_512.resize(
-                    (adj_size, adj_size), resample=Image.Resampling.BILINEAR
-                )
-
-            qim = ImageQt.ImageQt(final)
-            if image:
-                image.close()
-            pixmap = QPixmap.fromImage(qim)
-            pixmap.setDevicePixelRatio(pixelRatio)
-
-        if pixmap:
-            self.updated.emit(timestamp, pixmap, QSize(*base_size), extension)
-
-        else:
-            self.updated.emit(timestamp, QPixmap(), QSize(*base_size), extension)
-
-    def render_big(
-        self,
-        timestamp: float,
-        filepath,
-        base_size: tuple[int, int],
-        pixelRatio: float,
-        isLoading=False,
-    ):
-        """Renders a large, non-square entry/element thumbnail for the GUI."""
+        """Internal renderer. Renders an entry/element thumbnail for the GUI."""
         adj_size: int = 1
         image: Image.Image = None
         pixmap: QPixmap = None
@@ -307,42 +124,31 @@ class ThumbRenderer(QObject):
             adj_size = math.ceil(max(base_size[0], base_size[1]) * pixelRatio)
 
         if isLoading:
-            adj_size = math.ceil((512 * pixelRatio))
             final: Image.Image = ThumbRenderer.thumb_loading_512.resize(
                 (adj_size, adj_size), resample=Image.Resampling.BILINEAR
             )
             qim = ImageQt.ImageQt(final)
             pixmap = QPixmap.fromImage(qim)
             pixmap.setDevicePixelRatio(pixelRatio)
-            self.updated_ratio.emit(1)
-
+            if update_on_ratio_change:
+                self.updated_ratio.emit(1)
         elif filepath:
-            # mask: Image.Image = ThumbRenderer.thumb_mask_512.resize(
-            # 	(adj_size, adj_size), resample=Image.Resampling.BILINEAR).getchannel(3)
-            # hl: Image.Image = ThumbRenderer.thumb_mask_hl_512.resize(
-            # 	(adj_size, adj_size), resample=Image.Resampling.BILINEAR)
-
             extension = os.path.splitext(filepath)[1][1:].lower()
 
             try:
                 # Images =======================================================
                 if extension in IMAGE_TYPES:
-                    try:
-                        image = Image.open(filepath)
-                        # image = self.thumb_debug
-                        if image.mode == "RGBA":
-                            # logging.info(image.getchannel(3).tobytes())
-                            new_bg = Image.new("RGB", image.size, color="#1e1e1e")
-                            new_bg.paste(image, mask=image.getchannel(3))
-                            image = new_bg
-                        if image.mode != "RGB":
-                            image = image.convert(mode="RGB")
+                    image = Image.open(filepath)
+                    # image = self.thumb_debug
+                    if image.mode == "RGBA":
+                        # logging.info(image.getchannel(3).tobytes())
+                        new_bg = Image.new("RGB", image.size, color="#1e1e1e")
+                        new_bg.paste(image, mask=image.getchannel(3))
+                        image = new_bg
+                    if image.mode != "RGB":
+                        image = image.convert(mode="RGB")
 
-                        image = ImageOps.exif_transpose(image)
-                    except DecompressionBombError as e:
-                        logging.info(
-                            f"[ThumbRenderer][ERROR] Couldn't Render thumbnail for {filepath} (because of {e})"
-                        )
+                    image = ImageOps.exif_transpose(image)
 
                 # Videos =======================================================
                 elif extension in VIDEO_TYPES:
@@ -360,20 +166,21 @@ class ThumbRenderer(QObject):
                         success, frame = video.read()
                     frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                     image = Image.fromarray(frame)
+
                 # Plain Text ===================================================
                 elif extension in PLAINTEXT_TYPES:
-                    try:
-                        text: str = extension
-                        with open(filepath, "r", encoding="utf-8") as text_file:
-                            text = text_file.read(256)
-                        bg = Image.new("RGB", (256, 256), color="#1e1e1e")
-                        draw = ImageDraw.Draw(bg)
-                        draw.text((16, 16), text, file=(255, 255, 255))
-                        image = bg
-                    except:
-                        logging.info(
-                            f"[ThumbRenderer][ERROR]: Coulnd't render thumbnail for {filepath}"
-                        )
+                    # try:
+                    text: str = extension
+                    with open(filepath, "r", encoding="utf-8") as text_file:
+                        text = text_file.read(256)
+                    bg = Image.new("RGB", (256, 256), color="#1e1e1e")
+                    draw = ImageDraw.Draw(bg)
+                    draw.text((16, 16), text, file=(255, 255, 255))
+                    image = bg
+                    # except Exception as e:
+                    #    logging.info(
+                    #        f"[ThumbRenderer][ERROR]: Coulnd't render thumbnail for {filepath} ({e})"
+                    #    )
                 # No Rendered Thumbnail ========================================
                 else:
                     image = ThumbRenderer.thumb_file_default_512.resize(
@@ -384,120 +191,69 @@ class ThumbRenderer(QObject):
                     raise UnidentifiedImageError
 
                 orig_x, orig_y = image.size
-                if orig_x < adj_size and orig_y < adj_size:
-                    new_x, new_y = (adj_size, adj_size)
-                    if orig_x > orig_y:
-                        new_x = adj_size
-                        new_y = math.ceil(adj_size * (orig_y / orig_x))
-                    elif orig_y > orig_x:
-                        new_y = adj_size
-                        new_x = math.ceil(adj_size * (orig_x / orig_y))
-                else:
-                    new_x, new_y = (adj_size, adj_size)
-                    if orig_x > orig_y:
-                        new_x = adj_size
-                        new_y = math.ceil(adj_size * (orig_y / orig_x))
-                    elif orig_y > orig_x:
-                        new_y = adj_size
-                        new_x = math.ceil(adj_size * (orig_x / orig_y))
+                new_x, new_y = (adj_size, adj_size)
 
-                self.updated_ratio.emit(new_x / new_y)
+                if orig_x > orig_y:
+                    new_x = adj_size
+                    new_y = math.ceil(adj_size * (orig_y / orig_x))
+                elif orig_y > orig_x:
+                    new_y = adj_size
+                    new_x = math.ceil(adj_size * (orig_x / orig_y))
+
+                # img_ratio = new_x / new_y
+                if update_on_ratio_change:
+                    self.updated_ratio.emit(new_x / new_y)
                 image = image.resize((new_x, new_y), resample=Image.Resampling.BILINEAR)
-
-                # image = image.resize(
-                # 	(new_x, new_y), resample=Image.Resampling.BILINEAR)
-
-                # if image.size != (adj_size, adj_size):
-                # 	# Old 1 color method.
-                # 	# bg_col = image.copy().resize((1, 1)).getpixel((0,0))
-                # 	# bg = Image.new(mode='RGB',size=(adj_size,adj_size),color=bg_col)
-                # 	# bg.thumbnail((1, 1))
-                # 	# bg = bg.resize((adj_size,adj_size), resample=Image.Resampling.NEAREST)
-
-                # 	# Small gradient background. Looks decent, and is only a one-liner.
-                # 	# bg = image.copy().resize((2, 2), resample=Image.Resampling.BILINEAR).resize((adj_size,adj_size),resample=Image.Resampling.BILINEAR)
-
-                # 	# Four-Corner Gradient Background.
-                # 	# Not exactly a one-liner, but it's (subjectively) really cool.
-                # 	tl = image.getpixel((0, 0))
-                # 	tr = image.getpixel(((image.size[0]-1), 0))
-                # 	bl = image.getpixel((0, (image.size[1]-1)))
-                # 	br = image.getpixel(((image.size[0]-1), (image.size[1]-1)))
-                # 	bg = Image.new(mode='RGB', size=(2, 2))
-                # 	bg.paste(tl, (0, 0, 2, 2))
-                # 	bg.paste(tr, (1, 0, 2, 2))
-                # 	bg.paste(bl, (0, 1, 2, 2))
-                # 	bg.paste(br, (1, 1, 2, 2))
-                # 	bg = bg.resize((adj_size, adj_size),
-                # 				   resample=Image.Resampling.BICUBIC)
-
-                # 	bg.paste(image, box=(
-                # 		(adj_size-image.size[0])//2, (adj_size-image.size[1])//2))
-
-                # 	bg.putalpha(mask)
-                # 	final = bg
-
-                # else:
-                # 	image.putalpha(mask)
-                # 	final = image
-
-                # hl_soft = hl.copy()
-                # hl_soft.putalpha(ImageEnhance.Brightness(
-                # 	hl.getchannel(3)).enhance(.5))
-                # final.paste(ImageChops.soft_light(final, hl_soft),
-                # 			mask=hl_soft.getchannel(3))
-
-                # hl_add = hl.copy()
-                # hl_add.putalpha(ImageEnhance.Brightness(hl.getchannel(3)).enhance(.25))
-                # final.paste(hl_add, mask=hl_add.getchannel(3))
-                scalar = 4
-                rec: Image.Image = Image.new(
-                    "RGB", tuple([d * scalar for d in image.size]), "black"
+                if gradient:
+                    mask: Image.Image = ThumbRenderer.thumb_mask_512.resize(
+                        (adj_size, adj_size), resample=Image.Resampling.BILINEAR
+                    ).getchannel(3)
+                    hl: Image.Image = ThumbRenderer.thumb_mask_hl_512.resize(
+                        (adj_size, adj_size), resample=Image.Resampling.BILINEAR
+                    )
+                    final = four_corner_gradient_background(image, adj_size, mask, hl)
+                else:
+                    scalar = 4
+                    rec: Image.Image = Image.new(
+                        "RGB", tuple([d * scalar for d in image.size]), "black"
+                    )
+                    draw = ImageDraw.Draw(rec)
+                    draw.rounded_rectangle(
+                        (0, 0) + rec.size,
+                        (base_size[0] // 32) * scalar * pixelRatio,
+                        fill="red",
+                    )
+                    rec = rec.resize(
+                        tuple([d // scalar for d in rec.size]),
+                        resample=Image.Resampling.BILINEAR,
+                    )
+                    # final = image
+                    final = Image.new("RGBA", image.size, (0, 0, 0, 0))
+                    # logging.info(rec.size)
+                    # logging.info(image.size)
+                    final.paste(image, mask=rec.getchannel(0))
+            except (
+                UnidentifiedImageError,
+                FileNotFoundError,
+                cv2.error,
+                DecompressionBombError,
+                UnicodeDecodeError,
+            ) as e:
+                logging.info(
+                    f"[ThumbRenderer][ERROR]: Coulnd't render thumbnail for {filepath} ({e})"
                 )
-                draw = ImageDraw.Draw(rec)
-                draw.rounded_rectangle(
-                    (0, 0) + rec.size,
-                    (base_size[0] // 32) * scalar * pixelRatio,
-                    fill="red",
-                )
-                rec = rec.resize(
-                    tuple([d // scalar for d in rec.size]),
-                    resample=Image.Resampling.BILINEAR,
-                )
-                # final = image
-                final = Image.new("RGBA", image.size, (0, 0, 0, 0))
-                # logging.info(rec.size)
-                # logging.info(image.size)
-                final.paste(image, mask=rec.getchannel(0))
-
-            except (UnidentifiedImageError, FileNotFoundError, cv2.error):
                 broken_thumb = True
-                self.updated_ratio.emit(1)
+                if update_on_ratio_change:
+                    self.updated_ratio.emit(1)
                 final = ThumbRenderer.thumb_broken_512.resize(
                     (adj_size, adj_size), resample=Image.Resampling.BILINEAR
                 )
-
-            # if extension in VIDEO_TYPES + ['gif', 'apng'] or broken_thumb:
-            # 	idk = ImageDraw.Draw(final)
-            # 	# idk.textlength(file_type)
-            # 	ext_offset_x = idk.textlength(
-            # 		text=extension.upper(), font=ThumbRenderer.ext_font) / 2
-            # 	ext_offset_x = math.floor(ext_offset_x * (1/pixelRatio))
-            # 	x_margin = math.floor(
-            # 		(adj_size-((base_size[0]//6)+ext_offset_x) * pixelRatio))
-            # 	y_margin = math.floor(
-            # 		(adj_size-((base_size[0]//8)) * pixelRatio))
-            # 	stroke_width = round(2 * pixelRatio)
-            # 	fill = 'white' if not broken_thumb else '#E32B41'
-            # 	idk.text((x_margin, y_margin), extension.upper(
-            # 	), fill=fill, font=ThumbRenderer.ext_font, stroke_width=stroke_width, stroke_fill=(0, 0, 0))
 
             qim = ImageQt.ImageQt(final)
             if image:
                 image.close()
             pixmap = QPixmap.fromImage(qim)
             pixmap.setDevicePixelRatio(pixelRatio)
-
         if pixmap:
             # logging.info(final.size)
             # self.updated.emit(pixmap, QSize(*final.size))
@@ -513,3 +269,32 @@ class ThumbRenderer(QObject):
 
         else:
             self.updated.emit(timestamp, QPixmap(), QSize(*base_size), extension)
+
+    def render(
+        self,
+        timestamp: float,
+        filepath,
+        base_size: tuple[int, int],
+        pixelRatio: float,
+        isLoading=False,
+    ):
+        """Renders an entry/element thumbnail for the GUI."""
+        self._render(timestamp, filepath, base_size, pixelRatio, isLoading, True)
+
+    def render_big(
+        self,
+        timestamp: float,
+        filepath,
+        base_size: tuple[int, int],
+        pixelRatio: float,
+        isLoading=False,
+    ):
+        """Renders a large, non-square entry/element thumbnail for the GUI."""
+        self._render(
+            timestamp,
+            filepath,
+            base_size,
+            pixelRatio,
+            isLoading,
+            update_on_ratio_change=True,
+        )

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -21,6 +21,7 @@ from PIL import (
     ImageOps,
     ImageFile,
 )
+from PIL.Image import DecompressionBombError
 from PySide6.QtCore import QObject, Signal, QSize
 from PySide6.QtGui import QPixmap
 from src.core.ts_core import PLAINTEXT_TYPES, VIDEO_TYPES, IMAGE_TYPES
@@ -138,17 +139,22 @@ class ThumbRenderer(QObject):
             try:
                 # Images =======================================================
                 if extension in IMAGE_TYPES:
-                    image = Image.open(filepath)
-                    # image = self.thumb_debug
-                    if image.mode == "RGBA":
-                        # logging.info(image.getchannel(3).tobytes())
-                        new_bg = Image.new("RGB", image.size, color="#1e1e1e")
-                        new_bg.paste(image, mask=image.getchannel(3))
-                        image = new_bg
-                    if image.mode != "RGB":
-                        image = image.convert(mode="RGB")
+                    try:
+                        image = Image.open(filepath)
+                        # image = self.thumb_debug
+                        if image.mode == "RGBA":
+                            # logging.info(image.getchannel(3).tobytes())
+                            new_bg = Image.new("RGB", image.size, color="#1e1e1e")
+                            new_bg.paste(image, mask=image.getchannel(3))
+                            image = new_bg
+                        if image.mode != "RGB":
+                            image = image.convert(mode="RGB")
 
-                    image = ImageOps.exif_transpose(image)
+                        image = ImageOps.exif_transpose(image)
+                    except DecompressionBombError as e:
+                        logging.info(
+                            f"[ThumbRenderer][ERROR] Couldn't Render thumbnail for {filepath} (because of {e})"
+                        )
 
                 # Videos =======================================================
                 elif extension in VIDEO_TYPES:
@@ -321,17 +327,22 @@ class ThumbRenderer(QObject):
             try:
                 # Images =======================================================
                 if extension in IMAGE_TYPES:
-                    image = Image.open(filepath)
-                    # image = self.thumb_debug
-                    if image.mode == "RGBA":
-                        # logging.info(image.getchannel(3).tobytes())
-                        new_bg = Image.new("RGB", image.size, color="#1e1e1e")
-                        new_bg.paste(image, mask=image.getchannel(3))
-                        image = new_bg
-                    if image.mode != "RGB":
-                        image = image.convert(mode="RGB")
+                    try:
+                        image = Image.open(filepath)
+                        # image = self.thumb_debug
+                        if image.mode == "RGBA":
+                            # logging.info(image.getchannel(3).tobytes())
+                            new_bg = Image.new("RGB", image.size, color="#1e1e1e")
+                            new_bg.paste(image, mask=image.getchannel(3))
+                            image = new_bg
+                        if image.mode != "RGB":
+                            image = image.convert(mode="RGB")
 
-                    image = ImageOps.exif_transpose(image)
+                        image = ImageOps.exif_transpose(image)
+                    except DecompressionBombError as e:
+                        logging.info(
+                            f"[ThumbRenderer][ERROR] Couldn't Render thumbnail for {filepath} (because of {e})"
+                        )
 
                 # Videos =======================================================
                 elif extension in VIDEO_TYPES:

--- a/tagstudio/tag_studio.py
+++ b/tagstudio/tag_studio.py
@@ -45,6 +45,11 @@ def main():
         type=str,
         help="User interface option for TagStudio. Options: qt, cli (Default: qt)",
     )
+    parser.add_argument(
+        "--ci",
+        action=argparse.BooleanOptionalAction,
+        help="Exit the application after checking it starts without any problem. Meant for CI check.",
+    )
     args = parser.parse_args()
 
     core = TagStudioCore()  # The TagStudio Core instance. UI agnostic.


### PR DESCRIPTION
I refactored the Thumbrenderer render methods and merged them into one because there were only small differences.
The outputed preview is the same as the one that used render/render_big, all small differences between the output of these methods is kept( for example the four color gradient background for the small thumbs and no for the big preview)
I am open for any changes :)