### PR TITLE
Fix #2 for Add Library Tags panel

### DIFF
--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -84,6 +84,7 @@ class TagSearchPanel(PanelWidget):
 
         self.root_layout.addWidget(self.search_field)
         self.root_layout.addWidget(self.scroll_area)
+        self.update_tags("")
 
     # def reset(self):
     # 	self.search_field.setText('')


### PR DESCRIPTION
The "Add Tags" panel displays all tags when no search has been performed. Modifies the "Add Library Tags panel" to be the same.