### PR TITLE
Fix file path intercompatibility for Windows and POSIX systems

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -13,7 +13,7 @@ import xml.etree.ElementTree as ET
 import ujson
 
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import cast, Generator
 from typing_extensions import Self
 
@@ -52,7 +52,7 @@ class Entry:
         # Required Fields ======================================================
         self.id = int(id)
         self.filename = Path(filename)
-        self.path = Path(path)
+        self.path = Path(Path(path).as_posix())
         self.fields: list[dict] = fields
         self.type = None
 

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -52,7 +52,7 @@ class Entry:
         # Required Fields ======================================================
         self.id = int(id)
         self.filename = Path(filename)
-        self.path = Path(Path(path).as_posix())
+        self.path = Path(path).as_posix()
         self.fields: list[dict] = fields
         self.type = None
 

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -13,7 +13,7 @@ import xml.etree.ElementTree as ET
 import ujson
 
 from enum import Enum
-from pathlib import Path, PureWindowsPath
+from pathlib import Path
 from typing import cast, Generator
 from typing_extensions import Self
 


### PR DESCRIPTION
Fixes #298 

This fixes a bug where if you move a library saved on Windows to Linux or any POSIX operating system, it will cause the files to not be found due to backslashes. This is a hack I done to prevent this from happening.

Needs extensive testing though, even though that I have confirmed this fix works and does not crash Tag Studio.

cc @coolesding