### PR TITLE
Allow Tags to be deselected in search 

### DIFF
--- a/tagstudio/src/qt/modals/build_tag.py
+++ b/tagstudio/src/qt/modals/build_tag.py
@@ -120,7 +120,9 @@ class BuildTagPanel(PanelWidget):
         tsp.tag_chosen.connect(lambda x, checked: self.add_subtag_callback(x) if checked
                             else self.remove_subtag_callback(x))
         self.add_tag_modal = PanelModal(tsp, "Add Parent Tags", "Add Parent Tags")
-        self.subtags_add_button.clicked.connect(self.add_tag_modal.show)
+        self.subtags_add_button.clicked.connect(
+            lambda: (tsp.update_tags(current_tags=(self.tag.subtag_ids if self.tag else None)), self.add_tag_modal.show())  # type: ignore
+        )
         self.subtags_layout.addWidget(self.subtags_add_button)
 
         # self.subtags_field = TagBoxWidget()

--- a/tagstudio/src/qt/modals/build_tag.py
+++ b/tagstudio/src/qt/modals/build_tag.py
@@ -116,21 +116,14 @@ class BuildTagPanel(PanelWidget):
 
         self.subtags_add_button = QPushButton()
         self.subtags_add_button.setText("+")
-        tsp = TagSearchPanel(self.lib)
-        tsp.tag_chosen.connect(
+        self.tsp = TagSearchPanel(self.lib)
+        self.tsp.tag_chosen.connect(
             lambda x, checked: self.add_subtag_callback(x)
             if checked
             else self.remove_subtag_callback(x)
         )
-        self.add_tag_modal = PanelModal(tsp, "Add Parent Tags", "Add Parent Tags")
-        self.subtags_add_button.clicked.connect(
-            lambda: (
-                tsp.update_tags(
-                    current_tags=(self.tag.subtag_ids if self.tag else None) # type: ignore[attr-defined]
-                ),
-                self.add_tag_modal.show(),
-            )
-        )
+        self.add_tag_modal = PanelModal(self.tsp, "Add Parent Tags", "Add Parent Tags")
+        self.subtags_add_button.clicked.connect(self.add_button_clicked_callback)
         self.subtags_layout.addWidget(self.subtags_add_button)
 
         # self.subtags_field = TagBoxWidget()
@@ -176,6 +169,15 @@ class BuildTagPanel(PanelWidget):
         else:
             self.tag = Tag(-1, "New Tag", "", [], [], "")
         self.set_tag(self.tag)
+
+    def add_button_clicked_callback(self):
+        # Check if tag exists yet before trying to access subtag_ids
+        if self.tag:
+            self.tsp.update_tags(current_tags=self.tag.subtag_ids)
+        else:
+            self.tsp.update_tags()
+
+        self.add_tag_modal.show()
 
     def add_subtag_callback(self, tag_id: int):
         logging.info(f"adding {tag_id}")

--- a/tagstudio/src/qt/modals/build_tag.py
+++ b/tagstudio/src/qt/modals/build_tag.py
@@ -117,7 +117,8 @@ class BuildTagPanel(PanelWidget):
         self.subtags_add_button = QPushButton()
         self.subtags_add_button.setText("+")
         tsp = TagSearchPanel(self.lib)
-        tsp.tag_chosen.connect(lambda x: self.add_subtag_callback(x))
+        tsp.tag_chosen.connect(lambda x, checked: self.add_subtag_callback(x) if checked
+                            else self.remove_subtag_callback(x))
         self.add_tag_modal = PanelModal(tsp, "Add Parent Tags", "Add Parent Tags")
         self.subtags_add_button.clicked.connect(self.add_tag_modal.show)
         self.subtags_layout.addWidget(self.subtags_add_button)

--- a/tagstudio/src/qt/modals/build_tag.py
+++ b/tagstudio/src/qt/modals/build_tag.py
@@ -117,11 +117,19 @@ class BuildTagPanel(PanelWidget):
         self.subtags_add_button = QPushButton()
         self.subtags_add_button.setText("+")
         tsp = TagSearchPanel(self.lib)
-        tsp.tag_chosen.connect(lambda x, checked: self.add_subtag_callback(x) if checked
-                            else self.remove_subtag_callback(x))
+        tsp.tag_chosen.connect(
+            lambda x, checked: self.add_subtag_callback(x)
+            if checked
+            else self.remove_subtag_callback(x)
+        )
         self.add_tag_modal = PanelModal(tsp, "Add Parent Tags", "Add Parent Tags")
         self.subtags_add_button.clicked.connect(
-            lambda: (tsp.update_tags(current_tags=(self.tag.subtag_ids if self.tag else None)), self.add_tag_modal.show())  # type: ignore
+            lambda: (
+                tsp.update_tags(
+                    current_tags=(self.tag.subtag_ids if self.tag else None)
+                ),
+                self.add_tag_modal.show(),
+            )  # type: ignore
         )
         self.subtags_layout.addWidget(self.subtags_add_button)
 

--- a/tagstudio/src/qt/modals/build_tag.py
+++ b/tagstudio/src/qt/modals/build_tag.py
@@ -126,10 +126,10 @@ class BuildTagPanel(PanelWidget):
         self.subtags_add_button.clicked.connect(
             lambda: (
                 tsp.update_tags(
-                    current_tags=(self.tag.subtag_ids if self.tag else None)
+                    current_tags=(self.tag.subtag_ids if self.tag else None) # type: ignore[attr-defined]
                 ),
                 self.add_tag_modal.show(),
-            )  # type: ignore
+            )
         )
         self.subtags_layout.addWidget(self.subtags_add_button)
 

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -31,7 +31,7 @@ logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 
 class TagSearchPanel(PanelWidget):
-    tag_chosen = Signal(int)
+    tag_chosen = Signal(int, bool)
 
     def __init__(self, library):
         super().__init__()
@@ -117,15 +117,16 @@ class TagSearchPanel(PanelWidget):
             l.setSpacing(3)
             tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, False)
             ab = QPushButton()
+            ab.setCheckable(True)
             ab.setMinimumSize(23, 23)
             ab.setMaximumSize(23, 23)
             ab.setText("+")
             ab.setStyleSheet(
                 f"QPushButton{{"
-                f"background: {get_tag_color(ColorType.PRIMARY, self.lib.get_tag(tag_id).color)};"
+                f"background: #d2d2d2;"
                 # f'background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 {get_tag_color(ColorType.PRIMARY, tag.color)}, stop:1.0 {get_tag_color(ColorType.BORDER, tag.color)});'
                 # f"border-color:{get_tag_color(ColorType.PRIMARY, tag.color)};"
-                f"color: {get_tag_color(ColorType.TEXT, self.lib.get_tag(tag_id).color)};"
+                f"color: {get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
                 f"font-weight: 600;"
                 f"border-color:{get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
                 f"border-radius: 6px;"
@@ -137,15 +138,22 @@ class TagSearchPanel(PanelWidget):
                 # f'padding-left: 4px;'
                 f"font-size: 20px;"
                 f"}}"
-                f"QPushButton::hover"
-                f"{{"
+                f"QPushButton::checked{{"
+                f"border-color:{get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
+                f"color: {get_tag_color(ColorType.PRIMARY, self.lib.get_tag(tag_id).color)};"
+                f"background: {get_tag_color(ColorType.PRIMARY, self.lib.get_tag(tag_id).color)};"
+                f"}}"
+                f"QPushButton::hover{{"
                 f"border-color:{get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
                 f"color: {get_tag_color(ColorType.DARK_ACCENT, self.lib.get_tag(tag_id).color)};"
                 f"background: {get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
                 f"}}"
+                f"QPushButton::checked:hover{{"
+                f"color: {get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
+                f"}}"
             )
 
-            ab.clicked.connect(lambda checked=False, x=tag_id: self.tag_chosen.emit(x))
+            ab.toggled.connect(lambda checked, x=tag_id: self.tag_chosen.emit(x, checked))
 
             l.addWidget(tw)
             l.addWidget(ab)

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -160,7 +160,9 @@ class TagSearchPanel(PanelWidget):
             if tag_id in self.selected_tags:
                 ab.setChecked(True)
 
-            ab.toggled.connect(lambda checked, x=tag_id: self.tag_chosen.emit(x, checked))
+            ab.toggled.connect(
+                lambda checked, x=tag_id: self.tag_chosen.emit(x, checked)
+            )
 
             l.addWidget(tw)
             l.addWidget(ab)

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -119,7 +119,10 @@ class TagSearchPanel(PanelWidget):
             l = QHBoxLayout(c)
             l.setContentsMargins(0, 0, 0, 0)
             l.setSpacing(3)
+
             tw = TagWidget(self.lib, self.lib.get_tag(tag_id), False, False)
+
+            tag_colors = self.lib.get_tag(tag_id).color
             ab = QPushButton()
             ab.setCheckable(True)
             ab.setMinimumSize(23, 23)
@@ -130,9 +133,9 @@ class TagSearchPanel(PanelWidget):
                 f"background: #d2d2d2;"
                 # f'background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 {get_tag_color(ColorType.PRIMARY, tag.color)}, stop:1.0 {get_tag_color(ColorType.BORDER, tag.color)});'
                 # f"border-color:{get_tag_color(ColorType.PRIMARY, tag.color)};"
-                f"color: {get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
+                f"color: {get_tag_color(ColorType.BORDER, tag_colors)};"
                 f"font-weight: 600;"
-                f"border-color:{get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
+                f"border-color:{get_tag_color(ColorType.BORDER, tag_colors)};"
                 f"border-radius: 6px;"
                 f"border-style:solid;"
                 f"border-width: {math.ceil(1*self.devicePixelRatio())}px;"
@@ -143,17 +146,17 @@ class TagSearchPanel(PanelWidget):
                 f"font-size: 20px;"
                 f"}}"
                 f"QPushButton::checked{{"
-                f"border-color:{get_tag_color(ColorType.BORDER, self.lib.get_tag(tag_id).color)};"
-                f"color: {get_tag_color(ColorType.PRIMARY, self.lib.get_tag(tag_id).color)};"
-                f"background: {get_tag_color(ColorType.PRIMARY, self.lib.get_tag(tag_id).color)};"
+                f"border-color:{get_tag_color(ColorType.BORDER, tag_colors)};"
+                f"color: {get_tag_color(ColorType.PRIMARY, tag_colors)};"
+                f"background: {get_tag_color(ColorType.PRIMARY, tag_colors)};"
                 f"}}"
                 f"QPushButton::hover{{"
-                f"border-color:{get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
-                f"color: {get_tag_color(ColorType.DARK_ACCENT, self.lib.get_tag(tag_id).color)};"
-                f"background: {get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
+                f"border-color:{get_tag_color(ColorType.LIGHT_ACCENT, tag_colors)};"
+                f"color: {get_tag_color(ColorType.DARK_ACCENT, tag_colors)};"
+                f"background: {get_tag_color(ColorType.LIGHT_ACCENT, tag_colors)};"
                 f"}}"
                 f"QPushButton::checked:hover{{"
-                f"color: {get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
+                f"color: {get_tag_color(ColorType.LIGHT_ACCENT, tag_colors)};"
                 f"}}"
             )
 

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -38,6 +38,7 @@ class TagSearchPanel(PanelWidget):
         self.lib: Library = library
         # self.callback = callback
         self.first_tag_id = None
+        self.selected_tags = []
         self.tag_limit = 100
         # self.selected_tag: int = 0
         self.setMinimumSize(300, 400)
@@ -100,7 +101,10 @@ class TagSearchPanel(PanelWidget):
             self.search_field.setFocus()
             self.parentWidget().hide()
 
-    def update_tags(self, query: str = ""):
+    def update_tags(self, query: str = "", current_tags: list[int] = None):
+        if current_tags:
+            self.selected_tags = current_tags
+
         # for c in self.scroll_layout.children():
         # 	c.widget().deleteLater()
         while self.scroll_layout.count():
@@ -152,6 +156,9 @@ class TagSearchPanel(PanelWidget):
                 f"color: {get_tag_color(ColorType.LIGHT_ACCENT, self.lib.get_tag(tag_id).color)};"
                 f"}}"
             )
+
+            if tag_id in self.selected_tags:
+                ab.setChecked(True)
 
             ab.toggled.connect(lambda checked, x=tag_id: self.tag_chosen.emit(x, checked))
 

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -76,7 +76,7 @@ class TagBoxWidget(FieldWidget):
             f"}}"
         )
         tsp = TagSearchPanel(self.lib)
-        tsp.tag_chosen.connect(lambda x: self.add_tag_callback(x))
+        tsp.tag_chosen.connect(lambda x, checked: self.update_tag_callback(x, checked))
         self.add_modal = PanelModal(tsp, title, "Add Tags")
         self.add_button.clicked.connect(
             lambda: (tsp.update_tags(), self.add_modal.show())  # type: ignore
@@ -127,6 +127,9 @@ class TagBoxWidget(FieldWidget):
         if self.base_layout.itemAt(0) and not self.base_layout.itemAt(1):
             self.base_layout.update()
 
+    def edit_tag_callback(self, tag: Tag):
+        self.lib.update_tag(tag)
+
     def edit_tag(self, tag_id: int):
         btp = BuildTagPanel(self.lib, tag_id)
         # btp.on_edit.connect(lambda x: self.edit_tag_callback(x))
@@ -142,12 +145,18 @@ class TagBoxWidget(FieldWidget):
         # panel.tag_updated.connect(lambda tag: self.lib.update_tag(tag))
         self.edit_modal.show()
 
-    def add_tag_callback(self, tag_id: int):
+    def update_tag_callback(self, tag_id: int, checked: bool):
+        logging.info(
+            f"[TAG BOX WIDGET] UPDATE TAG CALLBACK: {"Add" if checked else "Remove"} T:{tag_id} to E:{self.item.id}"
+        )
+        if checked:
+            self.add_tag(tag_id)
+        else:
+            self.remove_tag(tag_id)
+
+    def add_tag(self, tag_id: int):
         # self.base_layout.addWidget(TagWidget(self.lib, self.lib.get_tag(tag), True))
         # self.tags.append(tag)
-        logging.info(
-            f"[TAG BOX WIDGET] ADD TAG CALLBACK: T:{tag_id} to E:{self.item.id}"
-        )
         logging.info(f"[TAG BOX WIDGET] SELECTED T:{self.driver.selected}")
         id: int = list(self.field.keys())[0]  # type: ignore
         for x in self.driver.selected:
@@ -166,9 +175,6 @@ class TagBoxWidget(FieldWidget):
         # 	self.tags.append(tag_id)
         # self.set_tags(self.tags)
         # elif type((x[0]) == ThumbButton):
-
-    def edit_tag_callback(self, tag: Tag):
-        self.lib.update_tag(tag)
 
     def remove_tag(self, tag_id: int):
         logging.info(f"[TAG BOX WIDGET] SELECTED T:{self.driver.selected}")

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -147,7 +147,7 @@ class TagBoxWidget(FieldWidget):
 
     def update_tag_callback(self, tag_id: int, checked: bool):
         logging.info(
-            f"[TAG BOX WIDGET] UPDATE TAG CALLBACK: {"Add" if checked else "Remove"} T:{tag_id} to E:{self.item.id}"
+            f"[TAG BOX WIDGET] UPDATE TAG CALLBACK: {'Add' if checked else 'Remove'} T:{tag_id} to E:{self.item.id}"
         )
         if checked:
             self.add_tag(tag_id)

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -79,7 +79,7 @@ class TagBoxWidget(FieldWidget):
         tsp.tag_chosen.connect(lambda x, checked: self.update_tag_callback(x, checked))
         self.add_modal = PanelModal(tsp, title, "Add Tags")
         self.add_button.clicked.connect(
-            lambda: (tsp.update_tags(), self.add_modal.show())  # type: ignore
+            lambda: (tsp.update_tags(current_tags=self.tags), self.add_modal.show())  # type: ignore
         )
 
         self.set_tags(tags)


### PR DESCRIPTION
Make buttons in TagSearch panel togglable to allow the selected tags to be deselected without having to close the panel. The standard look of the panel has had to been modified to support this behavior, now beginning with a light grey background and only matching the tag color when selected. When a tag is selected, the "+" text is only hidden because the ability to modify the buttons properties after the fact is lost, though I may have missed something obvious. The currently selected subtags for an entry are now passed into TagSearchPanel to allow the previously selected tags to be highlighted and deselect-able.

Workflow featuring new buttons:
![output](https://github.com/TagStudioDev/TagStudio/assets/71362472/2125d084-aec2-41be-8700-a3ad7d1104f6)