### PR TITLE
Bugfix for recent library re-creating a library at the last library location.

### DIFF
--- a/tagstudio/src/core/enums.py
+++ b/tagstudio/src/core/enums.py
@@ -16,3 +16,4 @@ class Theme(str, enum.Enum):
     COLOR_HOVER = "#65AAAAAA"
     COLOR_PRESSED = "#65EEEEEE"
     COLOR_DISABLED = "#65F39CAA"
+    COLOR_DISABLED_BG = "#65440D12"

--- a/tagstudio/src/core/enums.py
+++ b/tagstudio/src/core/enums.py
@@ -15,3 +15,4 @@ class Theme(str, enum.Enum):
     COLOR_BG = "#65000000"
     COLOR_HOVER = "#65AAAAAA"
     COLOR_PRESSED = "#65EEEEEE"
+    COLOR_DISABLED = "#65F39CAA"

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -525,6 +525,14 @@ class QtDriver(QObject):
         elif self.settings.value(SettingItems.START_LOAD_LAST, True, type=bool):
             lib = self.settings.value(SettingItems.LAST_LIBRARY)
 
+            # TODO: Remove this check if the library is no longer saved with files
+            if not (Path(lib) / TS_FOLDER_NAME).exists():
+                logging.error(
+                    f"[QT DRIVER] {TS_FOLDER_NAME} folder in {lib} does not exist."
+                )
+                self.settings.setValue(SettingItems.LAST_LIBRARY, "")
+                lib = None
+
         if lib:
             self.splash.showMessage(
                 f'Opening Library "{lib}"...',

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -526,7 +526,7 @@ class QtDriver(QObject):
             lib = self.settings.value(SettingItems.LAST_LIBRARY)
 
             # TODO: Remove this check if the library is no longer saved with files
-            if not (Path(lib) / TS_FOLDER_NAME).exists():
+            if lib and not (Path(lib) / TS_FOLDER_NAME).exists():
                 logging.error(
                     f"[QT DRIVER] {TS_FOLDER_NAME} folder in {lib} does not exist."
                 )

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -31,7 +31,7 @@ from humanfriendly import format_size
 
 from src.core.enums import SettingItems, Theme
 from src.core.library import Entry, ItemType, Library
-from src.core.constants import VIDEO_TYPES, IMAGE_TYPES, RAW_IMAGE_TYPES
+from src.core.constants import VIDEO_TYPES, IMAGE_TYPES, RAW_IMAGE_TYPES, TS_FOLDER_NAME
 from src.qt.helpers.file_opener import FileOpenerLabel, FileOpenerHelper, open_file
 from src.qt.modals.add_field import AddFieldModal
 from src.qt.widgets.thumb_renderer import ThumbRenderer
@@ -300,6 +300,7 @@ class PreviewPanel(QWidget):
                     "}"
                     f"QPushButton::hover{{background-color:{Theme.COLOR_HOVER.value};}}"
                     f"QPushButton::pressed{{background-color:{Theme.COLOR_PRESSED.value};}}"
+                    f"QPushButton::disabled{{color:{Theme.COLOR_DISABLED.value};}}"
                 )
             )
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -307,6 +308,11 @@ class PreviewPanel(QWidget):
         for item_key, (full_val, cut_val) in libraries:
             button = QPushButton(text=cut_val)
             button.setObjectName(f"path{item_key}")
+
+            lib = Path(full_val)
+            if not lib.exists() or not (lib / TS_FOLDER_NAME).exists():
+                button.setDisabled(True)
+                button.setToolTip("Location is missing")
 
             def open_library_button_clicked(path):
                 return lambda: self.driver.open_library(Path(path))

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -300,7 +300,7 @@ class PreviewPanel(QWidget):
                     "}"
                     f"QPushButton::hover{{background-color:{Theme.COLOR_HOVER.value};}}"
                     f"QPushButton::pressed{{background-color:{Theme.COLOR_PRESSED.value};}}"
-                    f"QPushButton::disabled{{color:{Theme.COLOR_DISABLED.value};}}"
+                    f"QPushButton::disabled{{background-color:{Theme.COLOR_DISABLED_BG.value};}}"
                 )
             )
             btn.setCursor(Qt.CursorShape.PointingHandCursor)


### PR DESCRIPTION
If the latest opened library no longer contains a `TS_FOLDER_NAME` (currently `.TagStudio`) folder clear the recent library and revert to default behavior for opening TagStudio. 

NOTE: if the library moves to a different architecture (e.g. living alongside preference instead of alongside the files this check will need to be removed)

Fixes #212 