### PR TITLE
fix: Clear Edit Button on container update (#115)

### DIFF
--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -948,6 +948,7 @@ class PreviewPanel(QWidget):
             container.set_remove_callback(
                 lambda: self.remove_message_box(prompt=prompt, callback=callback)
             )
+        container.edit_button.setHidden(True)
         container.setHidden(False)
         self.place_add_field_button()
 


### PR DESCRIPTION
Added a step to clear the edit button within the write_container().  This shouldn't interfere with the edit button showing, as its default behavior is to be hidden until a hover event.