### PR TITLE
Sidecar macro fixes

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -2051,7 +2051,7 @@ class Library:
                         # elif meta_tags_field_indices:
                         # 	priority_field_index = meta_tags_field_indices[0]
 
-                        if priority_field_index > 0:
+                        if priority_field_index >= 0:
                             self.update_entry_field(
                                 entry_id, priority_field_index, [matching[0]], "append"
                             )

--- a/tagstudio/src/core/ts_core.py
+++ b/tagstudio/src/core/ts_core.py
@@ -31,7 +31,7 @@ class TagStudioCore:
         json_dump = {}
         info = {}
         _filepath: Path = Path(filepath)
-        _filepath = _filepath.parent / (_filepath.stem + ".json")
+        _filepath = _filepath.parent / (_filepath.name + ".json")
 
         # NOTE: This fixes an unknown (recent?) bug in Gallery-DL where Instagram sidecar
         # files may be downloaded with indices starting at 1 rather than 0, unlike the posts.

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -947,7 +947,7 @@ class QtDriver(QObject):
         """Runs a specific Macro on an Entry given a Macro name."""
         entry = self.lib.get_entry(entry_id)
         path = self.lib.library_dir / entry.path / entry.filename
-        source = entry.path.parts[0]
+        source = "" if entry.path == Path(".") else entry.path.parts[0]
         if name == "sidecar":
             self.lib.add_generic_data_to_entry(
                 self.core.get_gdl_sidecar(path, source), entry_id

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -947,7 +947,7 @@ class QtDriver(QObject):
         """Runs a specific Macro on an Entry given a Macro name."""
         entry = self.lib.get_entry(entry_id)
         path = self.lib.library_dir / entry.path / entry.filename
-        source = "" if entry.path == Path(".") else entry.path.parts[0]
+        source = "" if entry.path == Path(".") else entry.path.parts[0].lower()
         if name == "sidecar":
             self.lib.add_generic_data_to_entry(
                 self.core.get_gdl_sidecar(path, source), entry_id


### PR DESCRIPTION
This Pull Request addresses 3 Bugs I found while using the gallery_dl-sidecar importing feature:
1. Running macros on files that aren't in a subdirectory was broken (see 1d4570174a3014cfaf348ae5752537528d9ed11e).
2. For `filename.jpg` `get_gdl_sidecar` would try to load `filename.json` instead of `filename.jpg.json`, which is the default filename format used by gallery_dl (see a0562a876630e7bd7fd0b3b91180c8c7bb32975c).
3. `add_generic_data_to_entry` would create a second Content Tags Field if the existing Content Tags field was the first field, because an if-statement used `>` instead of `>=` (see fbd2244a2eb27f9454c8d33006e5f443105fdcea).

I didn't create an Issue first because I had already fixed these issues in order to use the autofill macro to import gdl sidecar files.