### PR TITLE
Update Numpy to version 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 humanfriendly==10.0
-opencv_python>=4.8.0.74,<=4.9.0.80
+opencv_python==4.10.0.84
 Pillow==10.3.0
 PySide6==6.7.1
 PySide6_Addons==6.7.1
 PySide6_Essentials==6.7.1
 typing_extensions>=3.10.0.0,<=4.11.0
 ujson>=5.8.0,<=5.9.0
-numpy==1.26.4
-rawpy==0.21.0
+numpy==2.1.0
+rawpy==0.22.0
 pillow-heif==0.16.0
 chardet==5.2.0


### PR DESCRIPTION
I Updated the Numpy version Tagstudio is running on, to the newest version compatible with rawpy and opencv. I also updated the version they are pinned to.
I tested it a bit but feel free to test yourself