### PR TITLE
Workflows: attempt fix for mismatched hashes in pip and bump MacOS version

### DIFF
--- a/.github/workflows/apprun.yaml
+++ b/.github/workflows/apprun.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          pip install -Ur requirements.txt
 
       - name: Run TagStudio app and check exit code
         run: |

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -16,9 +16,13 @@ jobs:
         with:
           reviewdog_version: latest
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           # pyside 6.6.3 has some issue in their .pyi files
           pip install PySide6==6.6.2
           pip install -r requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - run: pip install -Ur requirements.txt pyinstaller
       - run: pyinstaller tagstudio.spec -- ${{ matrix.build-flag }}
       - run: tar czfC dist/tagstudio_linux_x86_64${{ matrix.suffix }}.tar.gz dist tagstudio
@@ -48,6 +49,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - run: pip install -Ur requirements.txt pyinstaller
       - run: pyinstaller tagstudio.spec
       - run: tar czfC dist/tagstudio_macos_${{ matrix.arch }}.tar.gz dist TagStudio.app
@@ -75,6 +77,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - run: pip install -Ur requirements.txt pyinstaller
       - run: PyInstaller tagstudio.spec -- ${{ matrix.build-flag }}
       - run: Compress-Archive -Path dist/TagStudio${{ matrix.file-end }} -DestinationPath dist/tagstudio_windows_x86_64${{ matrix.suffix }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,15 @@ jobs:
   macos:
     strategy:
       matrix:
-        os-version: ['11', '14']
+        os-version: ['12', '14']
         include:
-          - os-version: '11'
+          - os-version: '12'
             arch: x86_64
           - os-version: '14'
             arch: aarch64
     runs-on: macos-${{ matrix.os-version }}
     env:
+      # even though we run on 12, target towards compatibility
       MACOSX_DEPLOYMENT_TARGET: '11.0'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## All Workflows
Ocassionally, a pip install will fail because of mismatched hashes, which from my research I believe this to be related to a cache error. This cannot easily be tested due to its seemingly random nature, but my hope is that my fix in using the action/setup-python workflow will avoid it.

## Only Release Workflow
Additionally, the MacOS version needs to be bumped, as `macos-11` has been deprecated. 11 is still targeted for compatibility. See [this blog post](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/) for more information.