### PR TITLE
fix: backslashes in f-string error on file drop dupe widget

### DIFF
--- a/tagstudio/src/qt/modals/drop_import.py
+++ b/tagstudio/src/qt/modals/drop_import.py
@@ -167,11 +167,17 @@ class DropImport:
         dupes_to_show = self.duplicate_files
         if len(self.duplicate_files) > display_limit:
             dupes_to_show = dupes_to_show[0:display_limit]
-        
-        dupes_str = '\n    '.join(map(lambda path: str(path),dupes_to_show))
-        dupes_more = f"\nand {len(self.duplicate_files)-display_limit} more " if len(self.duplicate_files) > display_limit else '\n'
 
-        msgBox.setText(f"The following files:\n    {dupes_str}{dupes_more}have filenames that already exist in the library folder.")
+        dupes_str = "\n    ".join(map(lambda path: str(path), dupes_to_show))
+        dupes_more = (
+            f"\nand {len(self.duplicate_files)-display_limit} more "
+            if len(self.duplicate_files) > display_limit
+            else "\n"
+        )
+
+        msgBox.setText(
+            f"The following files:\n    {dupes_str}{dupes_more}have filenames that already exist in the library folder."
+        )
         msgBox.addButton("Skip", QMessageBox.ButtonRole.YesRole)
         msgBox.addButton("Override", QMessageBox.ButtonRole.DestructiveRole)
         msgBox.addButton("Rename", QMessageBox.ButtonRole.DestructiveRole)

--- a/tagstudio/src/qt/modals/drop_import.py
+++ b/tagstudio/src/qt/modals/drop_import.py
@@ -167,10 +167,11 @@ class DropImport:
         dupes_to_show = self.duplicate_files
         if len(self.duplicate_files) > display_limit:
             dupes_to_show = dupes_to_show[0:display_limit]
+        
+        dupes_str = '\n    '.join(map(lambda path: str(path),dupes_to_show))
+        dupes_more = "\nand {len(self.duplicate_files)-display_limit} more " if len(self.duplicate_files) > display_limit else '\n'
 
-        msgBox.setText(
-            f"The following files:\n    {'\n    '.join(map(lambda path: str(path),self.get_relative_paths(dupes_to_show)))} {(f'\nand {len(self.duplicate_files)-display_limit} more ') if len(self.duplicate_files)>display_limit else '\n'}have filenames that already exist in the library folder."
-        )
+        msgBox.setText(f"The following files:\n    {dupes_str}{dupes_more}have filenames that already exist in the library folder.")
         msgBox.addButton("Skip", QMessageBox.ButtonRole.YesRole)
         msgBox.addButton("Override", QMessageBox.ButtonRole.DestructiveRole)
         msgBox.addButton("Rename", QMessageBox.ButtonRole.DestructiveRole)

--- a/tagstudio/src/qt/modals/drop_import.py
+++ b/tagstudio/src/qt/modals/drop_import.py
@@ -169,7 +169,7 @@ class DropImport:
             dupes_to_show = dupes_to_show[0:display_limit]
         
         dupes_str = '\n    '.join(map(lambda path: str(path),dupes_to_show))
-        dupes_more = "\nand {len(self.duplicate_files)-display_limit} more " if len(self.duplicate_files) > display_limit else '\n'
+        dupes_more = f"\nand {len(self.duplicate_files)-display_limit} more " if len(self.duplicate_files) > display_limit else '\n'
 
         msgBox.setText(f"The following files:\n    {dupes_str}{dupes_more}have filenames that already exist in the library folder.")
         msgBox.addButton("Skip", QMessageBox.ButtonRole.YesRole)


### PR DESCRIPTION
Refactor excessively long f-string into separate variables to resolve issue

Fixes #288