### PR TITLE
Add font thumbnail preview support

### DIFF
--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -18,7 +18,7 @@ tuvwxyz
 0123456
 789!?@$
 %(){}[]"""
-FONT_SAMPLE_SIZES: list[int] = [10,12,15]
+FONT_SAMPLE_SIZES: list[int] = [10, 12, 15]
 
 # TODO: Turn this whitelist into a user-configurable blacklist.
 IMAGE_TYPES: list[str] = [

--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -7,12 +7,18 @@ BACKUP_FOLDER_NAME: str = "backups"
 COLLAGE_FOLDER_NAME: str = "collages"
 LIBRARY_FILENAME: str = "ts_library.json"
 
-FONT_SAMPLE_TEXT: str = """ABCDEFGHIJKLM
-NOPQRSTUVWXYZ
-abcdefghijklm
-nopqrstuvwxyz
-0123456789
-!?.@$%(){}[]"""
+FONT_SAMPLE_TEXT: str = """ABCDEF
+GHIJKLM
+NOPQRS
+TUVWXYZ
+abcdef
+ghijklm
+nopqrs
+tuvwxyz
+0123456
+789!?@$
+%(){}[]"""
+FONT_SAMPLE_SIZES: list[int] = [10,12,15]
 
 # TODO: Turn this whitelist into a user-configurable blacklist.
 IMAGE_TYPES: list[str] = [

--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -7,18 +7,10 @@ BACKUP_FOLDER_NAME: str = "backups"
 COLLAGE_FOLDER_NAME: str = "collages"
 LIBRARY_FILENAME: str = "ts_library.json"
 
-FONT_SAMPLE_TEXT: str = """ABCDEF
-GHIJKLM
-NOPQRS
-TUVWXYZ
-abcdef
-ghijklm
-nopqrs
-tuvwxyz
-0123456
-789!?@$
-%(){}[]"""
-FONT_SAMPLE_SIZES: list[int] = [10, 12, 15]
+FONT_SAMPLE_TEXT: str = (
+    """ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?@$%(){}[]"""
+)
+FONT_SAMPLE_SIZES: list[int] = [12, 15, 20]
 
 # TODO: Turn this whitelist into a user-configurable blacklist.
 IMAGE_TYPES: list[str] = [

--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -10,7 +10,7 @@ LIBRARY_FILENAME: str = "ts_library.json"
 FONT_SAMPLE_TEXT: str = (
     """ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?@$%(){}[]"""
 )
-FONT_SAMPLE_SIZES: list[int] = [12, 15, 20]
+FONT_SAMPLE_SIZES: list[int] = [10, 15, 20]
 
 # TODO: Turn this whitelist into a user-configurable blacklist.
 IMAGE_TYPES: list[str] = [
@@ -112,7 +112,7 @@ ARCHIVE_TYPES: list[str] = [
 ]
 PROGRAM_TYPES: list[str] = [".exe", ".app"]
 SHORTCUT_TYPES: list[str] = [".lnk", ".desktop", ".url"]
-FONT_TYPES: list[str] = [".ttf", ".otf", ".woff"]
+FONT_TYPES: list[str] = [".ttf", ".otf", ".woff", ".woff2", ".ttc"]
 
 ALL_FILE_TYPES: list[str] = (
     IMAGE_TYPES

--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -7,6 +7,13 @@ BACKUP_FOLDER_NAME: str = "backups"
 COLLAGE_FOLDER_NAME: str = "collages"
 LIBRARY_FILENAME: str = "ts_library.json"
 
+FONT_SAMPLE_TEXT: str = """ABCDEFGHIJKLM
+NOPQRSTUVWXYZ
+abcdefghijklm
+nopqrstuvwxyz
+0123456789
+!?.@$%(){}[]"""
+
 # TODO: Turn this whitelist into a user-configurable blacklist.
 IMAGE_TYPES: list[str] = [
     ".png",
@@ -107,6 +114,7 @@ ARCHIVE_TYPES: list[str] = [
 ]
 PROGRAM_TYPES: list[str] = [".exe", ".app"]
 SHORTCUT_TYPES: list[str] = [".lnk", ".desktop", ".url"]
+FONT_TYPES: list[str] = [".ttf", ".otf", ".woff"]
 
 ALL_FILE_TYPES: list[str] = (
     IMAGE_TYPES
@@ -118,6 +126,7 @@ ALL_FILE_TYPES: list[str] = (
     + ARCHIVE_TYPES
     + PROGRAM_TYPES
     + SHORTCUT_TYPES
+    + FONT_TYPES
 )
 
 BOX_FIELDS = ["tag_box", "text_box"]

--- a/tagstudio/src/qt/helpers/text_wrapper.py
+++ b/tagstudio/src/qt/helpers/text_wrapper.py
@@ -1,0 +1,47 @@
+from PIL import Image, ImageDraw, ImageFont
+
+
+def wrap_line(  # type: ignore
+    text: str,
+    font: ImageFont.ImageFont,
+    width: int = 256,
+    draw: ImageDraw.ImageDraw = None,
+) -> int:
+    """
+    Takes in a single line and returns the index it should be broken up at but
+    it only splits one Time
+    """
+    if draw is None:
+        bg = Image.new("RGB", (width, width), color="#1e1e1e")
+        draw = ImageDraw.Draw(bg)
+    if draw.textlength(text, font=font) > 256:
+        for i in range(
+            int(len(text) / int(draw.textlength(text, font=font)) * 256),
+            0,
+            -1,
+        ):
+            if draw.textlength(text[:i], font=font) < 256:
+                return i
+    else:
+        return -1
+
+
+def wrap_full_text(
+    text: str,
+    font: ImageFont.ImageFont,
+    width: int = 256,
+    draw: ImageDraw.ImageDraw = None,
+) -> str:
+    """
+    Takes in a string and breaks it up to fit in the canvas given accounts for kerning and font size etc.
+    """
+    lines = []
+    i = 0
+    last_i = 0
+    while wrap_line(text[i:], font=font, width=width, draw=draw) > 0:
+        i = wrap_line(text[i:], font=font, draw=draw) + last_i
+        lines.append(text[last_i:i])
+        last_i = i
+    lines.append(text[last_i:])
+    text_wrapped = "\n".join(lines)
+    return text_wrapped

--- a/tagstudio/src/qt/helpers/text_wrapper.py
+++ b/tagstudio/src/qt/helpers/text_wrapper.py
@@ -18,16 +18,13 @@ def wrap_line(  # type: ignore
     if draw is None:
         bg = Image.new("RGB", (width, width), color="#1e1e1e")
         draw = ImageDraw.Draw(bg)
-    if draw.textlength(text, font=font) > 256:
-        # print(draw.textlength(text, font=font))
+    if draw.textlength(text, font=font) > width:
         for i in range(
-            int(len(text) / int(draw.textlength(text, font=font)) * 256) - 2,
+            int(len(text) / int(draw.textlength(text, font=font)) * width) - 2,
             0,
             -1,
         ):
-            if draw.textlength(text[:i], font=font) < 256:
-                # print(len(text))
-                # print(i)
+            if draw.textlength(text[:i], font=font) < width:
                 return i
     else:
         return -1
@@ -46,7 +43,7 @@ def wrap_full_text(
     i = 0
     last_i = 0
     while wrap_line(text[i:], font=font, width=width, draw=draw) > 0:
-        i = wrap_line(text[i:], font=font, draw=draw) + last_i
+        i = wrap_line(text[i:], font=font, width=width, draw=draw) + last_i
         lines.append(text[last_i:i])
         last_i = i
     lines.append(text[last_i:])

--- a/tagstudio/src/qt/helpers/text_wrapper.py
+++ b/tagstudio/src/qt/helpers/text_wrapper.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2024 Travis Abendshien (CyanVoxel).
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
 from PIL import Image, ImageDraw, ImageFont
 
 

--- a/tagstudio/src/qt/helpers/text_wrapper.py
+++ b/tagstudio/src/qt/helpers/text_wrapper.py
@@ -15,12 +15,15 @@ def wrap_line(  # type: ignore
         bg = Image.new("RGB", (width, width), color="#1e1e1e")
         draw = ImageDraw.Draw(bg)
     if draw.textlength(text, font=font) > 256:
+        # print(draw.textlength(text, font=font))
         for i in range(
-            int(len(text) / int(draw.textlength(text, font=font)) * 256),
+            int(len(text) / int(draw.textlength(text, font=font)) * 256) - 2,
             0,
             -1,
         ):
             if draw.textlength(text[:i], font=font) < 256:
+                # print(len(text))
+                # print(i)
                 return i
     else:
         return -1

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -568,7 +568,7 @@ class PreviewPanel(QWidget):
                         elif filepath.suffix.lower() in FONT_TYPES:
                             font = ImageFont.truetype(filepath)
                             self.dimensions_label.setText(
-                                f"{filepath.suffix.upper()[1:]} •  {format_size(filepath.stat().st_size)}\n{font.getname()[0]} : {font.getname()[1]} "
+                                f"{filepath.suffix.upper()[1:]} •  {format_size(filepath.stat().st_size)}\n{font.getname()[0]} ({font.getname()[1]}) "
                             )
                         else:
                             self.dimensions_label.setText(

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -10,7 +10,7 @@ from datetime import datetime as dt
 
 import cv2
 import rawpy
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, UnidentifiedImageError, ImageFont
 from PIL.Image import DecompressionBombError
 from PySide6.QtCore import Signal, Qt, QSize
 from PySide6.QtGui import QResizeEvent, QAction
@@ -30,7 +30,13 @@ from humanfriendly import format_size
 
 from src.core.enums import SettingItems, Theme
 from src.core.library import Entry, ItemType, Library
-from src.core.constants import VIDEO_TYPES, IMAGE_TYPES, RAW_IMAGE_TYPES, TS_FOLDER_NAME
+from src.core.constants import (
+    VIDEO_TYPES,
+    IMAGE_TYPES,
+    RAW_IMAGE_TYPES,
+    TS_FOLDER_NAME,
+    FONT_TYPES,
+)
 from src.qt.helpers.file_opener import FileOpenerLabel, FileOpenerHelper, open_file
 from src.qt.modals.add_field import AddFieldModal
 from src.qt.widgets.thumb_renderer import ThumbRenderer
@@ -558,6 +564,11 @@ class PreviewPanel(QWidget):
                         ):
                             self.dimensions_label.setText(
                                 f"{filepath.suffix.upper()[1:]}  •  {format_size(filepath.stat().st_size)}\n{image.width} x {image.height} px"
+                            )
+                        elif filepath.suffix.lower() in FONT_TYPES:
+                            font = ImageFont.truetype(filepath)
+                            self.dimensions_label.setText(
+                                f"{filepath.suffix.upper()[1:]}  •  {font.getname()[0]} : {font.getname()[1]}  •  {format_size(filepath.stat().st_size)} "
                             )
                         else:
                             self.dimensions_label.setText(

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -568,7 +568,7 @@ class PreviewPanel(QWidget):
                         elif filepath.suffix.lower() in FONT_TYPES:
                             font = ImageFont.truetype(filepath)
                             self.dimensions_label.setText(
-                                f"{filepath.suffix.upper()[1:]}  •  {font.getname()[0]} : {font.getname()[1]}  •  {format_size(filepath.stat().st_size)} "
+                                f"{filepath.suffix.upper()[1:]} •  {format_size(filepath.stat().st_size)}\n{font.getname()[0]} : {font.getname()[1]} "
                             )
                         else:
                             self.dimensions_label.setText(

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -30,6 +30,7 @@ from src.core.constants import (
     IMAGE_TYPES,
     RAW_IMAGE_TYPES,
     FONT_SAMPLE_TEXT,
+    FONT_SAMPLE_SIZES,
 )
 from src.core.utils.encoding import detect_char_encoding
 
@@ -190,9 +191,17 @@ class ThumbRenderer(QObject):
                 # Fonts ========================================================
                 elif _filepath.suffix.lower() in FONT_TYPES:
                     bg = Image.new("RGB", (256, 256), color="#1e1e1e")
-                    font = ImageFont.truetype(_filepath, 25)
                     draw = ImageDraw.Draw(bg)
-                    draw.text((16, 16), FONT_SAMPLE_TEXT, font=font)
+                    lines = FONT_SAMPLE_TEXT.split("\n")
+                    lines.sort(key=draw.textlength)
+                    longest_line = lines[-1]
+                    padding = 2
+                    x_offset = 0
+                    for fontsize in FONT_SAMPLE_SIZES:
+                        font = ImageFont.truetype(_filepath,size=fontsize)
+                        text_box_width = draw.textlength(longest_line, font=font)
+                        draw.text((16+x_offset, 16), FONT_SAMPLE_TEXT, font=font)
+                        x_offset += text_box_width+padding
                     image = bg
                 # 3D ===========================================================
                 # elif extension == 'stl':

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -25,9 +25,11 @@ from PySide6.QtGui import QPixmap
 from src.qt.helpers.gradient import four_corner_gradient_background
 from src.core.constants import (
     PLAINTEXT_TYPES,
+    FONT_TYPES,
     VIDEO_TYPES,
     IMAGE_TYPES,
     RAW_IMAGE_TYPES,
+    FONT_SAMPLE_TEXT,
 )
 from src.core.utils.encoding import detect_char_encoding
 
@@ -183,7 +185,14 @@ class ThumbRenderer(QObject):
                         text = text_file.read(256)
                     bg = Image.new("RGB", (256, 256), color="#1e1e1e")
                     draw = ImageDraw.Draw(bg)
-                    draw.text((16, 16), text, file=(255, 255, 255))
+                    draw.text((16, 16), text, fill=(255, 255, 255))
+                    image = bg
+                # Fonts ========================================================
+                elif _filepath.suffix.lower() in FONT_TYPES:
+                    bg = Image.new("RGB", (256, 256), color="#1e1e1e")
+                    font = ImageFont.truetype(_filepath, 25)
+                    draw = ImageDraw.Draw(bg)
+                    draw.text((16, 16), FONT_SAMPLE_TEXT, font=font)
                     image = bg
                 # 3D ===========================================================
                 # elif extension == 'stl':

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -198,10 +198,10 @@ class ThumbRenderer(QObject):
                     padding = 2
                     x_offset = 0
                     for fontsize in FONT_SAMPLE_SIZES:
-                        font = ImageFont.truetype(_filepath,size=fontsize)
+                        font = ImageFont.truetype(_filepath, size=fontsize)
                         text_box_width = draw.textlength(longest_line, font=font)
-                        draw.text((16+x_offset, 16), FONT_SAMPLE_TEXT, font=font)
-                        x_offset += text_box_width+padding
+                        draw.text((16 + x_offset, 16), FONT_SAMPLE_TEXT, font=font)
+                        x_offset += text_box_width + padding
                     image = bg
                 # 3D ===========================================================
                 # elif extension == 'stl':

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -191,23 +191,30 @@ class ThumbRenderer(QObject):
                     image = bg
                 # Fonts ========================================================
                 elif _filepath.suffix.lower() in FONT_TYPES:
+                    # Scale the sample font sizes to the preview image
+                    # resolution,assuming the sizes are tuned for 256px.
+                    scaled_sizes: list[int] = [
+                        math.floor(x * (adj_size / 256)) for x in FONT_SAMPLE_SIZES
+                    ]
                     if gradient:
                         # handles small thumbnails
-                        bg = Image.new("RGB", (256, 256), color="#1e1e1e")
+                        bg = Image.new("RGB", (adj_size, adj_size), color="#1e1e1e")
                         draw = ImageDraw.Draw(bg)
-                        font = ImageFont.truetype(_filepath, size=170)
+                        font = ImageFont.truetype(
+                            _filepath, size=math.ceil(adj_size * 0.65)
+                        )
                         draw.text((10, 0), "Aa", font=font)
                     else:
                         # handles big thumbnails and renders a sample text in multiple font sizes
-                        bg = Image.new("RGB", (256, 256), color="#1e1e1e")
+                        bg = Image.new("RGB", (adj_size, adj_size), color="#1e1e1e")
                         draw = ImageDraw.Draw(bg)
                         lines_of_padding = 2
                         y_offset = 0
 
-                        for font_size in FONT_SAMPLE_SIZES:
+                        for font_size in scaled_sizes:
                             font = ImageFont.truetype(_filepath, size=font_size)
                             text_wrapped: str = wrap_full_text(
-                                FONT_SAMPLE_TEXT, font=font, draw=draw
+                                FONT_SAMPLE_TEXT, font=font, width=adj_size, draw=draw
                             )
                             draw.multiline_text((0, y_offset), text_wrapped, font=font)
                             y_offset += (


### PR DESCRIPTION
I added simple font thumbnail previews for .ttf, .otf and .woff files like it was requested in issue #304 . Currently there are three text sizes (10,12,15) that i selected. I stacked the sample text in the different font sizes next to each other and tried to dynamically fit them next to each other. I am open to changing how the text alignment works and other changes. At the moment it looks like this:
![font support](https://github.com/TagStudioDev/TagStudio/assets/91694323/36470bb3-e919-47a8-84e1-02680c29112a)
![font_support_2](https://github.com/TagStudioDev/TagStudio/assets/91694323/9eebbfe7-5e62-41bc-8553-d7cad29f35e4)

