### PR TITLE
fix: pip cache failures in workflows

### DIFF
--- a/.github/workflows/apprun.yaml
+++ b/.github/workflows/apprun.yaml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Install system dependencies
         run: |
@@ -37,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -Ur requirements.txt
+          pip install --no-cache-dir -r requirements.txt
 
       - name: Run TagStudio app and check exit code
         run: |

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -19,14 +19,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Install dependencies
         run: |
           # pyside 6.6.3 has some issue in their .pyi files
-          pip install PySide6==6.6.2
-          pip install -r requirements.txt
-          pip install mypy==1.10.0
+          pip install --no-cache-dir PySide6==6.6.2
+          pip install --no-cache-dir -r requirements.txt
+          pip install --no-cache-dir mypy==1.10.0
           mkdir tagstudio/.mypy_cache
 
       - uses: tsuyoshicho/action-mypy@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,11 +11,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install --no-cache-dir -r requirements.txt
+          pip install --no-cache-dir -r requirements-dev.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - run: pip install -Ur requirements.txt pyinstaller
+      - run: pip install --no-cache-dir -r requirements.txt pyinstaller
       - run: pyinstaller tagstudio.spec -- ${{ matrix.build-flag }}
       - run: tar czfC dist/tagstudio_linux_x86_64${{ matrix.suffix }}.tar.gz dist tagstudio
       - uses: actions/upload-artifact@v4
@@ -51,7 +51,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - run: pip install -Ur requirements.txt pyinstaller
+      - run: pip install --no-cache-dir -r requirements.txt pyinstaller
       - run: pyinstaller tagstudio.spec
       - run: tar czfC dist/tagstudio_macos_${{ matrix.arch }}.tar.gz dist TagStudio.app
       - uses: actions/upload-artifact@v4
@@ -79,7 +79,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - run: pip install -Ur requirements.txt pyinstaller
+      - run: pip install --no-cache-dir -r requirements.txt pyinstaller
       - run: PyInstaller tagstudio.spec -- ${{ matrix.build-flag }}
       - run: Compress-Archive -Path dist/TagStudio${{ matrix.file-end }} -DestinationPath dist/tagstudio_windows_x86_64${{ matrix.suffix }}.zip
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
From #255:
> Ocassionally, a pip install will fail because of mismatched hashes, which from my research I believe this to be related to a cache error. This cannot easily be tested due to its seemingly random nature, but my hope is that my fix in using the action/setup-python workflow will avoid it.

Unfortunately the fix in [82037e5](https://github.com/TagStudioDev/TagStudio/pull/255/commits/82037e570d8376ebf4007430bc45c5cd0f312666) seems to have just caused registered bad cache to be reused over and over. So, this serves as a sort of "opposite" to that and removes using the cache altogether.

Again, due to random nature, this cannot easily be tested and will show results over time.