### PR TITLE
Separately pin QT nixpkg version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712473363,
-        "narHash": "sha256-TIScFAVdI2yuybMxxNjC4YZ/j++c64wwuKbpnZnGiyU=",
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e89cf1c932006531f454de7d652163a9a5c86668",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
         "type": "github"
       },
       "original": {
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "qt6Pkgs": {
+      "locked": {
+        "lastModified": 1711460435,
+        "narHash": "sha256-Qb/J9NFk2Qemg7vTl8EDCto6p3Uf/GGORkGhTQJLj9U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f862bd46d3020bcfe7195b3dad638329271b0524",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f862bd46d3020bcfe7195b3dad638329271b0524",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "qt6Pkgs": "qt6Pkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716948383,
-        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "lastModified": 1717602782,
+        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
         "type": "github"
       },
       "original": {
@@ -16,7 +16,7 @@
         "type": "github"
       }
     },
-    "qt6Pkgs": {
+    "qt6Nixpkgs": {
       "locked": {
         "lastModified": 1711460435,
         "narHash": "sha256-Qb/J9NFk2Qemg7vTl8EDCto6p3Uf/GGORkGhTQJLj9U=",
@@ -35,7 +35,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "qt6Pkgs": "qt6Pkgs"
+        "qt6Nixpkgs": "qt6Nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
         pkgs.qt6.full
         pkgs.qt6.qtbase
         pkgs.zstd
+        # For PySide6 Multimedia
+        pkgs.libpulseaudio
+        pkgs.libkrb5
       ];
       buildInputs = with pkgs; [
         cmake

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,18 @@
 {
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs, }:
+    qt6Pkgs = {
+      # Commit bumping to qt6.6.3
+      url = "github:NixOS/nixpkgs/f862bd46d3020bcfe7195b3dad638329271b0524"; 
+    };
+  };
+
+  outputs = { self, nixpkgs, qt6Pkgs }:
   let
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+    qt6 = qt6Pkgs.legacyPackages.x86_64-linux.qt6;
   in {
     devShells.x86_64-linux.default = pkgs.mkShell {
       LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
@@ -17,22 +26,19 @@
         pkgs.xorg.libxcb
         pkgs.freetype
         pkgs.dbus
-        pkgs.qt6.qtwayland
-        pkgs.qt6.full
-        pkgs.qt6.qtbase
         pkgs.zstd
         # For PySide6 Multimedia
         pkgs.libpulseaudio
         pkgs.libkrb5
+
+        qt6.qtwayland
+        qt6.full
+        qt6.qtbase
       ];
       buildInputs = with pkgs; [
         cmake
         gdb
         zstd
-        qt6.qtbase
-        qt6.full
-        qt6.qtwayland
-        qtcreator
         python312Packages.pip
         python312Full
         python312Packages.virtualenv # run virtualenv .
@@ -52,11 +58,17 @@
         fontconfig
         xorg.libxcb
 
+        # this is for the shellhook portion
+        makeWrapper
+        bashInteractive
+      ] ++ [
+        qt6.qtbase
+        qt6.full
+        qt6.qtwayland
+        qtcreator
 
         # this is for the shellhook portion
         qt6.wrapQtAppsHook
-        makeWrapper
-        bashInteractive
       ];
       # set the environment variables that Qt apps expect
       shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,17 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-    qt6Pkgs = {
+    qt6Nixpkgs = {
       # Commit bumping to qt6.6.3
       url = "github:NixOS/nixpkgs/f862bd46d3020bcfe7195b3dad638329271b0524"; 
     };
   };
 
-  outputs = { self, nixpkgs, qt6Pkgs }:
+  outputs = { self, nixpkgs, qt6Nixpkgs }:
   let
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
 
-    qt6 = qt6Pkgs.legacyPackages.x86_64-linux.qt6;
+    qt6Pkgs = qt6Nixpkgs.legacyPackages.x86_64-linux;
   in {
     devShells.x86_64-linux.default = pkgs.mkShell {
       LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
@@ -31,9 +31,9 @@
         pkgs.libpulseaudio
         pkgs.libkrb5
 
-        qt6.qtwayland
-        qt6.full
-        qt6.qtbase
+        qt6Pkgs.qt6.qtwayland
+        qt6Pkgs.qt6.full
+        qt6Pkgs.qt6.qtbase
       ];
       buildInputs = with pkgs; [
         cmake
@@ -62,13 +62,13 @@
         makeWrapper
         bashInteractive
       ] ++ [
-        qt6.qtbase
-        qt6.full
-        qt6.qtwayland
-        qtcreator
+        qt6Pkgs.qt6.qtbase
+        qt6Pkgs.qt6.full
+        qt6Pkgs.qt6.qtwayland
+        qt6Pkgs.qtcreator
 
         # this is for the shellhook portion
-        qt6.wrapQtAppsHook
+        qt6Pkgs.qt6.wrapQtAppsHook
       ];
       # set the environment variables that Qt apps expect
       shellHook = ''


### PR DESCRIPTION
By pinning QT separately, the rest of dependent nixpkgs can be updated without being affected by the current QT version in nixpkgs unstable. The nixpkg revision is also bumped, fixing an issue where vim would immediately segfault on launch in the nix dev shell. This is for QT version 6.6.3, for when #223 is merged, the nixpkg commit tied to QT will need to be bumped to commit 47da0aee5616a063015f10ea593688646f2377e4. 

Also adds missing dependecies from the new video player. 
