### PR TITLE
feat(qt): Add hotkey to add tags to selection

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -391,7 +391,8 @@ class QtDriver(QObject):
             QtCore.QKeyCombination(
                 QtCore.Qt.KeyboardModifier(
                     QtCore.Qt.KeyboardModifier.ControlModifier
-                    | QtCore.Qt.KeyboardModifier.ShiftModifier),
+                    | QtCore.Qt.KeyboardModifier.ShiftModifier
+                ),
                 QtCore.Qt.Key.Key_T,
             )
         )


### PR DESCRIPTION
This is used so that you don't have to go through the mouse-heavy
nitty-gritty of:

1. Select one or more files
2. Add field
3. Tags
4. OK
5. Add Tag
6. Click on the plus sign
7. Done

To get to a tag selection modal. This reduces a lot of friction in my
opinion. I like the way that the fields can have multiple types, but in
the majority of cases I just want to quickly tag one or more files in my
selection and move on. The workflow after this change is as follows:

1. Select one or more files
2. Just press `Ctrl+Shift+T`
3. Click on the plus sign
4. Done

This way the tagbox gets added automatically (through the powerful core
library system) and you can immediately start tagging!
