### PR TITLE
[chore]Make get_field_attr safe and improve control flow in ts_core.py

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -2164,7 +2164,7 @@ class Library:
     # 	entry = self.entries[entry_index]
     # 	pass
     # 	# TODO: Implement.
-    
+
     def get_field_attr(self, entry_field: dict, attribute: str):
         """Returns the value of a specified attribute inside an Entry field."""
         match attribute.lower():

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -2169,12 +2169,15 @@ class Library:
         """Returns the value of a specified attribute inside an Entry field."""
         match attribute.lower():
             case "id":
-                return list(entry_field.keys())[:1]
+                return val[0] if not any(val := list(entry_field.keys())[:1]) else -1
             case "content":
                 return entry_field[self.get_field_attr(entry_field, "id")]
             case _:
-                _ensure_field: dict = self.get_field_obj(self.get_field_attr(entry_field, "id"))
-                return _ensure_field.get(attribute.lower())
+                #_ensure_field: dict = self.get_field_obj(self.get_field_attr(entry_field, "id"))
+                #return _ensure_field.get(attribute.lower())
+                return self.get_field_obj(self.get_field_attr(entry_field, "id"))[
+                attribute.lower()
+            ]
         
 
     def get_field_obj(self, field_id: int) -> dict:

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -2173,11 +2173,8 @@ class Library:
             case "content":
                 return entry_field[self.get_field_attr(entry_field, "id")]
             case _:
-                #_ensure_field: dict = self.get_field_obj(self.get_field_attr(entry_field, "id"))
-                #return _ensure_field.get(attribute.lower())
-                return self.get_field_obj(self.get_field_attr(entry_field, "id"))[
-                attribute.lower()
-            ]
+                _ensure_field: dict = self.get_field_obj(self.get_field_attr(entry_field, "id"))
+                return _ensure_field.get(attribute.lower())
         
 
     def get_field_obj(self, field_id: int) -> dict:

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -2164,17 +2164,18 @@ class Library:
     # 	entry = self.entries[entry_index]
     # 	pass
     # 	# TODO: Implement.
-
+    
     def get_field_attr(self, entry_field: dict, attribute: str):
         """Returns the value of a specified attribute inside an Entry field."""
-        if attribute.lower() == "id":
-            return list(entry_field.keys())[0]
-        elif attribute.lower() == "content":
-            return entry_field[self.get_field_attr(entry_field, "id")]
-        else:
-            return self.get_field_obj(self.get_field_attr(entry_field, "id"))[
-                attribute.lower()
-            ]
+        match attribute.lower():
+            case "id":
+                return list(entry_field.keys())[:1]
+            case "content":
+                return entry_field[self.get_field_attr(entry_field, "id")]
+            case _:
+                _ensure_field: dict = self.get_field_obj(self.get_field_attr(entry_field, "id"))
+                return _ensure_field.get(attribute.lower())
+        
 
     def get_field_obj(self, field_id: int) -> dict:
         """


### PR DESCRIPTION
**Refactor get_field_attr in library.py and improve control flow in ts_core.py**

### Changes:

**1. Refactor `get_field_attr` in `library.py`:**
- Ensure safety using list slicing to avoid `IndexError`.
- Use `any` to determine if there is a value before using it.
- Use `.get()` for dictionary access to handle default cases and prevent `KeyError`.

**2. Improve control flow in `ts_core.py`:**
- Remove nesting by exiting early in `match_conditions`.
- Eliminate the need for try-catch blocks for better readability and control flow.

### Additional Fix:
- Included fix for non-merged pull request #318.

**Note:**
- Kept `existing_fields` case unchanged due to `add_field_to_entry`'s procedural nature.