### PR TITLE
feat: drag-n-drop into other applications

### DIFF
--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Optional
 
 from PIL import Image, ImageQt
-from PySide6.QtCore import Qt, QSize, QEvent
-from PySide6.QtGui import QPixmap, QEnterEvent, QAction
+from PySide6.QtCore import Qt, QSize, QEvent, QMimeData, QUrl
+from PySide6.QtGui import QPixmap, QEnterEvent, QAction, QDrag
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -495,3 +495,17 @@ class ItemThumb(FlowWidget):
         if self.panel.isOpen:
             self.panel.update_widgets()
         self.panel.driver.update_badges()
+    
+    def mouseMoveEvent(self, event):
+
+        # ignore if no left button is pressed
+        if not (event.buttons() & Qt.LeftButton):
+            return
+
+        # simple drag-n-drop into other applications
+        if self.mode == ItemType.ENTRY:
+            drag = QDrag(self)
+            mimeData = QMimeData()
+            mimeData.setUrls([QUrl.fromLocalFile(str(self.opener.filepath))])
+            drag.setMimeData(mimeData)
+            dropAction = drag.exec(Qt.DropAction.CopyAction)


### PR DESCRIPTION
Dead simple drag-n-drop implementation because I was surprised this doesn't exist yet. Example here:

![Discord_A8bc5cWD9E](https://github.com/TagStudioDev/TagStudio/assets/8218061/e7cbeff9-6c43-4f0b-a86b-9cabdf76dfe2)

This can definitely be improved upon, but this was a quick and easy addition. Tested on Windows 11. Will test on Linux Mint (Cinnamon) shortly and I'll update the PR with my results.

closes #75 