### PR TITLE
Detach Library loading from Render thread

### DIFF
--- a/tagstudio/src/qt/helpers/custom_runnable.py
+++ b/tagstudio/src/qt/helpers/custom_runnable.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import Signal, QRunnable, QObject
 
 
 class CustomRunnable(QRunnable, QObject):
-    done = Signal()
+    done = Signal(object)
 
     def __init__(self, function) -> None:
         QRunnable.__init__(self)
@@ -15,5 +15,5 @@ class CustomRunnable(QRunnable, QObject):
         self.function = function
 
     def run(self):
-        self.function()
-        self.done.emit()
+        result = self.function()
+        self.done.emit(result)


### PR DESCRIPTION
In scenarios where the library takes a long amount of time to load, the application would become locked up and unresponsive, as library loading was blocking. By detaching library loading to its own thread, the program remains responsive even while the library is loading.

Eventually, a ProgressWidget should probably be added, but that would require a signifigant change to the logic of lib.open_library.
