### PR TITLE
Create and activate venv via Nix Flake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,10 @@ _Learn more about setting up a virtual environment [here](https://docs.python.or
 
   - Run the "TagStudio.sh" script and the program should launch! (Make sure that the script is marked as executable if on Linux). Note that launching from the script from outside of a terminal will not launch a terminal window with any debug or crash information. If you wish to see this information, just launch the shell script directly from your terminal with `./TagStudio.sh`.
 
-  - **NixOS** (TagStudio.sh)
+  - **NixOS** (Nix Flake)
     > [!WARNING]
     > Support for NixOS is still a work in progress.
-    - Use the provided `flake.nix` file to create and enter a working environment by running `nix develop`. Then, run the `TagStudio.sh` script.
+    - Use the provided [Flake](https://nixos.wiki/wiki/Flakes) to create and enter a working environment by running `nix develop`. Then, run the program via `python3 tagstudio/tag_studio.py` from the root directory.
 
 - **Any** (No Scripts)
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717602782,
-        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
+        "lastModified": 1718318537,
+        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
+        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
         "type": "github"
       },
       "original": {
@@ -18,17 +18,17 @@
     },
     "qt6Nixpkgs": {
       "locked": {
-        "lastModified": 1711460435,
-        "narHash": "sha256-Qb/J9NFk2Qemg7vTl8EDCto6p3Uf/GGORkGhTQJLj9U=",
+        "lastModified": 1716287118,
+        "narHash": "sha256-iUTrXABmJAkPRhwPB8GEP7k52OWHVSRtMzlKQ2kIrz4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f862bd46d3020bcfe7195b3dad638329271b0524",
+        "rev": "47da0aee5616a063015f10ea593688646f2377e4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f862bd46d3020bcfe7195b3dad638329271b0524",
+        "rev": "47da0aee5616a063015f10ea593688646f2377e4",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,8 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
     qt6Nixpkgs = {
-      # Commit bumping to qt6.6.3
-      url = "github:NixOS/nixpkgs/f862bd46d3020bcfe7195b3dad638329271b0524"; 
+      # Commit bumping to qt6.7.1
+      url = "github:NixOS/nixpkgs/47da0aee5616a063015f10ea593688646f2377e4";
     };
   };
 
@@ -82,7 +82,6 @@
         unset SOURCE_DATE_EPOCH
 
         echo Installing dependencies into virtual environment
-        pip install PySide6==6.6.2 # 6.6.3 has faulty .pyi files
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
         # Hacky solution to not fight with other dev deps

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
       postShellHook = ''
         unset SOURCE_DATE_EPOCH
 
-        export QT_QPA_PLATFORM=wayland
+        export QT_QPA_PLATFORM="wayland;xcb"
         export LIBRARY_PATH=/usr/lib:/usr/lib64:$LIBRARY_PATH
         # export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib/:/run/opengl-driver/lib/
         export QT_PLUGIN_PATH=${pkgs.qt6.qtbase}/${pkgs.qt6.qtbase.qtPluginPrefix}

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
         python312Packages.pip
         python312Packages.pyusb # fixes the pyusb 'No backend available' when installed directly via pip
         python312Packages.venvShellHook # Initializes a venv in $venvDir
+        ruff # Ruff cannot be installed via pip
 
         libgcc
         glib
@@ -82,6 +83,7 @@
         echo Installing dependencies into virtual environment
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+        pip uninstall -y ruff # Hacky solution to not fight with other dev deps
       '';
 
       # set the environment variables that Qt apps expect

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
         python312Packages.pyusb # fixes the pyusb 'No backend available' when installed directly via pip
         python312Packages.venvShellHook # Initializes a venv in $venvDir
         ruff # Ruff cannot be installed via pip
+        mypy # MyPy cannot be installed via pip
 
         libgcc
         glib
@@ -81,9 +82,12 @@
         unset SOURCE_DATE_EPOCH
 
         echo Installing dependencies into virtual environment
+        pip install PySide6==6.6.2 # 6.6.3 has faulty .pyi files
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip uninstall -y ruff # Hacky solution to not fight with other dev deps
+        # Hacky solution to not fight with other dev deps
+        # May show failure if skipped due to same version with nixpkgs
+        pip uninstall -y mypy ruff
       '';
 
       # set the environment variables that Qt apps expect


### PR DESCRIPTION
When running `nix develop` to generate a development shell, the python virtual environment will now automatically be created and dependencies from requirements.txt will be installed (and the venv will be activated). Effectively, this moves the setup portion of the TagStudio.sh to the flake and means the setup script for Linux/Mac is no longer needed when using nix. The README has been updated to reflect the new process of `nix develop` then `python3 tagstudio/tag_studio.py`. 

The python virtualenvironment package has been replaced with venvShellHook, which creates a virtual environment in the directory specified by $venvDir (in this case ./.venv). This also gives the postVenvCreation hook, where pip install is then executed. The previous shellHook needed to be moved to postShellHook to execute after the venv is created. `unset SOURCE_DATE_EPOCH` is probably not necessary, but is to solve a potential issue between pip and nix and appears in a lot of python flake examples. 
