### PR TITLE
add JPEG XL support via pillow-jpegxl-plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 humanfriendly==10.0
 opencv_python>=4.8.0.74,<=4.9.0.80
 Pillow==10.3.0
+pillow-jxl-plugin==1.2.6
 PySide6==6.7.1
 PySide6_Addons==6.7.1
 PySide6_Essentials==6.7.1

--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -21,6 +21,7 @@ IMAGE_TYPES: list[str] = [
     ".heic",
     ".heif",
     ".webp",
+    ".jxl",
     ".bmp",
     ".svg",
     ".avif",

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import cv2
 import rawpy
+import pillow_jxl
 from pillow_heif import register_heif_opener, register_avif_opener
 from PIL import (
     Image,


### PR DESCRIPTION
this PR adds JPEG XL support via a pillow plugin [pillow-jpegxl-plugin](https://github.com/Isotr0py/pillow-jpegxl-plugin).
I've tested on JPEG XL images made with [libjxl](https://github.com/libjxl/libjxl) `cjxl` and it seems to work fine
​
​
​
this closes #333