### PR TITLE
feat(ui): sort tags in add tag panel by color/alphabetical (close #327)

### DIFF
--- a/tagstudio/src/qt/modals/tag_database.py
+++ b/tagstudio/src/qt/modals/tag_database.py
@@ -104,16 +104,24 @@ class TagDatabasePanel(PanelWidget):
             # Get tag ids to keep this behaviorally identical
             tags = [t.id for t in self.lib.tags]
 
-        # sort tags by Archived and Favorite at the top, then by color,
-        # and then alphabetically
-        sorted_tags = sorted(
-            tags,
-            key=lambda tag_id: (
-                tag_id not in [0, 1],
-                TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
-                self.lib.get_tag(tag_id).display_name(self.lib),
-            ),
-        )
+        if query:
+            # sort tags alphabetically and then by color
+            sorted_tags = sorted(
+                tags,
+                key=lambda tag_id: (
+                    self.lib.get_tag(tag_id).display_name(self.lib),
+                    TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
+                ),
+            )
+        else:
+            # sort tags by color and then alphabetically
+            sorted_tags = sorted(
+                tags,
+                key=lambda tag_id: (
+                    TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
+                    self.lib.get_tag(tag_id).display_name(self.lib),
+                ),
+            )
 
         first_id_set = False
         for tag_id in sorted_tags:

--- a/tagstudio/src/qt/modals/tag_database.py
+++ b/tagstudio/src/qt/modals/tag_database.py
@@ -105,10 +105,11 @@ class TagDatabasePanel(PanelWidget):
             tags = [t.id for t in self.lib.tags]
 
         if query:
-            # sort tags alphabetically and then by color
+            # sort tags by whether the tag's name is the text that's matching the search, alphabetically, and then by color
             sorted_tags = sorted(
                 tags,
                 key=lambda tag_id: (
+                    not self.lib.get_tag(tag_id).name.lower().startswith(query.lower()),
                     self.lib.get_tag(tag_id).display_name(self.lib),
                     TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
                 ),

--- a/tagstudio/src/qt/modals/tag_database.py
+++ b/tagstudio/src/qt/modals/tag_database.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QFrame,
 )
 
+from src.core.constants import TAG_COLORS
 from src.core.library import Library
 from src.qt.widgets.panel import PanelWidget, PanelModal
 from src.qt.widgets.tag import TagWidget
@@ -103,8 +104,19 @@ class TagDatabasePanel(PanelWidget):
             # Get tag ids to keep this behaviorally identical
             tags = [t.id for t in self.lib.tags]
 
+        # sort tags by Archived and Favorite at the top, then by color,
+        # and then alphabetically
+        sorted_tags = sorted(
+            tags,
+            key=lambda tag_id: (
+                tag_id not in [0, 1],
+                TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
+                self.lib.get_tag(tag_id).display_name(self.lib),
+            ),
+        )
+
         first_id_set = False
-        for tag_id in tags:
+        for tag_id in sorted_tags:
             if not first_id_set:
                 self.first_tag_id = tag_id
                 first_id_set = True

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -110,7 +110,7 @@ class TagSearchPanel(PanelWidget):
 
         found_tags = self.lib.search_tags(query, include_cluster=True)[: self.tag_limit]
         self.first_tag_id = found_tags[0] if found_tags else None
-        
+
         if query:
             # sort tags alphabetically and then by color
             sorted_tags = sorted(

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -110,17 +110,25 @@ class TagSearchPanel(PanelWidget):
 
         found_tags = self.lib.search_tags(query, include_cluster=True)[: self.tag_limit]
         self.first_tag_id = found_tags[0] if found_tags else None
-
-        # sort tags by Archived and Favorite at the top, then by color,
-        # and then alphabetically
-        sorted_tags = sorted(
-            found_tags,
-            key=lambda tag_id: (
-                tag_id not in [0, 1],
-                TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
-                self.lib.get_tag(tag_id).display_name(self.lib),
-            ),
-        )
+        
+        if query:
+            # sort tags alphabetically and then by color
+            sorted_tags = sorted(
+                found_tags,
+                key=lambda tag_id: (
+                    self.lib.get_tag(tag_id).display_name(self.lib),
+                    TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
+                ),
+            )
+        else:
+            # sort tags by color and then alphabetically
+            sorted_tags = sorted(
+                found_tags,
+                key=lambda tag_id: (
+                    TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
+                    self.lib.get_tag(tag_id).display_name(self.lib),
+                ),
+            )
 
         for tag_id in sorted_tags:
             c = QWidget()

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QFrame,
 )
 
+from src.core.constants import TAG_COLORS
 from src.core.library import Library
 from src.core.palette import ColorType, get_tag_color
 from src.qt.widgets.panel import PanelWidget
@@ -110,7 +111,18 @@ class TagSearchPanel(PanelWidget):
         found_tags = self.lib.search_tags(query, include_cluster=True)[: self.tag_limit]
         self.first_tag_id = found_tags[0] if found_tags else None
 
-        for tag_id in found_tags:
+        # sort tags by Archived and Favorite at the top, then by color,
+        # and then alphabetically
+        sorted_tags = sorted(
+            found_tags,
+            key=lambda tag_id: (
+                tag_id not in [0, 1],
+                TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
+                self.lib.get_tag(tag_id).display_name(self.lib),
+            ),
+        )
+
+        for tag_id in sorted_tags:
             c = QWidget()
             l = QHBoxLayout(c)
             l.setContentsMargins(0, 0, 0, 0)

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -112,10 +112,11 @@ class TagSearchPanel(PanelWidget):
         self.first_tag_id = found_tags[0] if found_tags else None
 
         if query:
-            # sort tags alphabetically and then by color
+            # sort tags by whether the tag's name is the text that's matching the search, alphabetically, and then by color
             sorted_tags = sorted(
                 found_tags,
                 key=lambda tag_id: (
+                    not self.lib.get_tag(tag_id).name.lower().startswith(query.lower()),
                     self.lib.get_tag(tag_id).display_name(self.lib),
                     TAG_COLORS.index(self.lib.get_tag(tag_id).color.lower()),
                 ),


### PR DESCRIPTION
Sort tags in the Library Tags panel and the Add Parent Tags panel with Archived and Favorite at the top, then sort by color, and then sort alphabetically.

This is what the panels look like now when you have many tags of different colors:
![image](https://github.com/user-attachments/assets/c78642db-6891-49e8-842e-95a5f782627f) 
![image](https://github.com/user-attachments/assets/44cea4d4-a134-4258-bcc5-48ea6ae3adfa)

