### PR TITLE
fix: avoid `KeyError` in `add_folders_to_tree()` (fix #346)

### DIFF
--- a/tagstudio/src/qt/modals/folders_to_tags.py
+++ b/tagstudio/src/qt/modals/folders_to_tags.py
@@ -61,7 +61,7 @@ def folders_to_tags(library: Library):
                 library.add_tag_to_library(new_tag)
                 branch["dirs"][folder] = dict(dirs={}, tag=new_tag)
             branch = branch["dirs"][folder]
-        return branch["tag"]
+        return branch.get("tag")
 
     for tag in library.tags:
         reversed_tag = reverse_tag(library, tag, None)


### PR DESCRIPTION
Swaps the use of `branch["tag"]` for `branch.get("tag")` inside of `add_folders_to_tree()` to avoid a `KeyError` when there is no Tag.