### PR TITLE
Feature/boolean search syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ TagStudio is a photo & file organization application with an underlying system t
   - Description, Notes (Multiline Text Fields)
   - Tags, Meta Tags, Content Tags (Tag Boxes)
 - Create rich tags composed of a name, a list of aliases, and a list of “subtags” - being tags in which these tags inherit values from.
-- Search for entries based on tags, ~~metadata~~ (TBA), or filenames/filetypes (using `filename: <query>`)
-- Special search conditions for entries that are: `untagged`/`no tags` and `empty`/`no fields`.
+- Search for entries based on tags, ~~metadata~~ (TBA), or filenames/filetypes (using `filename:<query>`)
+- Special search conditions for entries that are: `untagged`/`no_tags`, `empty`/`no_fields`, `no_author`/`no_artist`, and `missing`/`no_file`.
+- Search for entries using Boolean expressions. (See the [search cheat-sheet](#search-cheat-sheet) section for more)
 
 > [!NOTE]
 > For more information on the project itself, please see the [FAQ](#faq) section as well as the [documentation](/doc/index.md).
@@ -133,6 +134,66 @@ Inevitably, some of the files inside your library will be renamed, moved, or del
 
 Libraries are saved upon exiting the program. To manually save, select File -> Save Library from the menu bar. To save a backup of your library, select File -> Save Library Backup from the menu bar.
 
+### Search Cheat-Sheet
+
+#### The Basics
+
+After loading a tagged library, enter your search into the bar that says `Search Entries` at the top of the window. Every tag needs a space after it. If your tag contains spaces between words, substitute underscores _ for the spaces. Capitalization doesn't affect tags and searches. After you have typed your search, press enter or click the `Search` button to the right of the search bar. It may take a moment for the search to complete. After you have made a few searches, you can use the arrows `<` `>` on the left hand side of the search bar to bring back previous searches.
+- **dog favorites** searches favorites for any entry tagged "dog"
+- **fat_cat dress_up** searches entries for the "fat cat" tag and searches for the "dress up" tag
+
+#### Search Modes
+
+On the right side of the window, just below the search bar, there is a dropdown option to choose the search bar. The options are `And (Includes All Tags)`, and `Or (Includes Any Tag)`. In And mode, if you have a list of search terms in the search bar, your search will try to match entries fitting all the search terms in the list. In Or mode, your search will try to match entries fitting even just one of the search terms.
+
+#### Optional Terms and Partial Match Terms
+
+If you have a search list with many search terms, you may use tilde ~ before a term to mark it as an optional term in And mode, or as a partial match term in Or mode.
+- In And mode, an entry with even just one of the tilde ~ marked optional terms can match a search list that uses them, so long as the entry matches all other terms in the list.
+  - **costume ~witch ~skeleton** matches all entries tagged costume and witch, and all entries tagged costume and skeleton.
+- In Or mode, an entry with all of the tilde ~ marked partial match terms will match a search list that uses them, even if the entry matches no other terms in the list.
+  - **lake river ~indoors ~life_vest** matches all entries tagged "lake", tagged "river", or tagged with both "indoors" and "life vest".
+
+> [!NOTE]
+> For simplicity, the remaining search examples are written for And mode unless otherwise specified.
+
+#### Exclude Terms
+
+Using minus -, exclamation mark !, or "not" before a term matches when the term doesn't. "not" needs a space after it. Tilde ~ will have no effect unless it comes before the exclude indicator.
+- **-golf** matches any entry that doesn't have the "golf" tag.
+- **party -birthday** matches any entry that has the "party" tag, but that does not have the "birthday" tag.
+
+#### Parentheses
+
+Surrounding a list of search terms with parentheses () makes it act like a single term, and allows for more complicated nesting of tags. Every parenthesis needs a space after it, or it will be interpreted as being part of a tag. Square brackets \[\] and curly braces {} can be used too.
+- **woods -( scary ~weapon ~animal )** matches any entry with the "woods" tag, unless it is also tagged "scary" and "weapon", or "scary" and "animal"
+
+#### Other Operators
+
+It is also possible to use various Boolean operators directly when combining tags instead of relying on tags to be combined automatically. These operators will be evaluated from left to right, after parentheses and exclusion operators, but before the implicit operations in lists of search terms. Every one of these Boolean operators needs a space after it, or it will be interpreted as being part of a tag. Many operators are supported, and many ways of writing the operators are supported. Here is a list: "and", "^", "&", "&&", "or", "v", "|", "||", "nor", "nand", "xor", "!=", "!=\=", "xnor", "=", "=\=", or "=\=\=".
+- **sad == dark_clothes and photograph** matches any entry tagged "photograph", but that doesn't have exactly one "sad" or "dark clothes" tag without the other.
+
+#### Metatags
+
+There are some terms that can be matched even without the need to be specifically tagged ahead of time. The following are the supported metatags:
+- **untagged**/**no_tags** whether the entry has no tags at all yet.
+- **empty**/**no_fields** whether the entry has no fields at all, tag or otherwise. This covers text lines, text boxes, dates, and more.
+- **missing**/**no_file** whether the media file associated with the entry is gone or missing from where it was when the entry was created.
+- **no_author**/**no_artist** whether the "Author" or "Artist" fields aren't present in the entry.
+- **filename:** matches any portion of text in the name and subdirectory that the file is located in relative to the library's path. Here are some usage examples:
+  - **filename:copy.png** matches any .PNG file whose filename ends with "copy" regardless of directory, such as "shared img \- Copy.png"
+  - **filename:subdir1\subdir2** matches any file in subdir2, such as "subdir1\subdir2\subdir3\hidden.gif"
+  - **filename:subdir3\photo.jpg** matches any file named photo.jpg in a folder called "subdir3", even if the path to it from the library directory is something like "subdir1\subdir2\subdir3\photo.jpg".
+- **tag_id:** matches any entry with a tag whose internal id matches the number. Click on a tag in the preview pane on the right to replace the search with a tag_id expression for that tag.
+  - **tag_id:1001** matches any entry tagged with the first custom tag created for the library.
+- Hopefully more coming in the future!
+
+#### Escape Characters
+
+If the name of one of your tags overlaps with the search syntax, then put a backslash \\ or a forward slash / just before the tag to ensure it's treated like a tag.
+- **~clip_art ~stock_photo \\\~cute~** matches entries tagged "clip art" and "\~cute~" or "stock photo" and "\~cute~". Without the backslash, the tilde ~ at the start of the "\~cute~" tag would mistakenly result in the mandatory "\~cute~" tag being interpreted as an optional "cute~" tag, missing the first tilde.
+- **transparent -\\empty -roses** matches entries tagged "transparent", but not tagged "empty" or "roses". Without the backslash, the "empty" tag would be interpreted as a metatag instead of a tag, meaning that the results would mistakenly include entries tagged "empty", since the entry didn't have "no_fields".
+
 ### Half-Implemented Features
 
 #### Fix Duplicate Files
@@ -184,7 +245,6 @@ Of the several features I have planned for the project, these are broken up into
 
 - Improved search
   - Sortable Search
-  - Boolean Search
   - Coexisting Text + Tag Search
   - Searchable File Metadata
 - Comprehensive Tag management tab

--- a/doc/updates/planned_features.md
+++ b/doc/updates/planned_features.md
@@ -19,7 +19,6 @@ The following lists outline the planned major and minor features for TagStudio, 
 - Settings Menu
 - Custom User Colors
 - Search Engine Rework
-  - Boolean Search
   - Tag Objects In Search
   - Search For Fields
   - Sortable Search Results

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -1338,7 +1338,7 @@ class Library:
         Uses a search query to generate a filtered results list.
         Returns a list of (str, int) tuples consisting of a result type and ID.
         """
-        
+
         results: list[tuple[ItemType, int]] = []
         collations_added = []
         if query_string:
@@ -1347,7 +1347,7 @@ class Library:
             # to minimize refactoring if it is reprogrammed to return an
             # SQL query instead of evaluating entries itself.
             search_query = SearchQuery(query_string, search_mode)
-            
+
             # By default, SearchQuery does not know the ID of any of its
             # tags, or the IDs of any of their child tags.
             # share_tag_requests() returns a list of potential tag
@@ -1357,20 +1357,18 @@ class Library:
             tag_text_to_id_clusters: dict[str, list[int]] = {}
             for tag_text in tags_to_identify:
                 cluster: set[int] = set()
-                
+
                 # Add the immediate associated Tags to the set (ex. Name, Alias hits)
                 # Since this term could technically map to multiple IDs, iterate over it
                 # (You're 99.9999999% likely to just get 1 item)
                 if tag_text in self._tag_strings_to_id_map:
                     for id in self._tag_strings_to_id_map[tag_text]:
                         cluster.add(id)
-                        cluster = cluster.union(
-                            set(self.get_tag_cluster(id))
-                        )
-                
+                        cluster = cluster.union(set(self.get_tag_cluster(id)))
+
                 tag_text_to_id_clusters[tag_text] = list(cluster)
             search_query.receive_requested_lib_info(tag_text_to_id_clusters)
-            
+
             # This loop evaluates the search query against each entry
             # and adds the entry to results if it matches the search.
             for entry in self.entries:
@@ -1378,29 +1376,29 @@ class Library:
                     # The filename of the current entry is not relevant
                     # to this Library, so skip the entry.
                     continue
-                
+
                 entry_has_author = False
                 entry_tag_ids: list[int] = []
-                
+
                 for field in entry.fields:
                     field_id = list(field.keys())[0]
                     field_obj = self.get_field_obj(field_id)
-                    
+
                     # If the entry has tags of any kind, append their ids to entry_tag_ids.
                     if field_obj["type"] == "tag_box":
                         entry_tag_ids.extend(field[field_id])
-                    
+
                     if field_obj["name"] == "Author":
                         entry_has_author = True
                     elif field_obj["name"] == "Artist":
                         entry_has_author = True
-                
+
                 if search_query.match_entry(
                     has_fields=bool(entry.fields),
                     has_author=entry_has_author,
                     path=entry.path,
                     filename=entry.filename,
-                    tag_ids=entry_tag_ids
+                    tag_ids=entry_tag_ids,
                 ):
                     results.append((ItemType.ENTRY, entry.id))
         else:

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -19,7 +19,7 @@ from typing_extensions import Self
 
 from src.core.enums import FieldID
 from src.core.json_typing import JsonCollation, JsonEntry, JsonLibary, JsonTag
-from src.core.utils.str import strip_punctuation
+from src.core.utils.str import replace_whitespace
 from src.core.utils.web import strip_web_protocol
 from src.core.enums import SearchMode
 from src.core.constants import (
@@ -1629,8 +1629,8 @@ class Library:
         for string in self._tag_strings_to_id_map:  # O(n), n = tags
             exact_match: bool = False
             partial_match: bool = False
-            query = strip_punctuation(query).lower()
-            string = strip_punctuation(string).lower()
+            query = replace_whitespace(query).lower()
+            string = replace_whitespace(string).lower()
 
             if query == string:
                 exact_match = True
@@ -1796,13 +1796,13 @@ class Library:
         # Remember that _tag_names_to_tag_id_map maps strings to a LIST of ids.
         # print(
         #     f'Removing connection from "{old_tag.name.lower()}" to {old_tag.id} in {self._tag_names_to_tag_id_map[old_tag.name.lower()]}')
-        old_name: str = strip_punctuation(old_tag.name).lower()
+        old_name: str = replace_whitespace(old_tag.name).lower()
         self._tag_strings_to_id_map[old_name].remove(old_tag.id)
         # Delete the map key if it doesn't point to any other IDs.
         if not self._tag_strings_to_id_map[old_name]:
             del self._tag_strings_to_id_map[old_name]
         if old_tag.shorthand:
-            old_sh: str = strip_punctuation(old_tag.shorthand).lower()
+            old_sh: str = replace_whitespace(old_tag.shorthand).lower()
             # print(
             #     f'Removing connection from "{old_tag.shorthand.lower()}" to {old_tag.id} in {self._tag_names_to_tag_id_map[old_tag.shorthand.lower()]}')
             self._tag_strings_to_id_map[old_sh].remove(old_tag.id)
@@ -1811,7 +1811,7 @@ class Library:
                 del self._tag_strings_to_id_map[old_sh]
         if old_tag.aliases:
             for alias in old_tag.aliases:
-                old_a: str = strip_punctuation(alias).lower()
+                old_a: str = replace_whitespace(alias).lower()
                 # print(
                 #     f'Removing connection from "{alias.lower()}" to {old_tag.id} in {self._tag_names_to_tag_id_map[alias.lower()]}')
                 self._tag_strings_to_id_map[old_a].remove(old_tag.id)
@@ -2209,18 +2209,18 @@ class Library:
         Uses name_and_alias_to_tag_id_map.
         """
         # tag_id: int, tag_name: str, tag_aliases: list[str] = []
-        name: str = strip_punctuation(tag.name).lower()
+        name: str = replace_whitespace(tag.name).lower()
         if name not in self._tag_strings_to_id_map:
             self._tag_strings_to_id_map[name] = []
         self._tag_strings_to_id_map[name].append(tag.id)
 
-        shorthand: str = strip_punctuation(tag.shorthand).lower()
+        shorthand: str = replace_whitespace(tag.shorthand).lower()
         if shorthand not in self._tag_strings_to_id_map:
             self._tag_strings_to_id_map[shorthand] = []
         self._tag_strings_to_id_map[shorthand].append(tag.id)
 
         for alias in tag.aliases:
-            alias = strip_punctuation(alias).lower()
+            alias = replace_whitespace(alias).lower()
             if alias not in self._tag_strings_to_id_map:
                 self._tag_strings_to_id_map[alias] = []
             self._tag_strings_to_id_map[alias].append(tag.id)

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -1379,12 +1379,7 @@ class Library:
                     # to this Library, so skip the entry.
                     continue
                 
-                # These 4 values contain all the pieces of entry-related
-                # information that the search_query may need in order to
-                # evaluate the entry.
-                entry_has_fields = bool(entry.fields)
                 entry_has_author = False
-                entry_filename = str(os.path.join(entry.path, entry.filename)).lower()
                 entry_tag_ids: list[int] = []
                 
                 for field in entry.fields:
@@ -1401,9 +1396,10 @@ class Library:
                         entry_has_author = True
                 
                 if search_query.match_entry(
-                    has_fields=entry_has_fields,
+                    has_fields=bool(entry.fields),
                     has_author=entry_has_author,
-                    filename=entry_filename,
+                    path=entry.path,
+                    filename=entry.filename,
                     tag_ids=entry_tag_ids
                 ):
                     results.append((ItemType.ENTRY, entry.id))

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -22,6 +22,7 @@ from src.core.json_typing import JsonCollation, JsonEntry, JsonLibary, JsonTag
 from src.core.utils.str import replace_whitespace
 from src.core.utils.web import strip_web_protocol
 from src.core.enums import SearchMode
+from src.core.search import SearchQuery
 from src.core.constants import (
     BACKUP_FOLDER_NAME,
     COLLAGE_FOLDER_NAME,
@@ -1327,7 +1328,7 @@ class Library:
 
     def search_library(
         self,
-        query: str = None,
+        query_string: str = None,
         entries=True,
         collations=True,
         tag_groups=True,
@@ -1337,210 +1338,81 @@ class Library:
         Uses a search query to generate a filtered results list.
         Returns a list of (str, int) tuples consisting of a result type and ID.
         """
-
-        # self.filtered_entries.clear()
+        
         results: list[tuple[ItemType, int]] = []
         collations_added = []
-        # print(f"Searching Library with query: {query} search_mode: {search_mode}")
-        if query:
-            # start_time = time.time()
-            query = query.strip().lower()
-            query_words: list[str] = query.split(" ")
-            all_tag_terms: list[str] = []
-            only_untagged: bool = "untagged" in query or "no tags" in query
-            only_empty: bool = "empty" in query or "no fields" in query
-            only_missing: bool = "missing" in query or "no file" in query
-            allow_adv: bool = "filename:" in query_words
-            tag_only: bool = "tag_id:" in query_words
-            if allow_adv:
-                query_words.remove("filename:")
-            if tag_only:
-                query_words.remove("tag_id:")
-            # TODO: Expand this to allow for dynamic fields to work.
-            only_no_author: bool = "no author" in query or "no artist" in query
-
-            # Preprocess the Tag terms.
-            if query_words:
-                # print(query_words, self._tag_strings_to_id_map)
-                for i, term in enumerate(query_words):
-                    for j, term in enumerate(query_words):
-                        if (
-                            query_words[i : j + 1]
-                            and " ".join(query_words[i : j + 1])
-                            in self._tag_strings_to_id_map
-                        ):
-                            all_tag_terms.append(" ".join(query_words[i : j + 1]))
-                        # print(all_tag_terms)
-
-                # This gets rid of any accidental term inclusions because they were words
-                # in another term. Ex. "3d" getting added in "3d art"
-                for i, term in enumerate(all_tag_terms):
-                    for j, term2 in enumerate(all_tag_terms):
-                        if i != j and all_tag_terms[i] in all_tag_terms[j]:
-                            # print(
-                            #     f'removing {all_tag_terms[i]} because {all_tag_terms[i]} was in {all_tag_terms[j]}')
-                            all_tag_terms.remove(all_tag_terms[i])
-                            break
-
-            # print(all_tag_terms)
-
-            # non_entry_count = 0
-            # Iterate over all Entries =============================================================
+        if query_string:
+            # SearchQuery is not intended to have any direct access to
+            # this library instance or to its entries. That's in order
+            # to minimize refactoring if it is reprogrammed to return an
+            # SQL query instead of evaluating entries itself.
+            search_query = SearchQuery(query_string, search_mode)
+            
+            # By default, SearchQuery does not know the ID of any of its
+            # tags, or the IDs of any of their child tags.
+            # share_tag_requests() returns a list of potential tag
+            # strings that the SearchQuery may need to know the IDs of
+            # in order to evaluate an entry
+            tags_to_identify: list[str] = search_query.share_tag_requests()
+            tag_text_to_id_clusters: dict[str, list[int]] = {}
+            for tag_text in tags_to_identify:
+                cluster: set[int] = set()
+                
+                # Add the immediate associated Tags to the set (ex. Name, Alias hits)
+                # Since this term could technically map to multiple IDs, iterate over it
+                # (You're 99.9999999% likely to just get 1 item)
+                if tag_text in self._tag_strings_to_id_map:
+                    for id in self._tag_strings_to_id_map[tag_text]:
+                        cluster.add(id)
+                        cluster = cluster.union(
+                            set(self.get_tag_cluster(id))
+                        )
+                
+                tag_text_to_id_clusters[tag_text] = list(cluster)
+            search_query.receive_requested_lib_info(tag_text_to_id_clusters)
+            
+            # This loop evaluates the search query against each entry
+            # and adds the entry to results if it matches the search.
             for entry in self.entries:
-                allowed_ext: bool = entry.filename.suffix.lower() not in self.ext_list
-                # try:
-                # entry: Entry = self.entries[self.file_to_library_index_map[self._source_filenames[i]]]
-                # print(f'{entry}')
-
-                if allowed_ext == self.is_exclude_list:
-                    # If the entry has tags of any kind, append them to this main tag list.
-                    entry_tags: list[int] = []
-                    entry_authors: list[str] = []
-                    if entry.fields:
-                        for field in entry.fields:
-                            field_id = list(field.keys())[0]
-                            if self.get_field_obj(field_id)["type"] == "tag_box":
-                                entry_tags.extend(field[field_id])
-                            if self.get_field_obj(field_id)["name"] == "Author":
-                                entry_authors.extend(field[field_id])
-                            if self.get_field_obj(field_id)["name"] == "Artist":
-                                entry_authors.extend(field[field_id])
-
-                    # print(f'Entry Tags: {entry_tags}')
-
-                    # Add Entries from special flags -------------------------------
-                    # TODO: Come up with a more user-resistent way to 'archived' and 'favorite' tags.
-                    if only_untagged:
-                        if not entry_tags:
-                            results.append((ItemType.ENTRY, entry.id))
-                    elif only_no_author:
-                        if not entry_authors:
-                            results.append((ItemType.ENTRY, entry.id))
-                    elif only_empty:
-                        if not entry.fields:
-                            results.append((ItemType.ENTRY, entry.id))
-                    elif only_missing:
-                        if (
-                            self.library_dir / entry.path / entry.filename
-                        ).resolve() in self.missing_files:
-                            results.append((ItemType.ENTRY, entry.id))
-
-                    # elif query == "archived":
-                    #     if entry.tags and self._tag_names_to_tag_id_map[self.archived_word.lower()][0] in entry.tags:
-                    #         self.filtered_file_list.append(file)
-                    #         pb.value = len(self.filtered_file_list)
-                    # elif query in entry.path.lower():
-
-                    # NOTE: This searches path and filenames.
-
-                    if allow_adv:
-                        if [q for q in query_words if (q in str(entry.path).lower())]:
-                            results.append((ItemType.ENTRY, entry.id))
-                        elif [
-                            q for q in query_words if (q in str(entry.filename).lower())
-                        ]:
-                            results.append((ItemType.ENTRY, entry.id))
-                    elif tag_only:
-                        if entry.has_tag(self, int(query_words[0])):
-                            results.append((ItemType.ENTRY, entry.id))
-
-                    # elif query in entry.filename.lower():
-                    # 	self.filtered_entries.append(index)
-                    elif entry_tags:
-                        # function to add entry to results
-                        def add_entry(entry: Entry):
-                            # self.filter_entries.append()
-                            # self.filtered_file_list.append(file)
-                            # results.append((SearchItemType.ENTRY, entry.id))
-                            added = False
-                            for f in entry.fields:
-                                if self.get_field_attr(f, "type") == "collation":
-                                    if (
-                                        self.get_field_attr(f, "content")
-                                        not in collations_added
-                                    ):
-                                        results.append(
-                                            (
-                                                ItemType.COLLATION,
-                                                self.get_field_attr(f, "content"),
-                                            )
-                                        )
-                                        collations_added.append(
-                                            self.get_field_attr(f, "content")
-                                        )
-                                    added = True
-
-                            if not added:
-                                results.append((ItemType.ENTRY, entry.id))
-
-                        if search_mode == SearchMode.AND:  # Include all terms
-                            # For each verified, extracted Tag term.
-                            failure_to_union_terms = False
-                            for term in all_tag_terms:
-                                # If the term from the previous loop was already verified:
-                                if not failure_to_union_terms:
-                                    cluster: set = set()
-                                    # Add the immediate associated Tags to the set (ex. Name, Alias hits)
-                                    # Since this term could technically map to multiple IDs, iterate over it
-                                    # (You're 99.9999999% likely to just get 1 item)
-                                    for id in self._tag_strings_to_id_map[term]:
-                                        cluster.add(id)
-                                        cluster = cluster.union(
-                                            set(self.get_tag_cluster(id))
-                                        )
-                                    # print(f'Full Cluster: {cluster}')
-                                    # For each of the Tag IDs in the term's ID cluster:
-                                    for t in cluster:
-                                        # Assume that this ID from the cluster is not in the Entry.
-                                        # Wait to see if proven wrong.
-                                        failure_to_union_terms = True
-                                        # If the ID actually is in the Entry,
-                                        if t in entry_tags:
-                                            # There wasn't a failure to find one of the term's cluster IDs in the Entry.
-                                            # There is also no more need to keep checking the rest of the terms in the cluster.
-                                            failure_to_union_terms = False
-                                            # print(f"FOUND MATCH: {t}")
-                                            break
-                                        # print(f'\tFailure to Match: {t}')
-                            # # failure_to_union_terms is used to determine if all terms in the query were found in the entry.
-                            # # If there even were tag terms to search through AND they all match an entry
-                            if all_tag_terms and not failure_to_union_terms:
-                                add_entry(entry)
-
-                        if search_mode == SearchMode.OR:  # Include any terms
-                            # For each verified, extracted Tag term.
-                            for term in all_tag_terms:
-                                # Add the immediate associated Tags to the set (ex. Name, Alias hits)
-                                # Since this term could technically map to multiple IDs, iterate over it
-                                # (You're 99.9999999% likely to just get 1 item)
-                                for id in self._tag_strings_to_id_map[term]:
-                                    # If the ID actually is in the Entry,
-                                    if id in entry_tags:
-                                        # check if result already contains the entry
-                                        if (ItemType.ENTRY, entry.id) not in results:
-                                            add_entry(entry)
-                                        break
-
-                # sys.stdout.write(
-                #     f'\r[INFO][FILTER]: {len(self.filtered_file_list)} matches found')
-                # sys.stdout.flush()
-
-                # except:
-                #     # # Put this here to have new non-registered images show up
-                #     # if query == "untagged" or query == "no author" or query == "no artist":
-                #     #     self.filtered_file_list.append(file)
-                #     # non_entry_count = non_entry_count + 1
-                #     pass
-
-            # end_time = time.time()
-            # print(
-            # 	f'[INFO][FILTER]: {len(self.filtered_entries)} matches found ({(end_time - start_time):.3f} seconds)')
-
-            # if non_entry_count:
-            # 	print(
-            # 		f'[INFO][FILTER]: There are {non_entry_count} new files in {self.source_dir} that do not have entries. These will not appear in most filtered results.')
-            # if not self.filtered_entries:
-            # 	print("[INFO][FILTER]: Filter returned no results.")
+                if self.is_exclude_list == (entry.filename.suffix in self.ext_list):
+                    # The filename of the current entry is not relevant
+                    # to this Library, so skip the entry.
+                    continue
+                
+                # These 5 values contain all the pieces of entry-related
+                # information that the search_query may need in order to
+                # evaluate the entry.
+                entry_has_fields = bool(entry.fields)
+                entry_has_author = False
+                entry_has_file = (
+                    self.library_dir /
+                    entry.path /
+                    entry.filename
+                ).resolve() in self.missing_files
+                entry_filename = str(os.path.join(entry.path, entry.filename)).lower()
+                entry_tag_ids: list[int] = []
+                
+                for field in entry.fields:
+                    field_id = list(field.keys())[0]
+                    field_obj = self.get_field_obj(field_id)
+                    
+                    # If the entry has tags of any kind, append their ids to entry_tag_ids.
+                    if field_obj["type"] == "tag_box":
+                        entry_tag_ids.extend(field[field_id])
+                    
+                    if field_obj["name"] == "Author":
+                        entry_has_author = True
+                    elif field_obj["name"] == "Artist":
+                        entry_has_author = True
+                
+                if search_query.match_entry(
+                    has_fields=entry_has_fields,
+                    has_author=entry_has_author,
+                    has_file=entry_has_file,
+                    filename=entry_filename,
+                    tag_ids=entry_tag_ids
+                ):
+                    results.append((ItemType.ENTRY, entry.id))
         else:
             for entry in self.entries:
                 added = False

--- a/tagstudio/src/core/search.py
+++ b/tagstudio/src/core/search.py
@@ -1,0 +1,553 @@
+
+"""Search query parsing functionality for use by the src.core.library.Library object in TagStudio"""
+
+import re
+
+from abc import ABC, abstractmethod
+from collections import deque
+
+from src.core.enums import SearchMode
+
+"""Container for search relevant entry data received by SearchQuery instances"""
+class _EntrySearchableData:
+    def __init__(
+        self,
+        has_fields,
+        has_author,
+        has_file,
+        filename: str,
+        tag_ids: list[int]
+    ):
+        self.has_fields = has_fields
+        self.has_author = has_author
+        self.has_file = has_file
+        self.filename = filename
+        self.tag_ids = tag_ids
+
+
+class ParseError(Exception):
+    """Thrown when the user formats a search incorrectly.
+    
+    Usually this is due to a bad Boolean operator or an extra closing
+    parenthesis.
+    
+    Currently there is no handling logic to inform the user that
+    that they made a mistake. Instead, ParseErrors are caught, and
+    problematic Boolean operators are simply ignored during parsing.
+    """
+
+class _Token:
+    """A raw token from a search query.
+    
+    kind should be "oparen", "cparen", "binary", "unary", or "tag".
+    """
+    
+    def __init__(self, kind: str, text: str):
+        self.kind = kind
+        self.text = text
+    
+    def __str__(self):
+        return f"({self.kind}, {self.text})"
+
+class _SynNode(ABC):
+    """A single node in a SearchQuery's syntax tree."""
+    
+    # _ListNodes need to be able to tell when one of their children is a
+    # tilde in _ListNode.eval(), so _SynNode has an is_tilde parameter.
+    def __init__(self, is_tilde: bool = False) -> None:
+        self.is_tilde = is_tilde
+    
+    # Recursively tests and returns whether the passed entry matches
+    # this _SynNode along with any necessary children.
+    #
+    # The entry parameter must contain any information needed for any
+    # _TagNode in the syntax tree to evaluate whether it matches the
+    # entry.
+    @abstractmethod
+    def match(self, entry: _EntrySearchableData) -> bool:
+        pass
+    # # Implement this at a later date to replace _SynNode.match().
+    # #
+    # # Recursively compile and return an SQL query to retrieve entries
+    # # that match this _SynNode along with any necessary children.
+    # @abstractmethod
+    # def compile_SQL(self):
+    #     pass
+    
+    # Recursively returns a string representing this _SynNode and all
+    # its children. Useful for debugging.
+    @abstractmethod
+    def __str__(self) -> str:
+        pass
+
+class _ListNode(_SynNode):
+    """A list type node in a SearchQuery's syntax tree.
+    
+    The default root node of a SearchQuery is an instance of this class.
+    The _SynNodes that hold the terms after an open parenthesis ( in a
+    search query string are also instances of this class.
+    
+    Instances of this class can have an arbitrary number of child nodes,
+    (including zero)
+    """
+    
+    # _ListNode instances change how they match entries based on the
+    # search_mode.
+    def __init__(self, search_mode: SearchMode, children: list[_SynNode]) -> None:
+        super().__init__()
+        self.search_mode = search_mode
+        self.children = children
+    
+    # The tilde ~ unary operator acts as a flag to indicate whether a
+    # _ListNode's child node should be treated as optional or partial
+    # instead of being treated as a normal term.
+    #
+    # If search mode is AND, then a search query like
+    # ( t1 ~t2 t3 ~t4 t5 ~t6 ) is evaluated like
+    # ( t1 and t3 and t4 and ( t2 or  t4 or  t6 ) )
+    # If search mode is OR, then
+    # ( t1 ~t2 t3 ~t4 t5 ~t6 ) is evaluated like
+    # ( t1 or  t3 or  t4 or  ( t2 and t4 and t6 ) )
+    #
+    # Note: _ListNode.match() has to keep track of whether tilde ~ is
+    # used, otherwise having at least one "optional term" becomes
+    # mandatory in AND mode, and otherwise having no "partial match
+    # terms" would automatically count as a full match in OR mode.
+    def match(self, entry: _EntrySearchableData) -> bool:
+        if self.search_mode is SearchMode.AND:
+            uses_optional = False
+            fulfils_optional = False
+            for child in self.children:
+                if child.is_tilde:
+                    uses_optional = True
+                    if child.match(entry):
+                        fulfils_optional = True
+                elif not child.match(entry):
+                    return False
+            return not uses_optional or fulfils_optional
+        elif self.search_mode is SearchMode.OR:
+            uses_partial = False
+            fulfils_partial = True
+            for child in self.children:
+                if child.is_tilde:
+                    uses_partial = True
+                    if not child.match(entry):
+                        fulfils_partial = False
+                elif child.match(entry):
+                    return True
+            return uses_partial and fulfils_partial
+    
+    def __str__(self) -> str:
+        s = "L("
+        for child_node in self.children:
+            s += str(child_node)
+            s += " "
+        s = s.removesuffix(" ")
+        s += ")"
+        return s
+class _BinaryNode(_SynNode):
+    """A two-input operator node in a SearchQuery's syntax tree.
+    
+    Instances of this class represent any explicit Boolean operations on
+    two inputs in the search query string.
+    
+    This class has two child nodes to act as the two operands of this
+    Boolean operator.
+    """
+    
+    # operator_text is the operator's raw representation in the search
+    # query string. This should be one of "and", "^", "&", "&&", "or",
+    # "v", "|", "||", "nor", "nand", "xor", "!=", "!==", "xnor", "=",
+    # "==", or "===".
+    def __init__(self, operator_text, left_operand: _SynNode, right_operand: _SynNode) -> None:
+        super().__init__()
+        self.operator_text = operator_text
+        self.left_operand = left_operand
+        self.right_operand = right_operand
+    
+    def match(self, entry: _EntrySearchableData) -> bool:
+        match self.operator_text:
+            case "and" | "^" | "&" | "&&":
+                return     self.left_operand.match(entry) and     self.right_operand.match(entry)
+            case "or" | "v" | "|" | "||":
+                return     self.left_operand.match(entry) or      self.right_operand.match(entry)
+            case "nor":
+                return not self.left_operand.match(entry) and not self.right_operand.match(entry)
+            case "nand":
+                return not self.left_operand.match(entry) or  not self.right_operand.match(entry)
+            case "xor" | "!=" | "!==":
+                return     self.left_operand.match(entry) !=      self.right_operand.match(entry)
+            case "xnor" | "=" | "==" | "===":
+                return     self.left_operand.match(entry) ==      self.right_operand.match(entry)
+            case other:
+                raise ValueError("self.operator_text must be a valid binary operator."
+                               f" self.operator_text was '{self.operator_text}'")
+    
+    def __str__(self) -> str:
+        return f"B({self.left_operand} {self.operator_text} {self.right_operand})"
+class _UnaryNode(_SynNode):
+    """A one-input operator node in a SearchQuery's syntax tree.
+    
+    Instances of this class represent either the tilde flag, or
+    exclusion operations in the search query string.
+    
+    This class has one child node.
+    """
+    
+    # operator_text is the operator's raw representation in the search
+    # query string. This should be one of "not", "-", "!", or "~".
+    def __init__(self, operator_text, operand: _SynNode) -> None:
+        super().__init__(is_tilde = operator_text == "~")
+        self.operator_text = operator_text
+        self.operand = operand
+    
+    def match(self, entry: _EntrySearchableData) -> bool:
+        match self.operator_text:
+            case "not" | "-" | "!":
+                return not self.operand.match(entry)
+            # Tilde ~ acts like the identity operator. ~ does not
+            # directly affect the output. Tilde ~ acts as a flag for
+            # _ListNode.match() and should not have any other affect.
+            case "~":
+                return     self.operand.match(entry)
+            case other:
+                raise ValueError("self.operator_text must be a valid unary operator."
+                               f" self.operator_text was '{self.operator_text}'")
+    def __str__(self) -> str:
+        return f"U({self.operator_text} {self.operand})"
+class _TagNode(_SynNode):
+    """A tag or metatag leaf node in a SearchQuery's syntax tree.
+    
+    Instances of this class represent tags and metatags in search query
+    strings.
+    
+    Instances of his class don't have child nodes, but currently their
+    id_cluster attribute must be set by SearchQuery before their match()
+    method can be called. id_cluster should contain any ids associated
+    with the tag and with any child tags it may have.
+    """
+    
+    # token_text should store this tag's raw representation in the
+    # search query string. (With any escape character included.)
+    def __init__(self, token_text) -> None:
+        super().__init__()
+        self.token_text = token_text
+    
+    # search.py is not meant to have direct access to src.core.library,
+    # so all relevant data has to be passed into this _TagNode manually.
+    # In the future, a compile_SQL method can be used to return an SQL
+    # query without any library data being passed at all.
+    id_cluster: list[int]
+    def match(self, entry: _EntrySearchableData) -> bool:
+        match self.token_text:
+            case "empty" | "no_fields" | "no-fields" | "nofields":
+                return not entry.has_fields
+            case "no_author" | "no-author" | "noauthor" | "no_artist" | "no-artist" | "noartist":
+                return not entry.has_author
+            case "missing" | "no_file" | "no-file" | "nofile":
+                return not entry.has_file
+            case "untagged" | "no_tags" | "no-tags" | "notags":
+                return not entry.tag_ids
+        
+        if self.token_text.startswith("filename:"):
+            filename = self.token_text.removeprefix("filename:")
+            return filename in entry.filename
+        if (
+               self.token_text.startswith("tag_id:")
+            or self.token_text.startswith("tag-id:")
+            or self.token_text.startswith("tagid:")
+        ):
+            tag_id_text = self.token_text.removeprefix("tag")
+            tag_id_text = tag_id_text.removeprefix("_")
+            tag_id_text = tag_id_text.removeprefix("-")
+            tag_id_text = tag_id_text.removeprefix("id:")
+            return tag_id_text.isdecimal() and int(tag_id_text) in entry.tag_ids
+        
+        for tag_id in self.id_cluster:
+            # If the ID actually is in the src.core.library.Entry,
+            if tag_id in entry.tag_ids:
+                return True
+        
+        return False
+    
+    def __str__(self) -> str:
+        return f"T({self.token_text})"
+
+# The named regex capturing groups each correspond with one kind of
+# token, these are oparen, cparen, binary, unary, and tag.
+#
+# This regex is designed so that exactly one named capturing group will
+# capture a token every time the regex matches.
+#
+# Only intended to be used by SearchQuery._tokenize().
+_token_regex = re.compile(
+     r"(?P<oparen>[([{])(?:\s|$)"
+    r"|(?P<cparen>[)\]}])(?:\s|$)"
+    r"|(?P<binary>[&^|v=]|or|\|\||and|&&|nor|nand|xor|!=|!==|xnor|==|===)(?:\s|$)"
+    r"|(?P<unary>[-~!]|not(?=\s|$))"
+    r"|(?P<tag>\S+)(?:\s|$)"
+)
+class SearchQuery:
+    """This class parses, manages, and interprets search queries.
+    
+    search.py is not meant to have direct access to src.core.library, so
+    so all relevant data has to be passed through to this SearchQuery's
+    _TagNodes to be stored while this SearchQuery is evaluated against
+    each and every entry in the library.
+    
+    In the future, a compile_SQL method can be used to return an SQL
+    query without having to manage any library data at all. No
+    persistence would be needed for that use case and this class could
+    be converted entirely into a function.
+    """
+    
+    def __init__(self, query_string, search_mode: SearchMode):
+        query_tokens: list[_Token] = self._tokenize(query_string.lower())
+        
+        # The _tag_text_to_tag_nodes attribute keeps track of the
+        # library information that the _TagNodes need, and which tag
+        # nodes requested the information. That way this SearchQuery can
+        # share requests for the information, and that way this
+        # SearchQuery can pass received information to the proper
+        # _TagNodes.
+        self._tag_text_to_tag_nodes: dict[str, list[_TagNode]] = {}
+        self._syntax_root: _ListNode = self._parse_list_node(deque(query_tokens), search_mode)
+    
+    def _tokenize(self, query_string: str) -> list[_Token]:
+        regex_matches = _token_regex.finditer(query_string)
+        
+        tokens: list[_Token] = []
+        for match in regex_matches:
+            # Each re.Match contains a dictionary for the named
+            # capturing groups in the regex. The keys of the dictionary
+            # are the names of the groups. If a particular named group
+            # in a re.Match captured a string of text, then the value of
+            # the group's dictionary entry is the text that it captured.
+            # If the named group captured nothing, then its entry's
+            # value is None.
+            for match_key, match_value in match.groupdict().items():
+                if match_value is not None:
+                    tokens.append(_Token(kind=match_key, text=match_value))
+                    break
+        
+        return tokens
+    
+    # This operation can be done because of an open parenthesis in the
+    # token list or in order to parse the root node of the syntax tree.
+    # oparens is True to indicate the former case, and False to indicate
+    # the latter.
+    #
+    # The only reason this is an instance method is because
+    # self._save_lib_info_request() needs to be called whenever a
+    # _TagNode is called.
+    def _parse_list_node(
+        self,
+        tokens: deque[_Token],
+        search_mode: SearchMode,
+        oparens=False
+    ) -> _ListNode:
+        children: list[_SynNode] = []
+        while tokens:
+            token = tokens.popleft()
+            match token.kind:
+                case "oparen":
+                    list_node = self._parse_list_node(tokens, search_mode, oparens=True)
+                    children.append(list_node)
+                case "cparen":
+                    if oparens:
+                        return _ListNode(search_mode, children)
+                    # Ignore the erroneous token. Do not raise exception.
+                    # else:
+                    #    cparen_text = token.text
+                    #    raise ParseError(f"'{cparen_text}' has no corresponding open parenthesis.")
+                case "binary":
+                    if not children:
+                        continue
+                    last_child = children.pop()
+                    try:
+                        binary_node = self._parse_binary_node(
+                            tokens,
+                            search_mode,
+                            oparens,
+                            left_operand=last_child,
+                            operator_text=token.text
+                        )
+                    # Ignore the error. Do not inform the user.
+                    except ParseError:
+                        children.append(last_child)
+                    else:
+                        children.append(binary_node)
+                case "unary":
+                    try:
+                        unary_node = self._parse_unary_node(
+                            tokens,
+                            search_mode,
+                            oparens,
+                            operator_text=token.text
+                        )
+                    # Ignore the error. Do not inform the user.
+                    except ParseError:
+                        pass
+                    else:
+                        children.append(unary_node)
+                case "tag":
+                    tag_node = _TagNode(token.text)
+                    
+                    self._save_lib_info_request(tag_node)
+                    
+                    children.append(tag_node)
+        return _ListNode(search_mode, children)
+    # This parse operation should only ever be called with a
+    # _parse_list_node operation higher on the call stack. If that
+    # operation is waiting for a closed parenthesis, then this operation
+    # is erroneous and the closed parenthesis should be returned to the
+    # queue. If that operation is not waiting for a closed parenthesis,
+    # then this operation can safely consume and ignore closed
+    # parentheses. oparens is True to indicate the former case, and
+    # False to indicate the latter.
+    #
+    # The only reason this is an instance method is because
+    # self._save_lib_info_request() needs to be called whenever a
+    # _TagNode is called.
+    def _parse_binary_node(
+        self,
+        tokens: deque[_Token],
+        search_mode: SearchMode,
+        oparens: bool,
+        operator_text,
+        left_operand: _SynNode
+    ) -> _BinaryNode:
+        while tokens:
+            token = tokens.popleft()
+            match token.kind:
+                case "oparen":
+                    list_node = self._parse_list_node(tokens, search_mode, oparens=True)
+                    return _BinaryNode(operator_text, left_operand, list_node)
+                case "cparen":
+                    if oparens:
+                        tokens.appendleft(token)
+                        cparen_text = token.text
+                        raise ParseError(f"'{operator_text}' cannot be followed by"
+                                        f" '{cparen_text}'.")
+                    # Ignore the erroneous token. Do not raise exception.
+                    # else:
+                    #    cparen_text = token.text
+                    #    raise ParseError(f"'{cparen_text}' has no corresponding open parenthesis.")
+                # Ignore the erroneous token. Do not raise exception.
+                case "binary":
+                    # second_operator_text = token_text
+                    # raise ParseError(f"'{operator_text}' cannot be followed by"
+                    #                  " '{second_operator_text}'")
+                    pass
+                case "unary":
+                    unary_node = self._parse_unary_node(
+                        tokens,
+                        search_mode,
+                        oparens,
+                        operator_text=token.text
+                    )
+                    return _BinaryNode(operator_text, left_operand, unary_node)
+                case "tag":
+                    tag_node = _TagNode(token.text)
+                    
+                    self._save_lib_info_request(tag_node)
+                    
+                    return _BinaryNode(operator_text, left_operand, tag_node)
+        raise ParseError(f"'{operator_text}' is not followed by a second term.")
+    # This parse operation should only ever be called with a
+    # _parse_list_node operation higher on the call stack. If that
+    # operation is waiting for a closed parenthesis, then this operation
+    # is erroneous and the closed parenthesis should be returned to the
+    # queue. If that operation is not waiting for a closed parenthesis,
+    # then this operation can safely consume and ignore closed
+    # parentheses. oparens is True to indicate the former case, and
+    # False to indicate the latter.
+    #
+    # The only reason this is an instance method is because
+    # self._save_lib_info_request() needs to be called whenever a
+    # _TagNode is called.
+    def _parse_unary_node(
+        self,
+        tokens: deque[_Token],
+        search_mode: SearchMode,
+        oparens: bool,
+        operator_text: str
+    ) -> _UnaryNode:
+        while tokens:
+            token = tokens.popleft()
+            match token.kind:
+                case "oparen":
+                    list_node = self._parse_list_node(tokens, search_mode, oparens=True)
+                    return _UnaryNode(operator_text, list_node)
+                case "cparen":
+                    if oparens:
+                        tokens.appendleft(token)
+                        cparen_text = token.text
+                        raise ParseError(f"'{operator_text}' cannot be followed by"
+                                        f" '{cparen_text}'.")
+                    # Ignore the erroneous token. Do not raise exception.
+                    # else:
+                    #    cparen_text = token.text
+                    #    raise ParseError(f"'{cparen_text}' has no corresponding open parenthesis.")
+                case "binary":
+                    tokens.appendleft(token)
+                    second_operator_text = token.text
+                    raise ParseError(f"'{operator_text}' cannot be followed by"
+                                    f" '{second_operator_text}'.")
+                case "unary":
+                    unary_node = self._parse_unary_node(
+                        tokens,
+                        search_mode,
+                        oparens,
+                        operator_text=token.text
+                    )
+                    return _UnaryNode(operator_text=operator_text, operand=unary_node)
+                case "tag":
+                    tag_node = _TagNode(token.text)
+                    
+                    self._save_lib_info_request(tag_node)
+                    
+                    return _UnaryNode(operator_text, tag_node)
+        raise ParseError(f"'{operator_text}' is not followed by a term.")
+    
+    # Assumes the token_text is for a regular tag and not a metatag.
+    # The reply will be ignored anyway if it is.
+    def _save_lib_info_request(self, tag_node: _TagNode) -> None:
+        # These escape characters prevent the syntax node from being
+        # interpreted as an open parenthesis, a closed parenthesis, a
+        # unary operator, a binary operator, or a metatag, but this code
+        # ensures that an escape character it will not interfere with it
+        # as a tag.
+        if tag_node.token_text.startswith("/"):
+            tag_text = tag_node.token_text.removeprefix("/")
+        else:
+            tag_text = tag_node.token_text.removeprefix("\\")
+        # Multiple tag nodes can be associated with the same tag text.
+        if tag_text not in self._tag_text_to_tag_nodes:
+            self._tag_text_to_tag_nodes[tag_text] = []
+        self._tag_text_to_tag_nodes[tag_text].append(tag_node)
+    def share_tag_requests(self) -> list[str]:
+        return list(self._tag_text_to_tag_nodes.keys())
+    def receive_requested_lib_info(self, tag_text_to_id_clusters: dict[str, list[int]]):
+        for tag_text, id_cluster in tag_text_to_id_clusters.items():
+            for tag_node in self._tag_text_to_tag_nodes[tag_text]:
+                tag_node.id_cluster = id_cluster
+    
+    def match_entry(
+        self,
+        has_fields,
+        has_author,
+        has_file,
+        filename: str,
+        tag_ids: list[int]
+    ):
+        return self._syntax_root.match(_EntrySearchableData(
+            has_fields,
+            has_author,
+            has_file,
+            filename,
+            tag_ids
+        ))
+    
+    def __str__(self):
+        return str(self._syntax_root)

--- a/tagstudio/src/core/search.py
+++ b/tagstudio/src/core/search.py
@@ -1,8 +1,7 @@
-
 """Search query parsing functionality for use by the src.core.library.Library object in TagStudio"""
 
 import re
-import os # for os.path.sep
+import os  # for os.path.sep
 
 from abc import ABC, abstractmethod
 from collections import deque
@@ -11,21 +10,18 @@ from pathlib import Path
 from src.core.enums import SearchMode
 
 """Container for search relevant entry data received by SearchQuery instances"""
+
+
 class _EntrySearchableData:
     def __init__(
-        self,
-        has_fields,
-        has_author,
-        path: Path,
-        filename: Path,
-        tag_ids: list[int]
+        self, has_fields, has_author, path: Path, filename: Path, tag_ids: list[int]
     ):
         self.has_fields = has_fields
         self.has_author = has_author
         self.path = path
         self.filename = filename
         self.tag_ids = tag_ids
-        
+
         # Path.__str__() is almost 10x slower than anything else you
         # will find in this file combined. If _TagNode.match() ever ends
         # up evaluating (str(path) + os.path.sep + str(filename)).lower(),
@@ -36,36 +32,38 @@ class _EntrySearchableData:
 
 class ParseError(Exception):
     """Thrown when the user formats a search incorrectly.
-    
+
     Usually this is due to a bad Boolean operator or an extra closing
     parenthesis.
-    
+
     Currently there is no handling logic to inform the user that
     that they made a mistake. Instead, ParseErrors are caught, and
     problematic Boolean operators are simply ignored during parsing.
     """
 
+
 class _Token:
     """A raw token from a search query.
-    
+
     kind should be "oparen", "cparen", "binary", "unary", or "tag".
     """
-    
+
     def __init__(self, kind: str, text: str):
         self.kind = kind
         self.text = text
-    
+
     def __str__(self):
         return f"({self.kind}, {self.text})"
 
+
 class _SynNode(ABC):
     """A single node in a SearchQuery's syntax tree."""
-    
+
     # _ListNodes need to be able to tell when one of their children is a
     # tilde in _ListNode.eval(), so _SynNode has an is_tilde parameter.
     def __init__(self, is_tilde: bool = False) -> None:
         self.is_tilde = is_tilde
-    
+
     # Recursively tests and returns whether the passed entry matches
     # this _SynNode along with any necessary children.
     #
@@ -75,6 +73,7 @@ class _SynNode(ABC):
     @abstractmethod
     def match(self, entry: _EntrySearchableData) -> bool:
         pass
+
     # # Implement this at a later date to replace _SynNode.match().
     # #
     # # Recursively compile and return an SQL query to retrieve entries
@@ -82,31 +81,32 @@ class _SynNode(ABC):
     # @abstractmethod
     # def compile_SQL(self):
     #     pass
-    
+
     # Recursively returns a string representing this _SynNode and all
     # its children. Useful for debugging.
     @abstractmethod
     def __str__(self) -> str:
         pass
 
+
 class _ListNode(_SynNode):
     """A list type node in a SearchQuery's syntax tree.
-    
+
     The default root node of a SearchQuery is an instance of this class.
     The _SynNodes that hold the terms after an open parenthesis ( in a
     search query string are also instances of this class.
-    
+
     Instances of this class can have an arbitrary number of child nodes,
     (including zero)
     """
-    
+
     # _ListNode instances change how they match entries based on the
     # search_mode.
     def __init__(self, search_mode: SearchMode, children: list[_SynNode]) -> None:
         super().__init__()
         self.search_mode = search_mode
         self.children = children
-    
+
     # The tilde ~ unary operator acts as a flag to indicate whether a
     # _ListNode's child node should be treated as optional or partial
     # instead of being treated as a normal term.
@@ -145,7 +145,7 @@ class _ListNode(_SynNode):
                 elif child.match(entry):
                     return True
             return uses_partial and fulfils_partial
-    
+
     def __str__(self) -> str:
         s = "L("
         for child_node in self.children:
@@ -154,135 +154,160 @@ class _ListNode(_SynNode):
         s = s.removesuffix(" ")
         s += ")"
         return s
+
+
 class _BinaryNode(_SynNode):
     """A two-input operator node in a SearchQuery's syntax tree.
-    
+
     Instances of this class represent any explicit Boolean operations on
     two inputs in the search query string.
-    
-    This class has two child nodes to act as the two operands of this
+
+    This class has two child nodes to act as the two inputs of this
     Boolean operator.
     """
-    
+
     # operator_text is the operator's raw representation in the search
     # query string. This should be one of "and", "^", "&", "&&", "or",
     # "v", "|", "||", "nor", "nand", "xor", "!=", "!==", "xnor", "=",
     # "==", or "===".
-    def __init__(self, operator_text, left_operand: _SynNode, right_operand: _SynNode) -> None:
+    def __init__(self, operator_text, left_in: _SynNode, right_in: _SynNode) -> None:
         super().__init__()
         self.operator_text = operator_text
-        self.left_operand = left_operand
-        self.right_operand = right_operand
-    
+        self.left_in = left_in
+        self.right_in = right_in
+
     def match(self, entry: _EntrySearchableData) -> bool:
         match self.operator_text:
             case "and" | "^" | "&" | "&&":
-                return     self.left_operand.match(entry) and     self.right_operand.match(entry)
+                return self.left_in.match(entry) and self.right_in.match(entry)
             case "or" | "v" | "|" | "||":
-                return     self.left_operand.match(entry) or      self.right_operand.match(entry)
+                return self.left_in.match(entry) or self.right_in.match(entry)
             case "nor":
-                return not self.left_operand.match(entry) and not self.right_operand.match(entry)
+                return not self.left_in.match(entry) and not self.right_in.match(entry)
             case "nand":
-                return not self.left_operand.match(entry) or  not self.right_operand.match(entry)
+                return not self.left_in.match(entry) or not self.right_in.match(entry)
             case "xor" | "!=" | "!==":
-                return     self.left_operand.match(entry) !=      self.right_operand.match(entry)
+                return self.left_in.match(entry) != self.right_in.match(entry)
             case "xnor" | "=" | "==" | "===":
-                return     self.left_operand.match(entry) ==      self.right_operand.match(entry)
+                return self.left_in.match(entry) == self.right_in.match(entry)
             case other:
-                raise ValueError("self.operator_text must be a valid binary operator."
-                               f" self.operator_text was '{self.operator_text}'")
-    
+                raise ValueError(
+                    "self.operator_text must be a valid binary operator. self.operator_text was"
+                    f" '{self.operator_text}'"
+                )
+
     def __str__(self) -> str:
-        return f"B({self.left_operand} {self.operator_text} {self.right_operand})"
+        return f"B({self.left_in} {self.operator_text} {self.right_in})"
+
+
 class _UnaryNode(_SynNode):
     """A one-input operator node in a SearchQuery's syntax tree.
-    
+
     Instances of this class represent either the tilde flag, or
     exclusion operations in the search query string.
-    
+
     This class has one child node.
     """
-    
+
     # operator_text is the operator's raw representation in the search
     # query string. This should be one of "not", "-", "!", or "~".
-    def __init__(self, operator_text, operand: _SynNode) -> None:
-        super().__init__(is_tilde = operator_text == "~")
+    def __init__(self, operator_text, input: _SynNode) -> None:
+        super().__init__(is_tilde=(operator_text == "~"))
         self.operator_text = operator_text
-        self.operand = operand
-    
+        self.input = input
+
     def match(self, entry: _EntrySearchableData) -> bool:
         match self.operator_text:
             case "not" | "-" | "!":
-                return not self.operand.match(entry)
+                return not self.input.match(entry)
             # Tilde ~ acts like the identity operator. ~ does not
             # directly affect the output. Tilde ~ acts as a flag for
             # _ListNode.match() and should not have any other affect.
             case "~":
-                return     self.operand.match(entry)
+                return self.input.match(entry)
             case other:
-                raise ValueError("self.operator_text must be a valid unary operator."
-                               f" self.operator_text was '{self.operator_text}'")
+                raise ValueError(
+                    "self.operator_text must be a valid unary operator. self.operator_text was"
+                    f" '{self.operator_text}'"
+                )
+
     def __str__(self) -> str:
-        return f"U({self.operator_text} {self.operand})"
+        return f"U({self.operator_text} {self.input})"
+
+
 class _TagNode(_SynNode):
     """A tag or metatag leaf node in a SearchQuery's syntax tree.
-    
+
     Instances of this class represent tags and metatags in search query
     strings.
-    
+
     Instances of his class don't have child nodes, but currently their
     id_cluster attribute must be set by SearchQuery before their match()
     method can be called. id_cluster should contain any ids associated
     with the tag and with any child tags it may have.
     """
-    
+
     # token_text should store this tag's raw representation in the
     # search query string. (With any escape character included.)
     def __init__(self, token_text) -> None:
         super().__init__()
         self.token_text = token_text
-    
+
     # search.py is not meant to have direct access to src.core.library,
     # so all relevant data has to be passed into this _TagNode manually.
     # In the future, a compile_SQL method can be used to return an SQL
     # query without any library data being passed at all.
     id_cluster: list[int]
+
     def match(self, entry: _EntrySearchableData) -> bool:
-        match self.token_text:
-            case "empty" | "no_fields" | "no-fields" | "nofields":
+        metatag = self.token_text.replace("-", "_")
+        match metatag.replace("no_", "no"):
+            case "empty" | "nofields":
                 return not entry.has_fields
-            case "no_author" | "no-author" | "noauthor" | "no_artist" | "no-artist" | "noartist":
+            case "noauthor" | "noartist":
                 return not entry.has_author
-            case "untagged" | "no_tags" | "no-tags" | "notags":
+            case "untagged" | "notags":
                 return not entry.tag_ids
-        
-        if self.token_text.startswith("filename:"):
-            filename = self.token_text.removeprefix("filename:")
+
+        if (
+            self.token_text.startswith("file_name:")
+            or self.token_text.startswith("file-name:")
+            or self.token_text.startswith("filename:")
+        ):
+            filename = self.token_text
+            filename = filename.removeprefix("file")
+            filename = filename.removeprefix("-")
+            filename = filename.removeprefix("_")
+            filename = filename.removeprefix("name:")
             # str(path) has a noticeable runtime cost, so cache the
             # result in case the query needs it multiple times per entry
             if not entry.filestring:
-                entry.filestring = (str(entry.path) + os.path.sep + str(entry.filename)).lower()
+                entry.filestring = (
+                    str(entry.path) + os.path.sep + str(entry.filename)
+                ).lower()
             return filename in entry.filestring
         if (
-               self.token_text.startswith("tag_id:")
+            self.token_text.startswith("tag_id:")
             or self.token_text.startswith("tag-id:")
             or self.token_text.startswith("tagid:")
         ):
-            tag_id_text = self.token_text.removeprefix("tag")
+            tag_id_text = self.token_text
+            tag_id_text = tag_id_text.removeprefix("tag")
             tag_id_text = tag_id_text.removeprefix("_")
             tag_id_text = tag_id_text.removeprefix("-")
             tag_id_text = tag_id_text.removeprefix("id:")
             return tag_id_text.isdecimal() and int(tag_id_text) in entry.tag_ids
-        
+
         for tag_id in self.id_cluster:
             # If the ID actually is in the src.core.library.Entry,
             if tag_id in entry.tag_ids:
                 return True
-        
+
         return False
-    
+
     def __str__(self) -> str:
         return f"T({self.token_text})"
+
 
 # The named regex capturing groups each correspond with one kind of
 # token, these are oparen, cparen, binary, unary, and tag.
@@ -292,29 +317,31 @@ class _TagNode(_SynNode):
 #
 # Only intended to be used by SearchQuery._tokenize().
 _token_regex = re.compile(
-     r"(?P<oparen>[([{])(?:\s|$)"
+    r"(?P<oparen>[([{])(?:\s|$)"
     r"|(?P<cparen>[)\]}])(?:\s|$)"
     r"|(?P<binary>[&^|v=]|or|\|\||and|&&|nor|nand|xor|!=|!==|xnor|==|===)(?:\s|$)"
     r"|(?P<unary>[-~!]|not(?=\s|$))"
     r"|(?P<tag>\S+)(?:\s|$)"
 )
+
+
 class SearchQuery:
     """This class parses, manages, and interprets search queries.
-    
+
     search.py is not meant to have direct access to src.core.library, so
     so all relevant data has to be passed through to this SearchQuery's
     _TagNodes to be stored while this SearchQuery is evaluated against
     each and every entry in the library.
-    
+
     In the future, a compile_SQL method can be used to return an SQL
     query without having to manage any library data at all. No
     persistence would be needed for that use case and this class could
     be converted entirely into a function.
     """
-    
+
     def __init__(self, query_string, search_mode: SearchMode):
         query_tokens: list[_Token] = self._tokenize(query_string.lower())
-        
+
         # The _tag_text_to_tag_nodes attribute keeps track of the
         # library information that the _TagNodes need, and which tag
         # nodes requested the information. That way this SearchQuery can
@@ -322,11 +349,13 @@ class SearchQuery:
         # SearchQuery can pass received information to the proper
         # _TagNodes.
         self._tag_text_to_tag_nodes: dict[str, list[_TagNode]] = {}
-        self._syntax_root: _ListNode = self._parse_list_node(deque(query_tokens), search_mode)
-    
+        self._syntax_root: _ListNode = self._parse_list_node(
+            deque(query_tokens), search_mode
+        )
+
     def _tokenize(self, query_string: str) -> list[_Token]:
         regex_matches = _token_regex.finditer(query_string)
-        
+
         tokens: list[_Token] = []
         for match in regex_matches:
             # Each re.Match contains a dictionary for the named
@@ -340,9 +369,9 @@ class SearchQuery:
                 if match_value is not None:
                     tokens.append(_Token(kind=match_key, text=match_value))
                     break
-        
+
         return tokens
-    
+
     # This operation can be done because of an open parenthesis in the
     # token list or in order to parse the root node of the syntax tree.
     # oparens is True to indicate the former case, and False to indicate
@@ -352,10 +381,7 @@ class SearchQuery:
     # self._save_lib_info_request() needs to be called whenever a
     # _TagNode is called.
     def _parse_list_node(
-        self,
-        tokens: deque[_Token],
-        search_mode: SearchMode,
-        oparens=False
+        self, tokens: deque[_Token], search_mode: SearchMode, oparens=False
     ) -> _ListNode:
         children: list[_SynNode] = []
         while tokens:
@@ -370,7 +396,9 @@ class SearchQuery:
                     # Ignore the erroneous token. Do not raise exception.
                     # else:
                     #    cparen_text = token.text
-                    #    raise ParseError(f"'{cparen_text}' has no corresponding open parenthesis.")
+                    #    raise ParseError(
+                    #        f"'{cparen_text}' has no corresponding open parenthesis."
+                    #    )
                 case "binary":
                     if not children:
                         continue
@@ -380,8 +408,8 @@ class SearchQuery:
                             tokens,
                             search_mode,
                             oparens,
-                            left_operand=last_child,
-                            operator_text=token.text
+                            left_in=last_child,
+                            operator_text=token.text,
                         )
                     # Ignore the error. Do not inform the user.
                     except ParseError:
@@ -391,10 +419,7 @@ class SearchQuery:
                 case "unary":
                     try:
                         unary_node = self._parse_unary_node(
-                            tokens,
-                            search_mode,
-                            oparens,
-                            operator_text=token.text
+                            tokens, search_mode, oparens, operator_text=token.text
                         )
                     # Ignore the error. Do not inform the user.
                     except ParseError:
@@ -403,11 +428,12 @@ class SearchQuery:
                         children.append(unary_node)
                 case "tag":
                     tag_node = _TagNode(token.text)
-                    
+
                     self._save_lib_info_request(tag_node)
-                    
+
                     children.append(tag_node)
         return _ListNode(search_mode, children)
+
     # This parse operation should only ever be called with a
     # _parse_list_node operation higher on the call stack. If that
     # operation is waiting for a closed parenthesis, then this operation
@@ -426,45 +452,47 @@ class SearchQuery:
         search_mode: SearchMode,
         oparens: bool,
         operator_text,
-        left_operand: _SynNode
+        left_in: _SynNode,
     ) -> _BinaryNode:
         while tokens:
             token = tokens.popleft()
             match token.kind:
                 case "oparen":
                     list_node = self._parse_list_node(tokens, search_mode, oparens=True)
-                    return _BinaryNode(operator_text, left_operand, list_node)
+                    return _BinaryNode(operator_text, left_in, list_node)
                 case "cparen":
                     if oparens:
                         tokens.appendleft(token)
                         cparen_text = token.text
-                        raise ParseError(f"'{operator_text}' cannot be followed by"
-                                        f" '{cparen_text}'.")
+                        raise ParseError(
+                            f"'{operator_text}' cannot be followed by '{cparen_text}'."
+                        )
                     # Ignore the erroneous token. Do not raise exception.
                     # else:
                     #    cparen_text = token.text
-                    #    raise ParseError(f"'{cparen_text}' has no corresponding open parenthesis.")
+                    #    raise ParseError(
+                    #        f"'{cparen_text}' has no corresponding open parenthesis."
+                    #    )
                 # Ignore the erroneous token. Do not raise exception.
                 case "binary":
                     # second_operator_text = token_text
-                    # raise ParseError(f"'{operator_text}' cannot be followed by"
-                    #                  " '{second_operator_text}'")
+                    # raise ParseError(
+                    #    f"'{operator_text}' cannot be followed by '{second_operator_text}'"
+                    # )
                     pass
                 case "unary":
                     unary_node = self._parse_unary_node(
-                        tokens,
-                        search_mode,
-                        oparens,
-                        operator_text=token.text
+                        tokens, search_mode, oparens, operator_text=token.text
                     )
-                    return _BinaryNode(operator_text, left_operand, unary_node)
+                    return _BinaryNode(operator_text, left_in, unary_node)
                 case "tag":
                     tag_node = _TagNode(token.text)
-                    
+
                     self._save_lib_info_request(tag_node)
-                    
-                    return _BinaryNode(operator_text, left_operand, tag_node)
+
+                    return _BinaryNode(operator_text, left_in, tag_node)
         raise ParseError(f"'{operator_text}' is not followed by a second term.")
+
     # This parse operation should only ever be called with a
     # _parse_list_node operation higher on the call stack. If that
     # operation is waiting for a closed parenthesis, then this operation
@@ -482,7 +510,7 @@ class SearchQuery:
         tokens: deque[_Token],
         search_mode: SearchMode,
         oparens: bool,
-        operator_text: str
+        operator_text: str,
     ) -> _UnaryNode:
         while tokens:
             token = tokens.popleft()
@@ -494,33 +522,34 @@ class SearchQuery:
                     if oparens:
                         tokens.appendleft(token)
                         cparen_text = token.text
-                        raise ParseError(f"'{operator_text}' cannot be followed by"
-                                        f" '{cparen_text}'.")
-                    # Ignore the erroneous token. Do not raise exception.
-                    # else:
-                    #    cparen_text = token.text
-                    #    raise ParseError(f"'{cparen_text}' has no corresponding open parenthesis.")
+                        raise ParseError(
+                            f"'{operator_text}' cannot be followed by '{cparen_text}'."
+                        )
+                        # Ignore the erroneous token. Do not raise exception.
+                        # else:
+                        #    cparen_text = token.text
+                        raise ParseError(
+                            f"'{cparen_text}' has no corresponding open parenthesis."
+                        )
                 case "binary":
                     tokens.appendleft(token)
                     second_operator_text = token.text
-                    raise ParseError(f"'{operator_text}' cannot be followed by"
-                                    f" '{second_operator_text}'.")
+                    raise ParseError(
+                        f"'{operator_text}' cannot be followed by '{second_operator_text}'."
+                    )
                 case "unary":
                     unary_node = self._parse_unary_node(
-                        tokens,
-                        search_mode,
-                        oparens,
-                        operator_text=token.text
+                        tokens, search_mode, oparens, operator_text=token.text
                     )
-                    return _UnaryNode(operator_text=operator_text, operand=unary_node)
+                    return _UnaryNode(operator_text=operator_text, input=unary_node)
                 case "tag":
                     tag_node = _TagNode(token.text)
-                    
+
                     self._save_lib_info_request(tag_node)
-                    
+
                     return _UnaryNode(operator_text, tag_node)
         raise ParseError(f"'{operator_text}' is not followed by a term.")
-    
+
     # Assumes the token_text is for a regular tag and not a metatag.
     # The reply will be ignored anyway if it is.
     def _save_lib_info_request(self, tag_node: _TagNode) -> None:
@@ -537,28 +566,21 @@ class SearchQuery:
         if tag_text not in self._tag_text_to_tag_nodes:
             self._tag_text_to_tag_nodes[tag_text] = []
         self._tag_text_to_tag_nodes[tag_text].append(tag_node)
+
     def share_tag_requests(self) -> list[str]:
         return list(self._tag_text_to_tag_nodes.keys())
+
     def receive_requested_lib_info(self, tag_text_to_id_clusters: dict[str, list[int]]):
         for tag_text, id_cluster in tag_text_to_id_clusters.items():
             for tag_node in self._tag_text_to_tag_nodes[tag_text]:
                 tag_node.id_cluster = id_cluster
-    
+
     def match_entry(
-        self,
-        has_fields,
-        has_author,
-        path: Path,
-        filename: Path,
-        tag_ids: list[int]
+        self, has_fields, has_author, path: Path, filename: Path, tag_ids: list[int]
     ):
-        return self._syntax_root.match(_EntrySearchableData(
-            has_fields,
-            has_author,
-            path,
-            filename,
-            tag_ids
-        ))
-    
+        return self._syntax_root.match(
+            _EntrySearchableData(has_fields, has_author, path, filename, tag_ids)
+        )
+
     def __str__(self):
         return str(self._syntax_root)

--- a/tagstudio/src/core/utils/str.py
+++ b/tagstudio/src/core/utils/str.py
@@ -5,6 +5,8 @@
 import re
 
 _space_regex = re.compile("\\s+")
+
+
 def replace_whitespace(string: str) -> str:
     """Returns a given string replacing all runs of whitespace characters with underscore _."""
     return re.sub(_space_regex, "_", string)

--- a/tagstudio/src/core/utils/str.py
+++ b/tagstudio/src/core/utils/str.py
@@ -2,25 +2,9 @@
 # Licensed under the GPL-3.0 License.
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
+import re
 
-def strip_punctuation(string: str) -> str:
-    """Returns a given string stripped of all punctuation characters."""
-    return (
-        string.replace("(", "")
-        .replace(")", "")
-        .replace("[", "")
-        .replace("]", "")
-        .replace("{", "")
-        .replace("}", "")
-        .replace("'", "")
-        .replace("`", "")
-        .replace("’", "")
-        .replace("‘", "")
-        .replace('"', "")
-        .replace("“", "")
-        .replace("”", "")
-        .replace("_", "")
-        .replace("-", "")
-        .replace(" ", "")
-        .replace("　", "")
-    )
+_space_regex = re.compile("\\s+")
+def replace_whitespace(string: str) -> str:
+    """Returns a given string replacing all runs of whitespace characters with underscore _."""
+    return re.sub(_space_regex, "_", string)

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -98,7 +98,6 @@ class TagBoxWidget(FieldWidget):
                 self.base_layout.takeAt(0).widget().deleteLater()
             is_recycled = True
         for tag in tags:
-            # TODO: Remove space from the special search here (tag_id:x) once that system is finalized.
             # tw = TagWidget(self.lib, self.lib.get_tag(tag), True, True,
             # 							on_remove_callback=lambda checked=False, t=tag: (self.lib.get_entry(self.item.id).remove_tag(self.lib, t, self.field_index), self.updated.emit()),
             # 							on_click_callback=lambda checked=False, q=f'tag_id: {tag}': (self.driver.main_window.searchField.setText(q), self.driver.filter_items(q)),
@@ -106,7 +105,7 @@ class TagBoxWidget(FieldWidget):
             # 							)
             tw = TagWidget(self.lib, self.lib.get_tag(tag), True, True)
             tw.on_click.connect(
-                lambda checked=False, q=f"tag_id: {tag}": (
+                lambda checked=False, q=f"tag_id:{tag}": (
                     self.driver.main_window.searchField.setText(q),
                     self.driver.filter_items(q),
                 )

--- a/tagstudio/tests/core/test_search.py
+++ b/tagstudio/tests/core/test_search.py
@@ -1,397 +1,600 @@
-
 from pathlib import Path
 
 from src.core.search import SearchQuery
 from src.core.enums import SearchMode
 
-def sqmtch( 
+
+def sqmtch(
     search_query: SearchQuery,
     tag_ids: list[int] = [],
     has_fields=True,
     has_author=True,
     path="subfolder",
-    filename="entry.png"
+    filename="entry.png",
 ) -> bool:
     return search_query.match_entry(
         has_fields=has_fields,
         has_author=has_author,
         path=Path(path),
         filename=Path(filename),
-        tag_ids=tag_ids
+        tag_ids=tag_ids,
     )
+
 
 def test_empty_AND_construction():
     search_query = SearchQuery("", SearchMode.AND)
     assert search_query
+
+
 def test_empty_OR_construction():
     search_query = SearchQuery("", SearchMode.OR)
     assert search_query
 
+
 def test_tokenize_empty_list():
     search_query = SearchQuery("", SearchMode.AND)
     assert str(search_query) == "L()"
+
+
 def test_tokenize_ws_list():
     search_query = SearchQuery(" \t\n\r", SearchMode.AND)
     assert str(search_query) == "L()"
-    
+
+
 def test_tokenize_ascii_tag():
-    search_query = SearchQuery("abcdefghijklmnopqrstuvwxyz0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`|{}~", SearchMode.AND)
-    assert str(search_query) == "L(T(abcdefghijklmnopqrstuvwxyz0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`|{}~))"
+    search_query = SearchQuery(
+        "abcdefghijklmnopqrstuvwxyz0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`|{}~",
+        SearchMode.AND,
+    )
+    assert (
+        str(search_query)
+        == "L(T(abcdefghijklmnopqrstuvwxyz0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`|{}~))"
+    )
+
+
 def test_tokenize_leading_ws_tag():
     search_query = SearchQuery(" tag", SearchMode.AND)
     assert str(search_query) == "L(T(tag))"
+
+
 def test_tokenize_trailing_ws_tag():
     search_query = SearchQuery("tag ", SearchMode.AND)
     assert str(search_query) == "L(T(tag))"
-    
+
+
 def test_tokenize_unary_minus():
     search_query = SearchQuery("-tag", SearchMode.AND)
     assert str(search_query) == "L(U(- T(tag)))"
+
+
 def test_tokenize_all_unary():
     search_query = SearchQuery("~-not !tag", SearchMode.AND)
     assert str(search_query) == "L(U(~ U(- U(not U(! T(tag))))))"
+
+
 def test_tokenize_all_unary_with_ws():
     search_query = SearchQuery(" ~ - not ! tag ", SearchMode.AND)
     assert str(search_query) == "L(U(~ U(- U(not U(! T(tag))))))"
+
+
 def test_tokenize_exc_before_equ_tag():
     search_query = SearchQuery("!=^_^=", SearchMode.AND)
     assert str(search_query) == "L(U(! T(=^_^=)))"
+
+
 def test_tokenize_exc_before_equ_equ_tag():
     search_query = SearchQuery("!==tag==", SearchMode.AND)
     assert str(search_query) == "L(U(! T(==tag==)))"
+
+
 def test_tokenize_exc_before_equ_equ_equ_equ():
     search_query = SearchQuery("!====", SearchMode.AND)
     assert str(search_query) == "L(U(! T(====)))"
+
+
 def test_tokenize_escaped_unary_tags():
     search_query = SearchQuery("/~ /- /! /not", SearchMode.AND)
     assert str(search_query) == "L(T(/~) T(/-) T(/!) T(/not))"
 
+
 def test_tokenize_binary_and():
     search_query = SearchQuery("tag1 and tag2", SearchMode.AND)
     assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+
+
 def test_tokenize_all_binary():
-    search_query = SearchQuery("t01 & t02 ^ t03 | t04 v t05 or t06 || t07 and t08 && t09 nor t10 nand t11 xor t12 != t13 !== t14 xnor t15 == t16 === t17", SearchMode.AND)
-    assert str(search_query) == "L(B(B(B(B(B(B(B(B(B(B(B(B(B(B(B(B(T(t01) & T(t02)) ^ T(t03)) | T(t04)) v T(t05)) or T(t06)) || T(t07)) and T(t08)) && T(t09)) nor T(t10)) nand T(t11)) xor T(t12)) != T(t13)) !== T(t14)) xnor T(t15)) == T(t16)) === T(t17)))"
+    search_query = SearchQuery(
+        "t01 & t02 ^ t03 | t04 v t05 or t06 || t07 and t08 && t09 nor t10 nand t11 xor t12 != t13 !== t14 xnor t15 == t16 === t17",
+        SearchMode.AND,
+    )
+    assert (
+        str(search_query)
+        == "L(B(B(B(B(B(B(B(B(B(B(B(B(B(B(B(B(T(t01) & T(t02)) ^ T(t03)) | T(t04)) v T(t05)) or T(t06)) || T(t07)) and T(t08)) && T(t09)) nor T(t10)) nand T(t11)) xor T(t12)) != T(t13)) !== T(t14)) xnor T(t15)) == T(t16)) === T(t17)))"
+    )
+
+
 def test_tokenize_leading_binary_tag():
     search_query = SearchQuery("tag1 ^_^ tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T(^_^) T(tag3))"
+
+
 def test_tokenize_binary_oparen_tag():
     search_query = SearchQuery("tag1 |( tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T(|() T(tag3))"
+
+
 def test_tokenize_binary_cparen_tag():
     search_query = SearchQuery("tag1 |) tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T(|)) T(tag3))"
+
+
 def test_tokenize_oparen_binary_tag():
     search_query = SearchQuery("tag1 (| tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T((|) T(tag3))"
+
+
 def test_tokenize_cparen_binary_tag():
     search_query = SearchQuery("tag1 )| tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T()|) T(tag3))"
+
+
 def test_tokenize_escaped_binary_tag():
     search_query = SearchQuery("tag1 /and tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T(/and) T(tag3))"
 
+
 def test_tokenize_nested_lists():
     search_query = SearchQuery("( )", SearchMode.AND)
     assert str(search_query) == "L(L())"
+
+
 def test_tokenize_mixed_paren_nexted_lists():
     search_query = SearchQuery("{ [ ( ] } )", SearchMode.AND)
     assert str(search_query) == "L(L(L(L())))"
+
+
 def test_tokenize_list_omit_cparen():
     search_query = SearchQuery("{ [ (", SearchMode.AND)
     assert str(search_query) == "L(L(L(L())))"
+
+
 def test_tokenize_list_omit_oparen():
     search_query = SearchQuery("] } )", SearchMode.AND)
     assert str(search_query) == "L()"
+
+
 def test_tokenize_leading_ws_list():
     search_query = SearchQuery(" ( )", SearchMode.AND)
     assert str(search_query) == "L(L())"
+
+
 def test_tokenize_trailing_ws_list():
     search_query = SearchQuery("( ) ", SearchMode.AND)
     assert str(search_query) == "L(L())"
+
+
 def test_tokenize_leading_ws_omit_cparen():
     search_query = SearchQuery(" (", SearchMode.AND)
     assert str(search_query) == "L(L())"
+
+
 def test_tokenize_trailing_ws_omit_cparen():
     search_query = SearchQuery("( ", SearchMode.AND)
     assert str(search_query) == "L(L())"
+
+
 def test_tokenize_leading_ws_omit_oparen():
     search_query = SearchQuery(" )", SearchMode.AND)
     assert str(search_query) == "L()"
+
+
 def test_tokenize_trailing_ws_omit_oparen():
     search_query = SearchQuery(") ", SearchMode.AND)
     assert str(search_query) == "L()"
+
+
 def test_tokenize_starting_oparen_tag():
     search_query = SearchQuery("(:", SearchMode.AND)
     assert str(search_query) == "L(T((:))"
+
+
 def test_tokenize_ending_oparen_tag():
     search_query = SearchQuery(":(", SearchMode.AND)
     assert str(search_query) == "L(T(:())"
+
+
 def test_tokenize_starting_cparen_tag():
     search_query = SearchQuery("):", SearchMode.AND)
     assert str(search_query) == "L(T():))"
+
+
 def test_tokenize_ending_cparen_tag():
     search_query = SearchQuery(":)", SearchMode.AND)
     assert str(search_query) == "L(T(:)))"
+
+
 def test_tokenize_unary_paren():
     search_query = SearchQuery("-( tag", SearchMode.AND)
     assert str(search_query) == "L(U(- L(T(tag))))"
 
+
 def test_parse_cparen():
     search_query = SearchQuery("( ) ( ) ( )", SearchMode.AND)
     assert str(search_query) == "L(L() L() L())"
+
+
 def test_parse_nested_cparen():
     search_query = SearchQuery("( ( ) ( ) ) ( ( ) ( ) )", SearchMode.AND)
     assert str(search_query) == "L(L(L() L()) L(L() L()))"
+
+
 def test_parse_unary_in_nested_list():
     search_query = SearchQuery("( -tag )", SearchMode.AND)
     assert str(search_query) == "L(L(U(- T(tag))))"
+
+
 def test_parse_binary_in_nested_list():
     search_query = SearchQuery("( tag1 and tag2 )", SearchMode.AND)
     assert str(search_query) == "L(L(B(T(tag1) and T(tag2))))"
+
+
 def test_parse_tag_in_nested_list():
     search_query = SearchQuery("( tag )", SearchMode.AND)
     assert str(search_query) == "L(L(T(tag)))"
 
+
 def test_parse_ignore_sole_unary():
     search_query = SearchQuery("not", SearchMode.AND)
     assert str(search_query) == "L()"
+
+
 def test_parse_ignore_unary_after_tag():
     search_query = SearchQuery("tag -", SearchMode.AND)
     assert str(search_query) == "L(T(tag))"
+
+
 def test_parse_ignore_unary_before_cparen():
     search_query = SearchQuery("( tag1 -) tag2", SearchMode.AND)
     assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+
+
 def test_parse_ignore_cparen_after_unary():
     search_query = SearchQuery("tag1 not ) tag2", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) U(not T(tag2)))"
+
+
 def test_parse_ignore_nested_unary():
     search_query = SearchQuery("tag - - ", SearchMode.AND)
     assert str(search_query) == "L(T(tag))"
+
+
 def test_parse_ignore_unary_before_binary():
     search_query = SearchQuery("tag1 -and tag2", SearchMode.AND)
     assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+
+
 def test_parse_ignore_unary_before_ignored_binary():
     search_query = SearchQuery("( tag1 -and ) tag2", SearchMode.AND)
     assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+
+
 def test_parse_ignore_exc_before_xnor2():
     search_query = SearchQuery("tag1 !=== tag2", SearchMode.AND)
     assert str(search_query) == "L(B(T(tag1) === T(tag2)))"
+
+
 def test_parse_list_in_unary():
     search_query = SearchQuery("-( )", SearchMode.AND)
     assert str(search_query) == "L(U(- L()))"
+
+
 def test_parse_ignore_nested_unary_before_cparen():
     search_query = SearchQuery("-( - ) tag", SearchMode.AND)
     assert str(search_query) == "L(U(- L()) T(tag))"
+
+
 def test_parse_ignore_cparen_with_nested_unary():
     search_query = SearchQuery(" ) - ) - ) tag ) ", SearchMode.AND)
     assert str(search_query) == "L(U(- U(- T(tag))))"
 
+
 def test_parse_ignore_sole_binary():
     search_query = SearchQuery("and", SearchMode.AND)
     assert str(search_query) == "L()"
+
+
 def test_parse_ignore_binary_after_tag():
     search_query = SearchQuery("tag and", SearchMode.AND)
     assert str(search_query) == "L(T(tag))"
+
+
 def test_parse_ignore_binary_before_tag():
     search_query = SearchQuery("and tag", SearchMode.AND)
     assert str(search_query) == "L(T(tag))"
+
+
 def test_parse_ignore_binary_before_cparen():
     search_query = SearchQuery("( tag1 and ) tag2", SearchMode.AND)
     assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+
+
 def test_parse_ignore_cparen_after_binary():
     search_query = SearchQuery("tag1 and ) tag2", SearchMode.AND)
     assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+
+
 def test_parse_ignore_binary_after_binary():
     search_query = SearchQuery("tag1 and nand tag2", SearchMode.AND)
     assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+
+
 def test_parse_binary_before_unary():
     search_query = SearchQuery("tag1 and not tag2", SearchMode.AND)
     assert str(search_query) == "L(B(T(tag1) and U(not T(tag2))))"
+
+
 def test_parse_ignore_binary_before_failed_unary():
     search_query = SearchQuery("( tag1 and not ) tag2", SearchMode.AND)
     assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+
 
 def test_share_tag_requests_list():
     search_query = SearchQuery(r"/\tag1 \/tag2 tag3 tag3", SearchMode.AND)
     assert str(search_query) == r"L(T(/\tag1) T(\/tag2) T(tag3) T(tag3))"
     assert search_query.share_tag_requests() == [r"\tag1", "/tag2", "tag3"]
+
+
 def test_share_tag_requests_unary():
     search_query = SearchQuery(r"~/\tag1 ~\/tag2 ~tag3 ~tag3", SearchMode.AND)
-    assert str(search_query) == r"L(U(~ T(/\tag1)) U(~ T(\/tag2)) U(~ T(tag3)) U(~ T(tag3)))"
+    assert (
+        str(search_query)
+        == r"L(U(~ T(/\tag1)) U(~ T(\/tag2)) U(~ T(tag3)) U(~ T(tag3)))"
+    )
     assert search_query.share_tag_requests() == [r"\tag1", "/tag2", "tag3"]
+
+
 def test_share_tag_requests_binary():
-    search_query = SearchQuery(r"( ) and /\tag1 and \/tag2 and tag3 and tag3", SearchMode.AND)
-    assert str(search_query) == r"L(B(B(B(B(L() and T(/\tag1)) and T(\/tag2)) and T(tag3)) and T(tag3)))"
+    search_query = SearchQuery(
+        r"( ) and /\tag1 and \/tag2 and tag3 and tag3", SearchMode.AND
+    )
+    assert (
+        str(search_query)
+        == r"L(B(B(B(B(L() and T(/\tag1)) and T(\/tag2)) and T(tag3)) and T(tag3)))"
+    )
     assert search_query.share_tag_requests() == [r"\tag1", "/tag2", "tag3"]
+
 
 def test_receive_requested_lib_info_true():
     search_query = SearchQuery("tag1 tag2 tag2", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T(tag2) T(tag2))"
     assert search_query.share_tag_requests() == ["tag1", "tag2"]
     search_query.receive_requested_lib_info({"tag1": [2, 4], "tag2": [3, 5]})
-    assert     sqmtch(search_query, tag_ids=[2, 3])
-    assert     sqmtch(search_query, tag_ids=[2, 5])
-    assert     sqmtch(search_query, tag_ids=[4, 3])
-    assert     sqmtch(search_query, tag_ids=[4, 5])
+    assert sqmtch(search_query, tag_ids=[2, 3])
+    assert sqmtch(search_query, tag_ids=[2, 5])
+    assert sqmtch(search_query, tag_ids=[4, 3])
+    assert sqmtch(search_query, tag_ids=[4, 5])
     assert not sqmtch(search_query, tag_ids=[2, 4])
     assert not sqmtch(search_query, tag_ids=[3, 5])
     assert not sqmtch(search_query, tag_ids=[2, 6])
     assert not sqmtch(search_query, tag_ids=[1, 3])
 
+
 def test_eval_with_no_author():
     search_query = SearchQuery("", SearchMode.AND)
     assert str(search_query) == "L()"
-    assert sqmtch(search_query, has_fields=True ,has_author=False)
+    assert sqmtch(search_query, has_fields=True, has_author=False)
+
+
 def test_eval_with_no_fields():
     search_query = SearchQuery("", SearchMode.AND)
     assert str(search_query) == "L()"
-    assert sqmtch(search_query, has_fields=False,has_author=False)
-    
+    assert sqmtch(search_query, has_fields=False, has_author=False)
+
+
 def test_eval_and_mode_list():
     search_query = SearchQuery("tag1 tag2 tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) T(tag2) T(tag3))"
     assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
     search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
-    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
-    assert not sqmtch(search_query, tag_ids=[   2, 3])
-    assert not sqmtch(search_query, tag_ids=[1,    3])
-    assert not sqmtch(search_query, tag_ids=[      3])
-    assert not sqmtch(search_query, tag_ids=[1, 2   ])
-    assert not sqmtch(search_query, tag_ids=[   2   ])
-    assert not sqmtch(search_query, tag_ids=[1      ])
-    assert not sqmtch(search_query, tag_ids=[       ])
+    assert sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert not sqmtch(search_query, tag_ids=[2, 3])
+    assert not sqmtch(search_query, tag_ids=[1, 3])
+    assert not sqmtch(search_query, tag_ids=[3])
+    assert not sqmtch(search_query, tag_ids=[1, 2])
+    assert not sqmtch(search_query, tag_ids=[2])
+    assert not sqmtch(search_query, tag_ids=[1])
+    assert not sqmtch(search_query, tag_ids=[])
+
+
 def test_eval_or_mode_list():
     search_query = SearchQuery("tag1 tag2 tag3", SearchMode.OR)
     assert str(search_query) == "L(T(tag1) T(tag2) T(tag3))"
     assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
     search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
-    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
-    assert     sqmtch(search_query, tag_ids=[   2, 3])
-    assert     sqmtch(search_query, tag_ids=[1,    3])
-    assert     sqmtch(search_query, tag_ids=[      3])
-    assert     sqmtch(search_query, tag_ids=[1, 2   ])
-    assert     sqmtch(search_query, tag_ids=[   2   ])
-    assert     sqmtch(search_query, tag_ids=[1      ])
-    assert not sqmtch(search_query, tag_ids=[       ])
+    assert sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert sqmtch(search_query, tag_ids=[2, 3])
+    assert sqmtch(search_query, tag_ids=[1, 3])
+    assert sqmtch(search_query, tag_ids=[3])
+    assert sqmtch(search_query, tag_ids=[1, 2])
+    assert sqmtch(search_query, tag_ids=[2])
+    assert sqmtch(search_query, tag_ids=[1])
+    assert not sqmtch(search_query, tag_ids=[])
+
+
 def test_eval_optional_tags_list():
     search_query = SearchQuery("tag1 ~tag2 ~tag3", SearchMode.AND)
     assert str(search_query) == "L(T(tag1) U(~ T(tag2)) U(~ T(tag3)))"
     assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
     search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
-    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
-    assert not sqmtch(search_query, tag_ids=[   2, 3])
-    assert     sqmtch(search_query, tag_ids=[1,    3])
-    assert not sqmtch(search_query, tag_ids=[      3])
-    assert     sqmtch(search_query, tag_ids=[1, 2   ])
-    assert not sqmtch(search_query, tag_ids=[   2   ])
-    assert not sqmtch(search_query, tag_ids=[1      ])
-    assert not sqmtch(search_query, tag_ids=[       ])
+    assert sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert not sqmtch(search_query, tag_ids=[2, 3])
+    assert sqmtch(search_query, tag_ids=[1, 3])
+    assert not sqmtch(search_query, tag_ids=[3])
+    assert sqmtch(search_query, tag_ids=[1, 2])
+    assert not sqmtch(search_query, tag_ids=[2])
+    assert not sqmtch(search_query, tag_ids=[1])
+    assert not sqmtch(search_query, tag_ids=[])
+
+
 def test_eval_partial_tags_list():
     search_query = SearchQuery("tag1 ~tag2 ~tag3", SearchMode.OR)
     assert str(search_query) == "L(T(tag1) U(~ T(tag2)) U(~ T(tag3)))"
     assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
     search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
-    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
-    assert     sqmtch(search_query, tag_ids=[   2, 3])
-    assert     sqmtch(search_query, tag_ids=[1,    3])
-    assert not sqmtch(search_query, tag_ids=[      3])
-    assert     sqmtch(search_query, tag_ids=[1, 2   ])
-    assert not sqmtch(search_query, tag_ids=[   2   ])
-    assert     sqmtch(search_query, tag_ids=[1      ])
-    assert not sqmtch(search_query, tag_ids=[       ])
+    assert sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert sqmtch(search_query, tag_ids=[2, 3])
+    assert sqmtch(search_query, tag_ids=[1, 3])
+    assert not sqmtch(search_query, tag_ids=[3])
+    assert sqmtch(search_query, tag_ids=[1, 2])
+    assert not sqmtch(search_query, tag_ids=[2])
+    assert sqmtch(search_query, tag_ids=[1])
+    assert not sqmtch(search_query, tag_ids=[])
+
 
 def test_eval_all_unary():
     search_query = SearchQuery("-tag1 !tag2 not tag3 -~tag4", SearchMode.AND)
-    assert str(search_query) == "L(U(- T(tag1)) U(! T(tag2)) U(not T(tag3)) U(- U(~ T(tag4))))"
+    assert (
+        str(search_query)
+        == "L(U(- T(tag1)) U(! T(tag2)) U(not T(tag3)) U(- U(~ T(tag4))))"
+    )
     assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3", "tag4"]
-    search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3], "tag4": [4]})
+    search_query.receive_requested_lib_info(
+        {"tag1": [1], "tag2": [2], "tag3": [3], "tag4": [4]}
+    )
     assert sqmtch(search_query, tag_ids=[])
+
 
 def test_eval_binary_and_false():
     search_query = SearchQuery("t1 and t2 t1 ^ t2 t1 & t2 t1 && t2", SearchMode.OR)
-    assert str(search_query) == "L(B(T(t1) and T(t2)) B(T(t1) ^ T(t2)) B(T(t1) & T(t2)) B(T(t1) && T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) and T(t2)) B(T(t1) ^ T(t2)) B(T(t1) & T(t2)) B(T(t1) && T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert not sqmtch(search_query, tag_ids=[    ])
-    assert not sqmtch(search_query, tag_ids=[1   ])
-    assert not sqmtch(search_query, tag_ids=[   2])
+    assert not sqmtch(search_query, tag_ids=[])
+    assert not sqmtch(search_query, tag_ids=[1])
+    assert not sqmtch(search_query, tag_ids=[2])
+
+
 def test_eval_binary_and_true():
     search_query = SearchQuery("t1 and t2 t1 ^ t2 t1 & t2 t1 && t2", SearchMode.AND)
-    assert str(search_query) == "L(B(T(t1) and T(t2)) B(T(t1) ^ T(t2)) B(T(t1) & T(t2)) B(T(t1) && T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) and T(t2)) B(T(t1) ^ T(t2)) B(T(t1) & T(t2)) B(T(t1) && T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert     sqmtch(search_query, tag_ids=[1, 2])
+    assert sqmtch(search_query, tag_ids=[1, 2])
+
+
 def test_eval_binary_or_false():
     search_query = SearchQuery("t1 or t2 t1 v t2 t1 | t2 t1 || t2", SearchMode.OR)
-    assert str(search_query) == "L(B(T(t1) or T(t2)) B(T(t1) v T(t2)) B(T(t1) | T(t2)) B(T(t1) || T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) or T(t2)) B(T(t1) v T(t2)) B(T(t1) | T(t2)) B(T(t1) || T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert not sqmtch(search_query, tag_ids=[    ])
+    assert not sqmtch(search_query, tag_ids=[])
+
+
 def test_eval_binary_or_true():
     search_query = SearchQuery("t1 or t2 t1 v t2 t1 | t2 t1 || t2", SearchMode.AND)
-    assert str(search_query) == "L(B(T(t1) or T(t2)) B(T(t1) v T(t2)) B(T(t1) | T(t2)) B(T(t1) || T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) or T(t2)) B(T(t1) v T(t2)) B(T(t1) | T(t2)) B(T(t1) || T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert     sqmtch(search_query, tag_ids=[1   ])
-    assert     sqmtch(search_query, tag_ids=[   2])
-    assert     sqmtch(search_query, tag_ids=[1, 2])
+    assert sqmtch(search_query, tag_ids=[1])
+    assert sqmtch(search_query, tag_ids=[2])
+    assert sqmtch(search_query, tag_ids=[1, 2])
+
+
 def test_eval_binary_nor_false():
     search_query = SearchQuery("t1 nor t2", SearchMode.OR)
     assert str(search_query) == "L(B(T(t1) nor T(t2)))"
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert not sqmtch(search_query, tag_ids=[1   ])
-    assert not sqmtch(search_query, tag_ids=[   2])
+    assert not sqmtch(search_query, tag_ids=[1])
+    assert not sqmtch(search_query, tag_ids=[2])
     assert not sqmtch(search_query, tag_ids=[1, 2])
+
+
 def test_eval_binary_nor_true():
     search_query = SearchQuery("t1 nor t2", SearchMode.AND)
     assert str(search_query) == "L(B(T(t1) nor T(t2)))"
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert     sqmtch(search_query, tag_ids=[    ])
+    assert sqmtch(search_query, tag_ids=[])
+
+
 def test_eval_binary_nand_false():
     search_query = SearchQuery("t1 nand t2", SearchMode.OR)
     assert str(search_query) == "L(B(T(t1) nand T(t2)))"
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
     assert not sqmtch(search_query, tag_ids=[1, 2])
+
+
 def test_eval_binary_nand_true():
     search_query = SearchQuery("t1 nand t2", SearchMode.AND)
     assert str(search_query) == "L(B(T(t1) nand T(t2)))"
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert     sqmtch(search_query, tag_ids=[    ])
-    assert     sqmtch(search_query, tag_ids=[1   ])
-    assert     sqmtch(search_query, tag_ids=[   2])
+    assert sqmtch(search_query, tag_ids=[])
+    assert sqmtch(search_query, tag_ids=[1])
+    assert sqmtch(search_query, tag_ids=[2])
+
+
 def test_eval_binary_xor_false():
     search_query = SearchQuery("t1 xor t2 t1 != t2 t1 !== t2", SearchMode.OR)
-    assert str(search_query) == "L(B(T(t1) xor T(t2)) B(T(t1) != T(t2)) B(T(t1) !== T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) xor T(t2)) B(T(t1) != T(t2)) B(T(t1) !== T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
     assert not sqmtch(search_query, tag_ids=[1, 2])
-    assert not sqmtch(search_query, tag_ids=[    ])
+    assert not sqmtch(search_query, tag_ids=[])
+
+
 def test_eval_binary_xor_true():
     search_query = SearchQuery("t1 xor t2 t1 != t2 t1 !== t2", SearchMode.AND)
-    assert str(search_query) == "L(B(T(t1) xor T(t2)) B(T(t1) != T(t2)) B(T(t1) !== T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) xor T(t2)) B(T(t1) != T(t2)) B(T(t1) !== T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert     sqmtch(search_query, tag_ids=[1   ])
-    assert     sqmtch(search_query, tag_ids=[   2])
+    assert sqmtch(search_query, tag_ids=[1])
+    assert sqmtch(search_query, tag_ids=[2])
+
+
 def test_eval_binary_xnor_false():
     search_query = SearchQuery("t1 xnor t2 t1 = t2 t1 == t2 t1 === t2", SearchMode.OR)
-    assert str(search_query) == "L(B(T(t1) xnor T(t2)) B(T(t1) = T(t2)) B(T(t1) == T(t2)) B(T(t1) === T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) xnor T(t2)) B(T(t1) = T(t2)) B(T(t1) == T(t2)) B(T(t1) === T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert not sqmtch(search_query, tag_ids=[1   ])
-    assert not sqmtch(search_query, tag_ids=[   2])
+    assert not sqmtch(search_query, tag_ids=[1])
+    assert not sqmtch(search_query, tag_ids=[2])
+
+
 def test_eval_binary_xnor_true():
     search_query = SearchQuery("t1 xnor t2 t1 = t2 t1 == t2 t1 === t2", SearchMode.AND)
-    assert str(search_query) == "L(B(T(t1) xnor T(t2)) B(T(t1) = T(t2)) B(T(t1) == T(t2)) B(T(t1) === T(t2)))"
+    assert (
+        str(search_query)
+        == "L(B(T(t1) xnor T(t2)) B(T(t1) = T(t2)) B(T(t1) == T(t2)) B(T(t1) === T(t2)))"
+    )
     assert search_query.share_tag_requests() == ["t1", "t2"]
     search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
-    assert     sqmtch(search_query, tag_ids=[1, 2])
-    assert     sqmtch(search_query, tag_ids=[    ])
+    assert sqmtch(search_query, tag_ids=[1, 2])
+    assert sqmtch(search_query, tag_ids=[])
+
 
 def test_eval_tag_empty_false():
     search_query = SearchQuery("empty no_fields no-fields nofields", SearchMode.OR)
@@ -400,15 +603,14 @@ def test_eval_tag_empty_false():
         "empty",
         "no_fields",
         "no-fields",
-        "nofields"
+        "nofields",
     ]
-    search_query.receive_requested_lib_info({
-        "empty": [],
-        "no_fields": [],
-        "no-fields": [],
-        "nofields": []
-    })
-    assert not sqmtch(search_query, has_fields=True ,has_author=True )
+    search_query.receive_requested_lib_info(
+        {"empty": [], "no_fields": [], "no-fields": [], "nofields": []}
+    )
+    assert not sqmtch(search_query, has_fields=True, has_author=True)
+
+
 def test_eval_tag_empty_true():
     search_query = SearchQuery("empty no_fields no-fields nofields", SearchMode.AND)
     assert str(search_query) == "L(T(empty) T(no_fields) T(no-fields) T(nofields))"
@@ -416,56 +618,73 @@ def test_eval_tag_empty_true():
         "empty",
         "no_fields",
         "no-fields",
-        "nofields"
+        "nofields",
     ]
-    search_query.receive_requested_lib_info({
-        "empty": [],
-        "no_fields": [],
-        "no-fields": [],
-        "nofields": []
-    })
-    assert     sqmtch(search_query, has_fields=False,has_author=False)
+    search_query.receive_requested_lib_info(
+        {"empty": [], "no_fields": [], "no-fields": [], "nofields": []}
+    )
+    assert sqmtch(search_query, has_fields=False, has_author=False)
+
+
 def test_eval_tag_no_author_false():
-    search_query = SearchQuery("no_author no-author noauthor no_artist no-artist noartist", SearchMode.OR)
-    assert str(search_query) == "L(T(no_author) T(no-author) T(noauthor) T(no_artist) T(no-artist) T(noartist))"
+    search_query = SearchQuery(
+        "no_author no-author noauthor no_artist no-artist noartist", SearchMode.OR
+    )
+    assert (
+        str(search_query)
+        == "L(T(no_author) T(no-author) T(noauthor) T(no_artist) T(no-artist) T(noartist))"
+    )
     assert search_query.share_tag_requests() == [
         "no_author",
         "no-author",
         "noauthor",
         "no_artist",
         "no-artist",
-        "noartist"
+        "noartist",
     ]
-    search_query.receive_requested_lib_info({
-        "no_author": [],
-        "no-author": [],
-        "noauthor": [],
-        "no_artist": [],
-        "no-artist": [],
-        "noartist": []
-    })
-    assert not sqmtch(search_query, has_fields=True ,has_author=True)
+    search_query.receive_requested_lib_info(
+        {
+            "no_author": [],
+            "no-author": [],
+            "noauthor": [],
+            "no_artist": [],
+            "no-artist": [],
+            "noartist": [],
+        }
+    )
+    assert not sqmtch(search_query, has_fields=True, has_author=True)
+
+
 def test_eval_tag_no_author_true():
-    search_query = SearchQuery("no_author no-author noauthor no_artist no-artist noartist", SearchMode.AND)
-    assert str(search_query) == "L(T(no_author) T(no-author) T(noauthor) T(no_artist) T(no-artist) T(noartist))"
+    search_query = SearchQuery(
+        "no_author no-author noauthor no_artist no-artist noartist", SearchMode.AND
+    )
+    assert (
+        str(search_query)
+        == "L(T(no_author) T(no-author) T(noauthor) T(no_artist) T(no-artist) T(noartist))"
+    )
     assert search_query.share_tag_requests() == [
         "no_author",
         "no-author",
         "noauthor",
         "no_artist",
         "no-artist",
-        "noartist"
+        "noartist",
     ]
-    search_query.receive_requested_lib_info({
-        "no_author": [],
-        "no-author": [],
-        "noauthor": [],
-        "no_artist": [],
-        "no-artist": [],
-        "noartist": []
-    })
-    assert     sqmtch(search_query, has_fields=True ,has_author=False)
-    assert     sqmtch(search_query, has_fields=False,has_author=False)
+    search_query.receive_requested_lib_info(
+        {
+            "no_author": [],
+            "no-author": [],
+            "noauthor": [],
+            "no_artist": [],
+            "no-artist": [],
+            "noartist": [],
+        }
+    )
+    assert sqmtch(search_query, has_fields=True, has_author=False)
+    assert sqmtch(search_query, has_fields=False, has_author=False)
+
+
 def test_eval_tag_untagged_false():
     search_query = SearchQuery("untagged no_tags no-tags notags", SearchMode.OR)
     assert str(search_query) == "L(T(untagged) T(no_tags) T(no-tags) T(notags))"
@@ -473,17 +692,16 @@ def test_eval_tag_untagged_false():
         "untagged",
         "no_tags",
         "no-tags",
-        "notags"
+        "notags",
     ]
-    search_query.receive_requested_lib_info({
-        "untagged": [],
-        "no_tags": [],
-        "no-tags": [],
-        "notags": []
-    })
-    assert not sqmtch(search_query, tag_ids=[1],has_fields=True ,has_author=True )
-    assert not sqmtch(search_query, tag_ids=[1],has_fields=True ,has_author=False)
-    assert not sqmtch(search_query, tag_ids=[1],has_fields=False,has_author=False)
+    search_query.receive_requested_lib_info(
+        {"untagged": [], "no_tags": [], "no-tags": [], "notags": []}
+    )
+    assert not sqmtch(search_query, tag_ids=[1], has_fields=True, has_author=True)
+    assert not sqmtch(search_query, tag_ids=[1], has_fields=True, has_author=False)
+    assert not sqmtch(search_query, tag_ids=[1], has_fields=False, has_author=False)
+
+
 def test_eval_tag_untagged_true():
     search_query = SearchQuery("untagged no_tags no-tags notags", SearchMode.AND)
     assert str(search_query) == "L(T(untagged) T(no_tags) T(no-tags) T(notags))"
@@ -491,34 +709,42 @@ def test_eval_tag_untagged_true():
         "untagged",
         "no_tags",
         "no-tags",
-        "notags"
+        "notags",
     ]
-    search_query.receive_requested_lib_info({
-        "untagged": [],
-        "no_tags": [],
-        "no-tags": [],
-        "notags": []
-    })
-    assert     sqmtch(search_query, tag_ids=[ ],has_fields=True ,has_author=True )
-    assert     sqmtch(search_query, tag_ids=[ ],has_fields=True ,has_author=False)
-    assert     sqmtch(search_query, tag_ids=[ ],has_fields=False,has_author=False)
+    search_query.receive_requested_lib_info(
+        {"untagged": [], "no_tags": [], "no-tags": [], "notags": []}
+    )
+    assert sqmtch(search_query, tag_ids=[], has_fields=True, has_author=True)
+    assert sqmtch(search_query, tag_ids=[], has_fields=True, has_author=False)
+    assert sqmtch(search_query, tag_ids=[], has_fields=False, has_author=False)
+
 
 def test_eval_tag_filename():
-    search_query = SearchQuery("filename:subfolder1 filename:entry1.png", SearchMode.AND)
+    search_query = SearchQuery(
+        "filename:subfolder1 filename:entry1.png", SearchMode.AND
+    )
     assert str(search_query) == "L(T(filename:subfolder1) T(filename:entry1.png))"
-    assert search_query.share_tag_requests() == ["filename:subfolder1", "filename:entry1.png"]
-    search_query.receive_requested_lib_info({"filename:subfolder1": [], "filename:entry1.png": []})
-    assert     sqmtch(search_query, path="subfolder1", filename="entry1.png")
+    assert search_query.share_tag_requests() == [
+        "filename:subfolder1",
+        "filename:entry1.png",
+    ]
+    search_query.receive_requested_lib_info(
+        {"filename:subfolder1": [], "filename:entry1.png": []}
+    )
+    assert sqmtch(search_query, path="subfolder1", filename="entry1.png")
     assert not sqmtch(search_query, path="subfolder2", filename="entry1.png")
     assert not sqmtch(search_query, path="subfolder1", filename="entry2.png")
     assert not sqmtch(search_query, path="subfolder2", filename="entry2.png")
+
+
 def test_eval_tag_tag_id():
     search_query = SearchQuery("tag_id:1 tag-id:2 tagid:3", SearchMode.AND)
     assert str(search_query) == "L(T(tag_id:1) T(tag-id:2) T(tagid:3))"
     assert search_query.share_tag_requests() == ["tag_id:1", "tag-id:2", "tagid:3"]
-    search_query.receive_requested_lib_info({"tag_id:1": [], "tag-id:2": [], "tagid:3": []})
-    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
-    assert not sqmtch(search_query, tag_ids=[1, 2   ])
-    assert not sqmtch(search_query, tag_ids=[   2, 3])
-    assert not sqmtch(search_query, tag_ids=[1,    3])
-    
+    search_query.receive_requested_lib_info(
+        {"tag_id:1": [], "tag-id:2": [], "tagid:3": []}
+    )
+    assert sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert not sqmtch(search_query, tag_ids=[1, 2])
+    assert not sqmtch(search_query, tag_ids=[2, 3])
+    assert not sqmtch(search_query, tag_ids=[1, 3])

--- a/tagstudio/tests/core/test_search.py
+++ b/tagstudio/tests/core/test_search.py
@@ -1,3 +1,6 @@
+
+from pathlib import Path
+
 from src.core.search import SearchQuery
 from src.core.enums import SearchMode
 
@@ -6,12 +9,14 @@ def sqmtch(
     tag_ids: list[int] = [],
     has_fields=True,
     has_author=True,
-    filename="subfolder\\entry.png"
+    path="subfolder",
+    filename="entry.png"
 ) -> bool:
     return search_query.match_entry(
         has_fields=has_fields,
         has_author=has_author,
-        filename=filename,
+        path=Path(path),
+        filename=Path(filename),
         tag_ids=tag_ids
     )
 
@@ -503,10 +508,10 @@ def test_eval_tag_filename():
     assert str(search_query) == "L(T(filename:subfolder1) T(filename:entry1.png))"
     assert search_query.share_tag_requests() == ["filename:subfolder1", "filename:entry1.png"]
     search_query.receive_requested_lib_info({"filename:subfolder1": [], "filename:entry1.png": []})
-    assert     sqmtch(search_query, filename="subfolder1\\entry1.png")
-    assert not sqmtch(search_query, filename="subfolder2\\entry1.png")
-    assert not sqmtch(search_query, filename="subfolder1\\entry2.png")
-    assert not sqmtch(search_query, filename="subfolder2\\entry2.png")
+    assert     sqmtch(search_query, path="subfolder1", filename="entry1.png")
+    assert not sqmtch(search_query, path="subfolder2", filename="entry1.png")
+    assert not sqmtch(search_query, path="subfolder1", filename="entry2.png")
+    assert not sqmtch(search_query, path="subfolder2", filename="entry2.png")
 def test_eval_tag_tag_id():
     search_query = SearchQuery("tag_id:1 tag-id:2 tagid:3", SearchMode.AND)
     assert str(search_query) == "L(T(tag_id:1) T(tag-id:2) T(tagid:3))"

--- a/tagstudio/tests/core/test_search.py
+++ b/tagstudio/tests/core/test_search.py
@@ -1,0 +1,572 @@
+from src.core.search import SearchQuery
+from src.core.enums import SearchMode
+
+def sqmtch( 
+    search_query: SearchQuery,
+    tag_ids: list[int] = [],
+    has_fields=True,
+    has_author=True,
+    has_file=True,
+    filename="subfolder\\entry.png"
+) -> bool:
+    return search_query.match_entry(
+        has_fields=has_fields,
+        has_author=has_author,
+        has_file=has_file,
+        filename=filename,
+        tag_ids=tag_ids
+    )
+
+def test_empty_AND_construction():
+    search_query = SearchQuery("", SearchMode.AND)
+    assert search_query
+def test_empty_OR_construction():
+    search_query = SearchQuery("", SearchMode.OR)
+    assert search_query
+
+def test_tokenize_empty_list():
+    search_query = SearchQuery("", SearchMode.AND)
+    assert str(search_query) == "L()"
+def test_tokenize_ws_list():
+    search_query = SearchQuery(" \t\n\r", SearchMode.AND)
+    assert str(search_query) == "L()"
+    
+def test_tokenize_ascii_tag():
+    search_query = SearchQuery("abcdefghijklmnopqrstuvwxyz0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`|{}~", SearchMode.AND)
+    assert str(search_query) == "L(T(abcdefghijklmnopqrstuvwxyz0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`|{}~))"
+def test_tokenize_leading_ws_tag():
+    search_query = SearchQuery(" tag", SearchMode.AND)
+    assert str(search_query) == "L(T(tag))"
+def test_tokenize_trailing_ws_tag():
+    search_query = SearchQuery("tag ", SearchMode.AND)
+    assert str(search_query) == "L(T(tag))"
+    
+def test_tokenize_unary_minus():
+    search_query = SearchQuery("-tag", SearchMode.AND)
+    assert str(search_query) == "L(U(- T(tag)))"
+def test_tokenize_all_unary():
+    search_query = SearchQuery("~-not !tag", SearchMode.AND)
+    assert str(search_query) == "L(U(~ U(- U(not U(! T(tag))))))"
+def test_tokenize_all_unary_with_ws():
+    search_query = SearchQuery(" ~ - not ! tag ", SearchMode.AND)
+    assert str(search_query) == "L(U(~ U(- U(not U(! T(tag))))))"
+def test_tokenize_exc_before_equ_tag():
+    search_query = SearchQuery("!=^_^=", SearchMode.AND)
+    assert str(search_query) == "L(U(! T(=^_^=)))"
+def test_tokenize_exc_before_equ_equ_tag():
+    search_query = SearchQuery("!==tag==", SearchMode.AND)
+    assert str(search_query) == "L(U(! T(==tag==)))"
+def test_tokenize_exc_before_equ_equ_equ_equ():
+    search_query = SearchQuery("!====", SearchMode.AND)
+    assert str(search_query) == "L(U(! T(====)))"
+def test_tokenize_escaped_unary_tags():
+    search_query = SearchQuery("/~ /- /! /not", SearchMode.AND)
+    assert str(search_query) == "L(T(/~) T(/-) T(/!) T(/not))"
+
+def test_tokenize_binary_and():
+    search_query = SearchQuery("tag1 and tag2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+def test_tokenize_all_binary():
+    search_query = SearchQuery("t01 & t02 ^ t03 | t04 v t05 or t06 || t07 and t08 && t09 nor t10 nand t11 xor t12 != t13 !== t14 xnor t15 == t16 === t17", SearchMode.AND)
+    assert str(search_query) == "L(B(B(B(B(B(B(B(B(B(B(B(B(B(B(B(B(T(t01) & T(t02)) ^ T(t03)) | T(t04)) v T(t05)) or T(t06)) || T(t07)) and T(t08)) && T(t09)) nor T(t10)) nand T(t11)) xor T(t12)) != T(t13)) !== T(t14)) xnor T(t15)) == T(t16)) === T(t17)))"
+def test_tokenize_leading_binary_tag():
+    search_query = SearchQuery("tag1 ^_^ tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T(^_^) T(tag3))"
+def test_tokenize_binary_oparen_tag():
+    search_query = SearchQuery("tag1 |( tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T(|() T(tag3))"
+def test_tokenize_binary_cparen_tag():
+    search_query = SearchQuery("tag1 |) tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T(|)) T(tag3))"
+def test_tokenize_oparen_binary_tag():
+    search_query = SearchQuery("tag1 (| tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T((|) T(tag3))"
+def test_tokenize_cparen_binary_tag():
+    search_query = SearchQuery("tag1 )| tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T()|) T(tag3))"
+def test_tokenize_escaped_binary_tag():
+    search_query = SearchQuery("tag1 /and tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T(/and) T(tag3))"
+
+def test_tokenize_nested_lists():
+    search_query = SearchQuery("( )", SearchMode.AND)
+    assert str(search_query) == "L(L())"
+def test_tokenize_mixed_paren_nexted_lists():
+    search_query = SearchQuery("{ [ ( ] } )", SearchMode.AND)
+    assert str(search_query) == "L(L(L(L())))"
+def test_tokenize_list_omit_cparen():
+    search_query = SearchQuery("{ [ (", SearchMode.AND)
+    assert str(search_query) == "L(L(L(L())))"
+def test_tokenize_list_omit_oparen():
+    search_query = SearchQuery("] } )", SearchMode.AND)
+    assert str(search_query) == "L()"
+def test_tokenize_leading_ws_list():
+    search_query = SearchQuery(" ( )", SearchMode.AND)
+    assert str(search_query) == "L(L())"
+def test_tokenize_trailing_ws_list():
+    search_query = SearchQuery("( ) ", SearchMode.AND)
+    assert str(search_query) == "L(L())"
+def test_tokenize_leading_ws_omit_cparen():
+    search_query = SearchQuery(" (", SearchMode.AND)
+    assert str(search_query) == "L(L())"
+def test_tokenize_trailing_ws_omit_cparen():
+    search_query = SearchQuery("( ", SearchMode.AND)
+    assert str(search_query) == "L(L())"
+def test_tokenize_leading_ws_omit_oparen():
+    search_query = SearchQuery(" )", SearchMode.AND)
+    assert str(search_query) == "L()"
+def test_tokenize_trailing_ws_omit_oparen():
+    search_query = SearchQuery(") ", SearchMode.AND)
+    assert str(search_query) == "L()"
+def test_tokenize_starting_oparen_tag():
+    search_query = SearchQuery("(:", SearchMode.AND)
+    assert str(search_query) == "L(T((:))"
+def test_tokenize_ending_oparen_tag():
+    search_query = SearchQuery(":(", SearchMode.AND)
+    assert str(search_query) == "L(T(:())"
+def test_tokenize_starting_cparen_tag():
+    search_query = SearchQuery("):", SearchMode.AND)
+    assert str(search_query) == "L(T():))"
+def test_tokenize_ending_cparen_tag():
+    search_query = SearchQuery(":)", SearchMode.AND)
+    assert str(search_query) == "L(T(:)))"
+def test_tokenize_unary_paren():
+    search_query = SearchQuery("-( tag", SearchMode.AND)
+    assert str(search_query) == "L(U(- L(T(tag))))"
+
+def test_parse_cparen():
+    search_query = SearchQuery("( ) ( ) ( )", SearchMode.AND)
+    assert str(search_query) == "L(L() L() L())"
+def test_parse_nested_cparen():
+    search_query = SearchQuery("( ( ) ( ) ) ( ( ) ( ) )", SearchMode.AND)
+    assert str(search_query) == "L(L(L() L()) L(L() L()))"
+def test_parse_unary_in_nested_list():
+    search_query = SearchQuery("( -tag )", SearchMode.AND)
+    assert str(search_query) == "L(L(U(- T(tag))))"
+def test_parse_binary_in_nested_list():
+    search_query = SearchQuery("( tag1 and tag2 )", SearchMode.AND)
+    assert str(search_query) == "L(L(B(T(tag1) and T(tag2))))"
+def test_parse_tag_in_nested_list():
+    search_query = SearchQuery("( tag )", SearchMode.AND)
+    assert str(search_query) == "L(L(T(tag)))"
+
+def test_parse_ignore_sole_unary():
+    search_query = SearchQuery("not", SearchMode.AND)
+    assert str(search_query) == "L()"
+def test_parse_ignore_unary_after_tag():
+    search_query = SearchQuery("tag -", SearchMode.AND)
+    assert str(search_query) == "L(T(tag))"
+def test_parse_ignore_unary_before_cparen():
+    search_query = SearchQuery("( tag1 -) tag2", SearchMode.AND)
+    assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+def test_parse_ignore_cparen_after_unary():
+    search_query = SearchQuery("tag1 not ) tag2", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) U(not T(tag2)))"
+def test_parse_ignore_nested_unary():
+    search_query = SearchQuery("tag - - ", SearchMode.AND)
+    assert str(search_query) == "L(T(tag))"
+def test_parse_ignore_unary_before_binary():
+    search_query = SearchQuery("tag1 -and tag2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+def test_parse_ignore_unary_before_ignored_binary():
+    search_query = SearchQuery("( tag1 -and ) tag2", SearchMode.AND)
+    assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+def test_parse_ignore_exc_before_xnor2():
+    search_query = SearchQuery("tag1 !=== tag2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(tag1) === T(tag2)))"
+def test_parse_list_in_unary():
+    search_query = SearchQuery("-( )", SearchMode.AND)
+    assert str(search_query) == "L(U(- L()))"
+def test_parse_ignore_nested_unary_before_cparen():
+    search_query = SearchQuery("-( - ) tag", SearchMode.AND)
+    assert str(search_query) == "L(U(- L()) T(tag))"
+def test_parse_ignore_cparen_with_nested_unary():
+    search_query = SearchQuery(" ) - ) - ) tag ) ", SearchMode.AND)
+    assert str(search_query) == "L(U(- U(- T(tag))))"
+
+def test_parse_ignore_sole_binary():
+    search_query = SearchQuery("and", SearchMode.AND)
+    assert str(search_query) == "L()"
+def test_parse_ignore_binary_after_tag():
+    search_query = SearchQuery("tag and", SearchMode.AND)
+    assert str(search_query) == "L(T(tag))"
+def test_parse_ignore_binary_before_tag():
+    search_query = SearchQuery("and tag", SearchMode.AND)
+    assert str(search_query) == "L(T(tag))"
+def test_parse_ignore_binary_before_cparen():
+    search_query = SearchQuery("( tag1 and ) tag2", SearchMode.AND)
+    assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+def test_parse_ignore_cparen_after_binary():
+    search_query = SearchQuery("tag1 and ) tag2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+def test_parse_ignore_binary_after_binary():
+    search_query = SearchQuery("tag1 and nand tag2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(tag1) and T(tag2)))"
+def test_parse_binary_before_unary():
+    search_query = SearchQuery("tag1 and not tag2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(tag1) and U(not T(tag2))))"
+def test_parse_ignore_binary_before_failed_unary():
+    search_query = SearchQuery("( tag1 and not ) tag2", SearchMode.AND)
+    assert str(search_query) == "L(L(T(tag1)) T(tag2))"
+
+def test_share_tag_requests_list():
+    search_query = SearchQuery(r"/\tag1 \/tag2 tag3 tag3", SearchMode.AND)
+    assert str(search_query) == r"L(T(/\tag1) T(\/tag2) T(tag3) T(tag3))"
+    assert search_query.share_tag_requests() == [r"\tag1", "/tag2", "tag3"]
+def test_share_tag_requests_unary():
+    search_query = SearchQuery(r"~/\tag1 ~\/tag2 ~tag3 ~tag3", SearchMode.AND)
+    assert str(search_query) == r"L(U(~ T(/\tag1)) U(~ T(\/tag2)) U(~ T(tag3)) U(~ T(tag3)))"
+    assert search_query.share_tag_requests() == [r"\tag1", "/tag2", "tag3"]
+def test_share_tag_requests_binary():
+    search_query = SearchQuery(r"( ) and /\tag1 and \/tag2 and tag3 and tag3", SearchMode.AND)
+    assert str(search_query) == r"L(B(B(B(B(L() and T(/\tag1)) and T(\/tag2)) and T(tag3)) and T(tag3)))"
+    assert search_query.share_tag_requests() == [r"\tag1", "/tag2", "tag3"]
+
+def test_receive_requested_lib_info_true():
+    search_query = SearchQuery("tag1 tag2 tag2", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T(tag2) T(tag2))"
+    assert search_query.share_tag_requests() == ["tag1", "tag2"]
+    search_query.receive_requested_lib_info({"tag1": [2, 4], "tag2": [3, 5]})
+    assert     sqmtch(search_query, tag_ids=[2, 3])
+    assert     sqmtch(search_query, tag_ids=[2, 5])
+    assert     sqmtch(search_query, tag_ids=[4, 3])
+    assert     sqmtch(search_query, tag_ids=[4, 5])
+    assert not sqmtch(search_query, tag_ids=[2, 4])
+    assert not sqmtch(search_query, tag_ids=[3, 5])
+    assert not sqmtch(search_query, tag_ids=[2, 6])
+    assert not sqmtch(search_query, tag_ids=[1, 3])
+
+def test_eval_with_no_author():
+    search_query = SearchQuery("", SearchMode.AND)
+    assert str(search_query) == "L()"
+    assert sqmtch(search_query, has_fields=True ,has_author=False,has_file=True )
+def test_eval_with_no_fields():
+    search_query = SearchQuery("", SearchMode.AND)
+    assert str(search_query) == "L()"
+    assert sqmtch(search_query, has_fields=False,has_author=False,has_file=True )
+def test_eval_with_no_file():
+    search_query = SearchQuery("", SearchMode.AND)
+    assert str(search_query) == "L()"
+    assert sqmtch(search_query, has_fields=True ,has_author=True ,has_file=False)
+    
+def test_eval_and_mode_list():
+    search_query = SearchQuery("tag1 tag2 tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) T(tag2) T(tag3))"
+    assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
+    search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
+    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert not sqmtch(search_query, tag_ids=[   2, 3])
+    assert not sqmtch(search_query, tag_ids=[1,    3])
+    assert not sqmtch(search_query, tag_ids=[      3])
+    assert not sqmtch(search_query, tag_ids=[1, 2   ])
+    assert not sqmtch(search_query, tag_ids=[   2   ])
+    assert not sqmtch(search_query, tag_ids=[1      ])
+    assert not sqmtch(search_query, tag_ids=[       ])
+def test_eval_or_mode_list():
+    search_query = SearchQuery("tag1 tag2 tag3", SearchMode.OR)
+    assert str(search_query) == "L(T(tag1) T(tag2) T(tag3))"
+    assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
+    search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
+    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert     sqmtch(search_query, tag_ids=[   2, 3])
+    assert     sqmtch(search_query, tag_ids=[1,    3])
+    assert     sqmtch(search_query, tag_ids=[      3])
+    assert     sqmtch(search_query, tag_ids=[1, 2   ])
+    assert     sqmtch(search_query, tag_ids=[   2   ])
+    assert     sqmtch(search_query, tag_ids=[1      ])
+    assert not sqmtch(search_query, tag_ids=[       ])
+def test_eval_optional_tags_list():
+    search_query = SearchQuery("tag1 ~tag2 ~tag3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag1) U(~ T(tag2)) U(~ T(tag3)))"
+    assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
+    search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
+    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert not sqmtch(search_query, tag_ids=[   2, 3])
+    assert     sqmtch(search_query, tag_ids=[1,    3])
+    assert not sqmtch(search_query, tag_ids=[      3])
+    assert     sqmtch(search_query, tag_ids=[1, 2   ])
+    assert not sqmtch(search_query, tag_ids=[   2   ])
+    assert not sqmtch(search_query, tag_ids=[1      ])
+    assert not sqmtch(search_query, tag_ids=[       ])
+def test_eval_partial_tags_list():
+    search_query = SearchQuery("tag1 ~tag2 ~tag3", SearchMode.OR)
+    assert str(search_query) == "L(T(tag1) U(~ T(tag2)) U(~ T(tag3)))"
+    assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3"]
+    search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3]})
+    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert     sqmtch(search_query, tag_ids=[   2, 3])
+    assert     sqmtch(search_query, tag_ids=[1,    3])
+    assert not sqmtch(search_query, tag_ids=[      3])
+    assert     sqmtch(search_query, tag_ids=[1, 2   ])
+    assert not sqmtch(search_query, tag_ids=[   2   ])
+    assert     sqmtch(search_query, tag_ids=[1      ])
+    assert not sqmtch(search_query, tag_ids=[       ])
+
+def test_eval_all_unary():
+    search_query = SearchQuery("-tag1 !tag2 not tag3 -~tag4", SearchMode.AND)
+    assert str(search_query) == "L(U(- T(tag1)) U(! T(tag2)) U(not T(tag3)) U(- U(~ T(tag4))))"
+    assert search_query.share_tag_requests() == ["tag1", "tag2", "tag3", "tag4"]
+    search_query.receive_requested_lib_info({"tag1": [1], "tag2": [2], "tag3": [3], "tag4": [4]})
+    assert sqmtch(search_query, tag_ids=[])
+
+def test_eval_binary_and_false():
+    search_query = SearchQuery("t1 and t2 t1 ^ t2 t1 & t2 t1 && t2", SearchMode.OR)
+    assert str(search_query) == "L(B(T(t1) and T(t2)) B(T(t1) ^ T(t2)) B(T(t1) & T(t2)) B(T(t1) && T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert not sqmtch(search_query, tag_ids=[    ])
+    assert not sqmtch(search_query, tag_ids=[1   ])
+    assert not sqmtch(search_query, tag_ids=[   2])
+def test_eval_binary_and_true():
+    search_query = SearchQuery("t1 and t2 t1 ^ t2 t1 & t2 t1 && t2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(t1) and T(t2)) B(T(t1) ^ T(t2)) B(T(t1) & T(t2)) B(T(t1) && T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert     sqmtch(search_query, tag_ids=[1, 2])
+def test_eval_binary_or_false():
+    search_query = SearchQuery("t1 or t2 t1 v t2 t1 | t2 t1 || t2", SearchMode.OR)
+    assert str(search_query) == "L(B(T(t1) or T(t2)) B(T(t1) v T(t2)) B(T(t1) | T(t2)) B(T(t1) || T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert not sqmtch(search_query, tag_ids=[    ])
+def test_eval_binary_or_true():
+    search_query = SearchQuery("t1 or t2 t1 v t2 t1 | t2 t1 || t2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(t1) or T(t2)) B(T(t1) v T(t2)) B(T(t1) | T(t2)) B(T(t1) || T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert     sqmtch(search_query, tag_ids=[1   ])
+    assert     sqmtch(search_query, tag_ids=[   2])
+    assert     sqmtch(search_query, tag_ids=[1, 2])
+def test_eval_binary_nor_false():
+    search_query = SearchQuery("t1 nor t2", SearchMode.OR)
+    assert str(search_query) == "L(B(T(t1) nor T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert not sqmtch(search_query, tag_ids=[1   ])
+    assert not sqmtch(search_query, tag_ids=[   2])
+    assert not sqmtch(search_query, tag_ids=[1, 2])
+def test_eval_binary_nor_true():
+    search_query = SearchQuery("t1 nor t2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(t1) nor T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert     sqmtch(search_query, tag_ids=[    ])
+def test_eval_binary_nand_false():
+    search_query = SearchQuery("t1 nand t2", SearchMode.OR)
+    assert str(search_query) == "L(B(T(t1) nand T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert not sqmtch(search_query, tag_ids=[1, 2])
+def test_eval_binary_nand_true():
+    search_query = SearchQuery("t1 nand t2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(t1) nand T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert     sqmtch(search_query, tag_ids=[    ])
+    assert     sqmtch(search_query, tag_ids=[1   ])
+    assert     sqmtch(search_query, tag_ids=[   2])
+def test_eval_binary_xor_false():
+    search_query = SearchQuery("t1 xor t2 t1 != t2 t1 !== t2", SearchMode.OR)
+    assert str(search_query) == "L(B(T(t1) xor T(t2)) B(T(t1) != T(t2)) B(T(t1) !== T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert not sqmtch(search_query, tag_ids=[1, 2])
+    assert not sqmtch(search_query, tag_ids=[    ])
+def test_eval_binary_xor_true():
+    search_query = SearchQuery("t1 xor t2 t1 != t2 t1 !== t2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(t1) xor T(t2)) B(T(t1) != T(t2)) B(T(t1) !== T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert     sqmtch(search_query, tag_ids=[1   ])
+    assert     sqmtch(search_query, tag_ids=[   2])
+def test_eval_binary_xnor_false():
+    search_query = SearchQuery("t1 xnor t2 t1 = t2 t1 == t2 t1 === t2", SearchMode.OR)
+    assert str(search_query) == "L(B(T(t1) xnor T(t2)) B(T(t1) = T(t2)) B(T(t1) == T(t2)) B(T(t1) === T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert not sqmtch(search_query, tag_ids=[1   ])
+    assert not sqmtch(search_query, tag_ids=[   2])
+def test_eval_binary_xnor_true():
+    search_query = SearchQuery("t1 xnor t2 t1 = t2 t1 == t2 t1 === t2", SearchMode.AND)
+    assert str(search_query) == "L(B(T(t1) xnor T(t2)) B(T(t1) = T(t2)) B(T(t1) == T(t2)) B(T(t1) === T(t2)))"
+    assert search_query.share_tag_requests() == ["t1", "t2"]
+    search_query.receive_requested_lib_info({"t1": [1], "t2": [2]})
+    assert     sqmtch(search_query, tag_ids=[1, 2])
+    assert     sqmtch(search_query, tag_ids=[    ])
+
+def test_eval_tag_empty_false():
+    search_query = SearchQuery("empty no_fields no-fields nofields", SearchMode.OR)
+    assert str(search_query) == "L(T(empty) T(no_fields) T(no-fields) T(nofields))"
+    assert search_query.share_tag_requests() == [
+        "empty",
+        "no_fields",
+        "no-fields",
+        "nofields"
+    ]
+    search_query.receive_requested_lib_info({
+        "empty": [],
+        "no_fields": [],
+        "no-fields": [],
+        "nofields": []
+    })
+    assert not sqmtch(search_query, has_fields=True ,has_author=True ,has_file=True )
+    assert not sqmtch(search_query, has_fields=True ,has_author=True ,has_file=False)
+def test_eval_tag_empty_true():
+    search_query = SearchQuery("empty no_fields no-fields nofields", SearchMode.AND)
+    assert str(search_query) == "L(T(empty) T(no_fields) T(no-fields) T(nofields))"
+    assert search_query.share_tag_requests() == [
+        "empty",
+        "no_fields",
+        "no-fields",
+        "nofields"
+    ]
+    search_query.receive_requested_lib_info({
+        "empty": [],
+        "no_fields": [],
+        "no-fields": [],
+        "nofields": []
+    })
+    assert     sqmtch(search_query, has_fields=False,has_author=False,has_file=True )
+    assert     sqmtch(search_query, has_fields=False,has_author=False,has_file=False)
+def test_eval_tag_no_author_false():
+    search_query = SearchQuery("no_author no-author noauthor no_artist no-artist noartist", SearchMode.OR)
+    assert str(search_query) == "L(T(no_author) T(no-author) T(noauthor) T(no_artist) T(no-artist) T(noartist))"
+    assert search_query.share_tag_requests() == [
+        "no_author",
+        "no-author",
+        "noauthor",
+        "no_artist",
+        "no-artist",
+        "noartist"
+    ]
+    search_query.receive_requested_lib_info({
+        "no_author": [],
+        "no-author": [],
+        "noauthor": [],
+        "no_artist": [],
+        "no-artist": [],
+        "noartist": []
+    })
+    assert not sqmtch(search_query, has_fields=True ,has_author=True ,has_file=True )
+    assert not sqmtch(search_query, has_fields=True ,has_author=True ,has_file=False)
+def test_eval_tag_no_author_true():
+    search_query = SearchQuery("no_author no-author noauthor no_artist no-artist noartist", SearchMode.AND)
+    assert str(search_query) == "L(T(no_author) T(no-author) T(noauthor) T(no_artist) T(no-artist) T(noartist))"
+    assert search_query.share_tag_requests() == [
+        "no_author",
+        "no-author",
+        "noauthor",
+        "no_artist",
+        "no-artist",
+        "noartist"
+    ]
+    search_query.receive_requested_lib_info({
+        "no_author": [],
+        "no-author": [],
+        "noauthor": [],
+        "no_artist": [],
+        "no-artist": [],
+        "noartist": []
+    })
+    assert     sqmtch(search_query, has_fields=True ,has_author=False,has_file=True )
+    assert     sqmtch(search_query, has_fields=True ,has_author=False,has_file=False)
+    assert     sqmtch(search_query, has_fields=False,has_author=False,has_file=True )
+    assert     sqmtch(search_query, has_fields=False,has_author=False,has_file=False)
+def test_eval_tag_missing_false():
+    search_query = SearchQuery("missing no_file no-file nofile", SearchMode.OR)
+    assert str(search_query) == "L(T(missing) T(no_file) T(no-file) T(nofile))"
+    assert search_query.share_tag_requests() == [
+        "missing",
+        "no_file",
+        "no-file",
+        "nofile"
+    ]
+    search_query.receive_requested_lib_info({
+        "missing": [],
+        "no_file": [],
+        "no-file": [],
+        "nofile": []
+    })
+    assert not sqmtch(search_query, has_fields=True ,has_author=True ,has_file=True )
+    assert not sqmtch(search_query, has_fields=True ,has_author=False,has_file=True )
+    assert not sqmtch(search_query, has_fields=False,has_author=False,has_file=True )
+def test_eval_tag_missing_true():
+    search_query = SearchQuery("missing no_file no-file nofile", SearchMode.OR)
+    assert str(search_query) == "L(T(missing) T(no_file) T(no-file) T(nofile))"
+    assert search_query.share_tag_requests() == [
+        "missing",
+        "no_file",
+        "no-file",
+        "nofile"
+    ]
+    search_query.receive_requested_lib_info({
+        "missing": [],
+        "no_file": [],
+        "no-file": [],
+        "nofile": []
+    })
+    assert     sqmtch(search_query, has_fields=True ,has_author=True ,has_file=False)
+    assert     sqmtch(search_query, has_fields=True ,has_author=False,has_file=False)
+    assert     sqmtch(search_query, has_fields=False,has_author=False,has_file=False)
+def test_eval_tag_untagged_false():
+    search_query = SearchQuery("untagged no_tags no-tags notags", SearchMode.OR)
+    assert str(search_query) == "L(T(untagged) T(no_tags) T(no-tags) T(notags))"
+    assert search_query.share_tag_requests() == [
+        "untagged",
+        "no_tags",
+        "no-tags",
+        "notags"
+    ]
+    search_query.receive_requested_lib_info({
+        "untagged": [],
+        "no_tags": [],
+        "no-tags": [],
+        "notags": []
+    })
+    assert not sqmtch(search_query, tag_ids=[1],has_fields=True ,has_author=True ,has_file=True )
+    assert not sqmtch(search_query, tag_ids=[1],has_fields=True ,has_author=False,has_file=True )
+    assert not sqmtch(search_query, tag_ids=[1],has_fields=False,has_author=False,has_file=True )
+    assert not sqmtch(search_query, tag_ids=[1],has_fields=True ,has_author=True ,has_file=False)
+    assert not sqmtch(search_query, tag_ids=[1],has_fields=True ,has_author=False,has_file=False)
+    assert not sqmtch(search_query, tag_ids=[1],has_fields=False,has_author=False,has_file=False)
+def test_eval_tag_untagged_true():
+    search_query = SearchQuery("untagged no_tags no-tags notags", SearchMode.AND)
+    assert str(search_query) == "L(T(untagged) T(no_tags) T(no-tags) T(notags))"
+    assert search_query.share_tag_requests() == [
+        "untagged",
+        "no_tags",
+        "no-tags",
+        "notags"
+    ]
+    search_query.receive_requested_lib_info({
+        "untagged": [],
+        "no_tags": [],
+        "no-tags": [],
+        "notags": []
+    })
+    assert     sqmtch(search_query, tag_ids=[ ],has_fields=True ,has_author=True ,has_file=True )
+    assert     sqmtch(search_query, tag_ids=[ ],has_fields=True ,has_author=False,has_file=True )
+    assert     sqmtch(search_query, tag_ids=[ ],has_fields=False,has_author=False,has_file=True )
+    assert     sqmtch(search_query, tag_ids=[ ],has_fields=True ,has_author=True ,has_file=False)
+    assert     sqmtch(search_query, tag_ids=[ ],has_fields=True ,has_author=False,has_file=False)
+    assert     sqmtch(search_query, tag_ids=[ ],has_fields=False,has_author=False,has_file=False)
+
+def test_eval_tag_filename():
+    search_query = SearchQuery("filename:subfolder1 filename:entry1.png", SearchMode.AND)
+    assert str(search_query) == "L(T(filename:subfolder1) T(filename:entry1.png))"
+    assert search_query.share_tag_requests() == ["filename:subfolder1", "filename:entry1.png"]
+    search_query.receive_requested_lib_info({"filename:subfolder1": [], "filename:entry1.png": []})
+    assert     sqmtch(search_query, filename="subfolder1\\entry1.png")
+    assert not sqmtch(search_query, filename="subfolder2\\entry1.png")
+    assert not sqmtch(search_query, filename="subfolder1\\entry2.png")
+    assert not sqmtch(search_query, filename="subfolder2\\entry2.png")
+def test_eval_tag_tag_id():
+    search_query = SearchQuery("tag_id:1 tag-id:2 tagid:3", SearchMode.AND)
+    assert str(search_query) == "L(T(tag_id:1) T(tag-id:2) T(tagid:3))"
+    assert search_query.share_tag_requests() == ["tag_id:1", "tag-id:2", "tagid:3"]
+    search_query.receive_requested_lib_info({"tag_id:1": [], "tag-id:2": [], "tagid:3": []})
+    assert     sqmtch(search_query, tag_ids=[1, 2, 3])
+    assert not sqmtch(search_query, tag_ids=[1, 2   ])
+    assert not sqmtch(search_query, tag_ids=[   2, 3])
+    assert not sqmtch(search_query, tag_ids=[1,    3])
+    


### PR DESCRIPTION
Adds Boolean search syntax to the library search bar. For an explanation of how the search syntax works, check out the new "Search Cheat-Sheet" section in README.md.

Some existing features were changed. Tags with spaces now require underscores when being used in searches. Special consideration was made for the upcoming SQLite migration to hopefully reduce necessary refactoring.

I am happy to discuss these details or any other ones if there are any questions or concerns.