### PR TITLE
Bugfix for #252, don't attempt to read video file if invalid or 0 frames long

### DIFF
--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -532,6 +532,8 @@ class PreviewPanel(QWidget):
                                 pass
                         elif filepath.suffix.lower() in VIDEO_TYPES:
                             video = cv2.VideoCapture(str(filepath))
+                            if video.get(cv2.CAP_PROP_FRAME_COUNT) <= 0:
+                                raise cv2.error("File is invalid or has 0 frames")
                             video.set(cv2.CAP_PROP_POS_FRAMES, 0)
                             success, frame = video.read()
                             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -162,10 +162,10 @@ class ThumbRenderer(QObject):
                 # Videos =======================================================
                 elif _filepath.suffix.lower() in VIDEO_TYPES:
                     video = cv2.VideoCapture(str(_filepath))
-                    video.set(
-                        cv2.CAP_PROP_POS_FRAMES,
-                        (video.get(cv2.CAP_PROP_FRAME_COUNT) // 2),
-                    )
+                    frame_count = video.get(cv2.CAP_PROP_FRAME_COUNT)
+                    if frame_count <= 0:
+                        raise cv2.error("File is invalid or has 0 frames")
+                    video.set(cv2.CAP_PROP_POS_FRAMES, frame_count // 2)
                     success, frame = video.read()
                     if not success:
                         # Depending on the video format, compression, and frame


### PR DESCRIPTION
Raise error if video file has 0 frames or is in valid.
video.get(cv2.CAP_PROP_FRAME_COUNT) returns 0 or -1

An addition change could be implemented by calling video.setExceptionMode(True) which would raise cv2 errors if other issues arise later.

Fixes #252 
