### PR TITLE
GPU Hardware Acceleration for Nix Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,6 @@
                           makeShellWrapper
                         ])
                         ++ (with qt6Pkgs.qt6; [
-                          full
                           wrapQtAppsHook
                         ]);
                       }
@@ -139,10 +138,13 @@
                       libglvnd
                       libkrb5
                       libpulseaudio
+                      libva
                       libxkbcommon
+                      openssl
                       stdenv.cc.cc.lib
                       wayland
                       xorg.libxcb
+                      xorg.libXrandr
                       zlib
                       zstd
                     ])

--- a/flake.nix
+++ b/flake.nix
@@ -89,9 +89,15 @@
                       {
                         buildInputs = with qt6Pkgs.qt6; [
                           qtbase # Needed by wrapQtAppsHook.
-                          wrapQtAppsHook
                         ];
-                        nativeBuildInputs = with pkgs; [ makeShellWrapper ];
+
+                        nativeBuildInputs = (with pkgs; [
+                          makeShellWrapper
+                        ])
+                        ++ (with qt6Pkgs.qt6; [
+                          full
+                          wrapQtAppsHook
+                        ]);
                       }
                       ''
                         makeShellWrapper "$(type -p sh)" "$out" "''${qtWrapperArgs[@]}"
@@ -99,6 +105,17 @@
                       '';
                   in
                   ''
+                    AMD_VDPAU=$(${pkgs.libva-utils}/bin/vainfo 2>/dev/null | ${pkgs.gnugrep}/bin/grep -F radeonsi)
+
+                    # If no explicit VDPAU driver is specified, check for a potential VDPAU~>VA-API adapter.
+                    # Try to use AMD driver `radeonsi` (non-zero output for AMD_VDPAU => found a driver)
+                    if [ -z "$VDPAU_DRIVER" ] && [ -n "$AMD_VDPAU" ]; then
+                      echo "Use \"radeonsi\" as VDPAU~>VA-API adapter for video hardware acceleration on AMD-GPUs."
+                      echo "$AMD_VDPAU"
+
+                      export VDPAU_DRIVER=radeonsi
+                    fi
+
                     source ${setQtEnv}
                   '';
 
@@ -124,6 +141,7 @@
                       libpulseaudio
                       libxkbcommon
                       stdenv.cc.cc.lib
+                      wayland
                       xorg.libxcb
                       zlib
                       zstd


### PR DESCRIPTION
Fixes #417

Enables hardware accelerated video playback for Nix _devenv_.

Also supports VA-API compatible GPUs like AMD and Intel (also see [libva](https://github.com/intel/libva/blob/01153523f25ac703e7ce2afc0023788a90f6c1bb/va/drm/va_drm_utils.c#L62-L68) for reference).