### PR TITLE
Fix bug 213

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -837,7 +837,7 @@ class Library:
 
         logging.info(f"[LIBRARY] Saving Library Backup to Disk...")
         start_time = time.time()
-        filename = f'ts_library_backup_{datetime.datetime.utcnow().strftime("%F_%T").replace(":", "")}.json'
+        filename = f'ts_library_backup_{datetime.datetime.now(datetime.UTC).strftime("%F_%T").replace(":", "")}.json'
 
         self.verify_ts_folders()
         with open(

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -925,6 +925,7 @@ class PreviewPanel(QWidget):
                     inner_container = TextWidget(
                         title, str(self.lib.get_field_attr(field, "content"))
                     )
+                    container.set_inner_widget(inner_container)
                 # if type(item) == Entry:
                 container.set_copy_callback(None)
                 container.set_edit_callback(None)


### PR DESCRIPTION
I added "container.set_inner_widget(inner_container)" in the exception to fix #213 
I don't know if this method is temporary or not, so I don't changed anything, but I think this need some rework.  The default value shoud be the dates form the file metadata. 

In library.py I see that  there is a add_generic_data_to_entry() for  this, but the add_field_to_entry() just set my date to ''