### PR TITLE
fix: correct behavior for tag widget search options

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -1352,10 +1352,13 @@ class Library:
             only_missing: bool = "missing" in query or "no file" in query
             allow_adv: bool = "filename:" in query_words
             tag_only: bool = "tag_id:" in query_words
+            tag_only_ids: list[int] = []
             if allow_adv:
                 query_words.remove("filename:")
             if tag_only:
                 query_words.remove("tag_id:")
+                tag_only_ids.append(int(query_words[0]))
+                tag_only_ids = tag_only_ids + self.get_tag_cluster(int(query_words[0]))
             # TODO: Expand this to allow for dynamic fields to work.
             only_no_author: bool = "no author" in query or "no artist" in query
 
@@ -1382,15 +1385,9 @@ class Library:
                             all_tag_terms.remove(all_tag_terms[i])
                             break
 
-            # print(all_tag_terms)
-
-            # non_entry_count = 0
             # Iterate over all Entries =============================================================
             for entry in self.entries:
                 allowed_ext: bool = entry.filename.suffix.lower() not in self.ext_list
-                # try:
-                # entry: Entry = self.entries[self.file_to_library_index_map[self._source_filenames[i]]]
-                # print(f'{entry}')
 
                 if allowed_ext == self.is_exclude_list:
                     # If the entry has tags of any kind, append them to this main tag list.
@@ -1432,7 +1429,6 @@ class Library:
                     # elif query in entry.path.lower():
 
                     # NOTE: This searches path and filenames.
-
                     if allow_adv:
                         if [q for q in query_words if (q in str(entry.path).lower())]:
                             results.append((ItemType.ENTRY, entry.id))
@@ -1441,17 +1437,14 @@ class Library:
                         ]:
                             results.append((ItemType.ENTRY, entry.id))
                     elif tag_only:
-                        if entry.has_tag(self, int(query_words[0])):
-                            results.append((ItemType.ENTRY, entry.id))
+                        for id in tag_only_ids:
+                            if entry.has_tag(self, id) and entry.id not in results:
+                                results.append((ItemType.ENTRY, entry.id))
+                                break
 
-                    # elif query in entry.filename.lower():
-                    # 	self.filtered_entries.append(index)
                     elif entry_tags:
                         # function to add entry to results
                         def add_entry(entry: Entry):
-                            # self.filter_entries.append()
-                            # self.filtered_file_list.append(file)
-                            # results.append((SearchItemType.ENTRY, entry.id))
                             added = False
                             for f in entry.fields:
                                 if self.get_field_attr(f, "type") == "collation":
@@ -1521,26 +1514,6 @@ class Library:
                                             add_entry(entry)
                                         break
 
-                # sys.stdout.write(
-                #     f'\r[INFO][FILTER]: {len(self.filtered_file_list)} matches found')
-                # sys.stdout.flush()
-
-                # except:
-                #     # # Put this here to have new non-registered images show up
-                #     # if query == "untagged" or query == "no author" or query == "no artist":
-                #     #     self.filtered_file_list.append(file)
-                #     # non_entry_count = non_entry_count + 1
-                #     pass
-
-            # end_time = time.time()
-            # print(
-            # 	f'[INFO][FILTER]: {len(self.filtered_entries)} matches found ({(end_time - start_time):.3f} seconds)')
-
-            # if non_entry_count:
-            # 	print(
-            # 		f'[INFO][FILTER]: There are {non_entry_count} new files in {self.source_dir} that do not have entries. These will not appear in most filtered results.')
-            # if not self.filtered_entries:
-            # 	print("[INFO][FILTER]: Filter returned no results.")
         else:
             for entry in self.entries:
                 added = False
@@ -1565,8 +1538,6 @@ class Library:
 
                     if not added:
                         results.append((ItemType.ENTRY, entry.id))
-            # for file in self._source_filenames:
-            #     self.filtered_file_list.append(file)
         results.reverse()
         return results
 
@@ -2309,7 +2280,7 @@ class Library:
         return self.tags[self._tag_id_to_index_map[int(tag_id)]]
 
     def get_tag_cluster(self, tag_id: int) -> list[int]:
-        """Returns a list of Tag IDs that reference this Tag."""
+        """Returns a list of Tag IDs that reference this Tag as its parent."""
         if tag_id in self._tag_id_to_cluster_map:
             return self._tag_id_to_cluster_map[int(tag_id)]
         return []

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -1357,8 +1357,13 @@ class Library:
                 query_words.remove("filename:")
             if tag_only:
                 query_words.remove("tag_id:")
-                tag_only_ids.append(int(query_words[0]))
-                tag_only_ids = tag_only_ids + self.get_tag_cluster(int(query_words[0]))
+                if query_words and query_words[0].isdigit():
+                    tag_only_ids.append(int(query_words[0]))
+                    tag_only_ids.extend(self.get_tag_cluster(int(query_words[0])))
+                else:
+                    logging.error(
+                        f"[Library][ERROR] Invalid Tag ID in query: {query_words}"
+                    )
             # TODO: Expand this to allow for dynamic fields to work.
             only_no_author: bool = "no author" in query or "no artist" in query
 

--- a/tagstudio/src/qt/modals/tag_database.py
+++ b/tagstudio/src/qt/modals/tag_database.py
@@ -3,25 +3,24 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 import typing
-from PySide6.QtCore import Signal, Qt, QSize
+
+from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
+    QFrame,
     QHBoxLayout,
     QLineEdit,
     QScrollArea,
-    QFrame,
+    QVBoxLayout,
+    QWidget,
 )
-
 from src.core.constants import TAG_COLORS
-from src.core.library import Library
-from src.qt.widgets.panel import PanelWidget, PanelModal
-from src.qt.widgets.tag import TagWidget
 from src.qt.modals.build_tag import BuildTagPanel
+from src.qt.widgets.panel import PanelModal, PanelWidget
+from src.qt.widgets.tag import TagWidget
 
 # Only import for type checking/autocompletion, will not be imported at runtime.
 if typing.TYPE_CHECKING:
-    from src.core.library import Tag
+    from src.core.library import Library, Tag
     from src.qt.ts_qt import QtDriver
 
 

--- a/tagstudio/src/qt/modals/tag_database.py
+++ b/tagstudio/src/qt/modals/tag_database.py
@@ -2,6 +2,7 @@
 # Licensed under the GPL-3.0 License.
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
+import typing
 from PySide6.QtCore import Signal, Qt, QSize
 from PySide6.QtWidgets import (
     QWidget,
@@ -18,17 +19,21 @@ from src.qt.widgets.panel import PanelWidget, PanelModal
 from src.qt.widgets.tag import TagWidget
 from src.qt.modals.build_tag import BuildTagPanel
 
+# Only import for type checking/autocompletion, will not be imported at runtime.
+if typing.TYPE_CHECKING:
+    from src.core.library import Tag
+    from src.qt.ts_qt import QtDriver
+
 
 class TagDatabasePanel(PanelWidget):
     tag_chosen = Signal(int)
 
-    def __init__(self, library):
+    def __init__(self, library: "Library", driver: "QtDriver"):
         super().__init__()
         self.lib: Library = library
-        # self.callback = callback
+        self.driver: QtDriver = driver
         self.first_tag_id = -1
         self.tag_limit = 30
-        # self.selected_tag: int = 0
 
         self.setMinimumSize(300, 400)
         self.root_layout = QVBoxLayout(self)
@@ -133,9 +138,14 @@ class TagDatabasePanel(PanelWidget):
             row = QHBoxLayout(container)
             row.setContentsMargins(0, 0, 0, 0)
             row.setSpacing(3)
-            tw = TagWidget(self.lib, self.lib.get_tag(tag_id), True, False)
-            tw.on_edit.connect(
-                lambda checked=False, t=self.lib.get_tag(tag_id): (self.edit_tag(t.id))
+            tag: Tag = self.lib.get_tag(tag_id)
+            tw = TagWidget(self.lib, tag, True, False)
+            tw.on_edit.connect(lambda checked=False, t=tag: (self.edit_tag(t.id)))
+            tw.on_click.connect(
+                lambda checked=False, q=f"tag_id: {tag_id}": (
+                    self.driver.main_window.searchField.setText(q),
+                    self.driver.filter_items(q),
+                )
             )
             row.addWidget(tw)
             self.scroll_layout.addWidget(container)

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -791,7 +791,10 @@ class QtDriver(QObject):
 
     def show_tag_database(self):
         self.modal = PanelModal(
-            TagDatabasePanel(self.lib), "Library Tags", "Library Tags", has_save=False
+            TagDatabasePanel(self.lib, self),
+            "Library Tags",
+            "Library Tags",
+            has_save=False,
         )
         self.modal.show()
 

--- a/tagstudio/src/qt/widgets/tag.py
+++ b/tagstudio/src/qt/widgets/tag.py
@@ -74,8 +74,6 @@ class TagWidget(QWidget):
         # search_for_tag_action.triggered.connect(on_click_callback)
         search_for_tag_action.triggered.connect(self.on_click.emit)
         self.bg_button.addAction(search_for_tag_action)
-        # add_to_search_action = QAction("Add to Search", self)
-        # self.bg_button.addAction(add_to_search_action)
 
         self.inner_layout = QHBoxLayout()
         self.inner_layout.setObjectName("innerLayout")

--- a/tagstudio/src/qt/widgets/tag.py
+++ b/tagstudio/src/qt/widgets/tag.py
@@ -74,8 +74,8 @@ class TagWidget(QWidget):
         # search_for_tag_action.triggered.connect(on_click_callback)
         search_for_tag_action.triggered.connect(self.on_click.emit)
         self.bg_button.addAction(search_for_tag_action)
-        add_to_search_action = QAction("Add to Search", self)
-        self.bg_button.addAction(add_to_search_action)
+        # add_to_search_action = QAction("Add to Search", self)
+        # self.bg_button.addAction(add_to_search_action)
 
         self.inner_layout = QHBoxLayout()
         self.inner_layout.setObjectName("innerLayout")


### PR DESCRIPTION
This PR addresses three related issues:
1. #211: "Search for Tag" context menu option + left-click behavior for tag widgets did not include tag clusters in results; only instances of that exact tag ID. Expected behavior is to include the entire inheritance cluster, and this has now been implemented. Additional commented-out code has been removed inside the `search_library()` method. 
2. "Add to Search" context menu option was non-functional. This option has been removed from the context menu.
3. Undocumented issue found during testing: The "Search for Tag" context menu and left-click behavior was non-functional for tag widgets inside the "Tag Manager" panel. This functionality has been implemented.

I have not updated the display of tag IDs in the search bar as discussed in 211, as I feel this is much better suited for a future UI revamp of how tags are displayed in the search bar.

Closes #211.