### PR TITLE
Fix ts_qt empty file bug, show more file previews, and rename "Show file in explorer" to vary based on OS

### DIFF
--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -86,12 +86,17 @@ PLAINTEXT_TYPES: list[str] = [
     ".json",
     ".js",
     ".ts",
+    ".py",
+    ".c",
+    ".cpp",
+    ".cs",
     ".ini",
     ".htm",
     ".csv",
     ".php",
     ".sh",
     ".bat",
+    ".yml"
 ]
 SPREADSHEET_TYPES: list[str] = [".csv", ".xls", ".xlsx", ".numbers", ".ods"]
 PRESENTATION_TYPES: list[str] = [".ppt", ".pptx", ".key", ".odp"]

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1215,7 +1215,7 @@ class QtDriver(QObject):
         base_size: tuple[int, int] = (self.thumb_size, self.thumb_size)
 
         for i, item_thumb in enumerate(self.item_thumbs, start=0):
-            if i < len(self.nav_frames[self.cur_frame_idx].contents):
+            if self.nav_frames[self.cur_frame_idx].contents and i < len(self.nav_frames[self.cur_frame_idx].contents):
                 # Set new item type modes
                 # logging.info(f'[UPDATE] Setting Mode To: {self.nav_stack[self.cur_page_idx].contents[i][0]}')
                 item_thumb.set_mode(self.nav_frames[self.cur_frame_idx].contents[i][0])
@@ -1245,7 +1245,7 @@ class QtDriver(QObject):
         self.main_window.update()
 
         for i, item_thumb in enumerate(self.item_thumbs, start=0):
-            if i < len(self.nav_frames[self.cur_frame_idx].contents):
+            if self.nav_frames[self.cur_frame_idx].contents and i < len(self.nav_frames[self.cur_frame_idx].contents):
                 filepath = ""
                 if self.nav_frames[self.cur_frame_idx].contents[i][0] == ItemType.ENTRY:
                     entry = self.lib.get_entry(

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -200,7 +200,7 @@ class ItemThumb(FlowWidget):
         if system == "Darwin":
             open_explorer_action = QAction("Reveal file in Finder", self)
         elif system == "Linux":
-            open_explorer_action = QAction("Open file in explorer", self) # TODO: Rename to whatever the Linux explorer is
+            open_explorer_action = QAction("Open file in filesystem", self) # TODO: Rename to whatever the Linux explorer is
         else:
             open_explorer_action = QAction("Open file in explorer", self)
 

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -4,6 +4,7 @@
 import contextlib
 import logging
 import os
+import platform
 import time
 import typing
 from pathlib import Path
@@ -194,7 +195,15 @@ class ItemThumb(FlowWidget):
         self.opener = FileOpenerHelper("")
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)
-        open_explorer_action = QAction("Open file in explorer", self)
+        
+        system = platform.system()
+        if system == "Darwin":
+            open_explorer_action = QAction("Reveal file in Finder", self)
+        elif system == "Linux":
+            open_explorer_action = QAction("Open file in explorer", self) # TODO: Rename to whatever the Linux explorer is
+        else:
+            open_explorer_action = QAction("Open file in explorer", self)
+
         open_explorer_action.triggered.connect(self.opener.open_explorer)
         self.thumb_button.addAction(open_file_action)
         self.thumb_button.addAction(open_explorer_action)

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -90,7 +90,7 @@ class PreviewPanel(QWidget):
         if system == "Darwin":
             self.open_explorer_action = QAction("Reveal file in Finder", self)
         elif system == "Linux":
-            self.open_explorer_action = QAction("Open file in explorer", self) # TODO: Rename to whatever the Linux explorer is
+            self.open_explorer_action = QAction("Open file in filesystem", self) # TODO: Rename to whatever the Linux explorer is
         else:
             self.open_explorer_action = QAction("Open file in explorer", self)
 

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -4,6 +4,7 @@
 
 import logging
 from pathlib import Path
+import platform
 import time
 import typing
 from datetime import datetime as dt
@@ -83,7 +84,15 @@ class PreviewPanel(QWidget):
         image_layout.setContentsMargins(0, 0, 0, 0)
 
         self.open_file_action = QAction("Open file", self)
-        self.open_explorer_action = QAction("Open file in explorer", self)
+
+        system = platform.system()
+
+        if system == "Darwin":
+            self.open_explorer_action = QAction("Reveal file in Finder", self)
+        elif system == "Linux":
+            self.open_explorer_action = QAction("Open file in explorer", self) # TODO: Rename to whatever the Linux explorer is
+        else:
+            self.open_explorer_action = QAction("Open file in explorer", self)
 
         self.preview_img = QPushButtonWrapper()
         self.preview_img.setMinimumSize(*self.img_button_size)

--- a/tagstudio/src/qt/widgets/video_player.py
+++ b/tagstudio/src/qt/widgets/video_player.py
@@ -4,6 +4,7 @@
 import logging
 
 from pathlib import Path
+import platform
 import typing
 
 from PySide6.QtCore import (
@@ -129,7 +130,15 @@ class VideoPlayer(QGraphicsView):
 
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)
-        open_explorer_action = QAction("Open file in explorer", self)
+
+        system = platform.system()
+        if system == "Darwin":
+            open_explorer_action = QAction("Reveal file in Finder", self)
+        elif system == "Linux":
+            open_explorer_action = QAction("Open file in explorer", self) # TODO: Rename to whatever the Linux explorer is
+        else:
+            open_explorer_action = QAction("Open file in explorer", self)
+
         open_explorer_action.triggered.connect(self.opener.open_explorer)
         self.addAction(open_file_action)
         self.addAction(open_explorer_action)

--- a/tagstudio/src/qt/widgets/video_player.py
+++ b/tagstudio/src/qt/widgets/video_player.py
@@ -135,7 +135,7 @@ class VideoPlayer(QGraphicsView):
         if system == "Darwin":
             open_explorer_action = QAction("Reveal file in Finder", self)
         elif system == "Linux":
-            open_explorer_action = QAction("Open file in explorer", self) # TODO: Rename to whatever the Linux explorer is
+            open_explorer_action = QAction("Open file in filesystem", self) # TODO: Rename to whatever the Linux explorer is
         else:
             open_explorer_action = QAction("Open file in explorer", self)
 


### PR DESCRIPTION
Previously, when you pressed the forward arrow and there wasn't anything to go forward with, it would raise this error:
`TypeError: object of type 'bool' has no len()
Calling NavForward with Content:False, Index:0, PageCount:0
Traceback (most recent call last):
  File "/Users/maxpersonal/Downloads/TagStudio/tagstudio/src/qt/ts_qt.py", line 1008, in nav_forward
    self.update_thumbs()
  File "/Users/maxpersonal/Downloads/TagStudio/tagstudio/src/qt/ts_qt.py", line 1218, in update_thumbs
    if i < len(self.nav_frames[self.cur_frame_idx].contents):`
This has been fixed.

Second, I made it so Python, C, C++, C#, and Yaml files are rendered as plain text.

Lastly, I made it so it either says reveal in Finder or show in explorer based on the operating system. I don't know what it usually says on Linux, as I've never used it, so I made it stay the same, but somebody else could change this later.