### PR TITLE
More ways to open files

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -322,7 +322,11 @@ class QtDriver(QObject):
         open_selected_action = QAction("Open selected files", self)
         open_selected_action.triggered.connect(
             lambda: (
-                [self.item_thumbs[selection].opener.open_file() for selection in self.selected],
+                (
+                    [self.item_thumbs[selection].opener.open_file() for selection in self.selected]
+                    if QApplication.focusWidget() == self.main_window.scrollArea
+                    else None
+                ),
                 logger.info("Opening files", count=len(self.selected)),
             )
         )

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -323,7 +323,7 @@ class QtDriver(QObject):
 
         open_selected_action = QAction("Open selected files", self)
         open_selected_action.triggered.connect(self.open_selected_files)
-        shortcut = QtCore.QKeyCombination(
+        shortcut: QtCore.QKeyCombination | Qt.Key = QtCore.QKeyCombination(
             QtCore.Qt.KeyboardModifier(QtCore.Qt.KeyboardModifier.ControlModifier),
             QtCore.Qt.Key.Key_Down,
         )
@@ -1122,8 +1122,8 @@ class QtDriver(QObject):
             open_button = confirm_open.addButton("&Open", QMessageBox.ButtonRole.ActionRole)
             confirm_open.setDefaultButton(open_button)
 
-            result = confirm_open.exec()
+            result = QMessageBox.ButtonRole(confirm_open.exec())
 
-        if result == QMessageBox.ButtonRole.ActionRole.value:
+        if result == QMessageBox.ButtonRole.ActionRole:
             for selection in self.selected:
                 self.item_thumbs[selection].opener.open_file()

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -318,6 +318,23 @@ class QtDriver(QObject):
         add_new_files_action.setStatusTip("Ctrl+R")
         # file_menu.addAction(refresh_lib_action)
         file_menu.addAction(add_new_files_action)
+
+        open_selected_action = QAction("Open selected files", self)
+        open_selected_action.triggered.connect(
+            lambda: (
+                [self.item_thumbs[selection].opener.open_file() for selection in self.selected],
+                logger.info("Opening files", count=len(self.selected)),
+            )
+        )
+        shortcut = QtCore.QKeyCombination(
+            QtCore.Qt.KeyboardModifier(QtCore.Qt.KeyboardModifier.ControlModifier),
+            QtCore.Qt.Key.Key_Down,
+        )
+        if sys.platform == "win32":
+            shortcut = Qt.Key.Key_Return
+
+        open_selected_action.setShortcut(shortcut)
+        file_menu.addAction(open_selected_action)
         file_menu.addSeparator()
 
         close_library_action = QAction("&Close Library", menu_bar)

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -196,9 +196,7 @@ class ItemThumb(FlowWidget):
         self.thumb_button.setContextMenuPolicy(Qt.ContextMenuPolicy.ActionsContextMenu)
 
         self.opener = FileOpenerHelper("")
-        self.thumb_button.double_clicked.connect(
-            lambda: self.opener.open_file()
-        )
+        self.thumb_button.double_clicked.connect(lambda: self.opener.open_file())
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)
         open_explorer_action = QAction("Open file in explorer", self)

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -196,7 +196,7 @@ class ItemThumb(FlowWidget):
         self.thumb_button.setContextMenuPolicy(Qt.ContextMenuPolicy.ActionsContextMenu)
 
         self.opener = FileOpenerHelper("")
-        self.thumb_button.clicked.connect(
+        self.thumb_button.double_clicked.connect(
             lambda: self.opener.open_file() if self.thumb_button.selected else None
         )
         open_file_action = QAction("Open file", self)

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -197,7 +197,7 @@ class ItemThumb(FlowWidget):
 
         self.opener = FileOpenerHelper("")
         self.thumb_button.double_clicked.connect(
-            lambda: self.opener.open_file() if self.thumb_button.selected else None
+            lambda: self.opener.open_file()
         )
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -196,7 +196,7 @@ class ItemThumb(FlowWidget):
         self.thumb_button.setContextMenuPolicy(Qt.ContextMenuPolicy.ActionsContextMenu)
 
         self.opener = FileOpenerHelper("")
-        self.thumb_button.double_clicked.connect(lambda: self.opener.open_file())
+        self.thumb_button.double_clicked.connect(self.opener.open_file)
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)
         open_explorer_action = QAction("Open file in explorer", self)

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -218,6 +218,9 @@ class ItemThumb(FlowWidget):
 
         self.thumb_button.setContextMenuPolicy(Qt.ContextMenuPolicy.ActionsContextMenu)
         self.opener = FileOpenerHelper("")
+        self.thumb_button.clicked.connect(
+            lambda: self.opener.open_file() if self.thumb_button.selected else None
+        )
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)
         open_explorer_action = QAction("Open file in explorer", self)

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -101,8 +101,8 @@ class PreviewPanel(QWidget):
         self.open_file_action = QAction("Open file", self)
         self.open_file_action.setShortcut(
             QKeyCombination(
-                Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier,
-                Qt.Key.Key_O,
+                Qt.KeyboardModifier.ControlModifier,
+                Qt.Key.Key_Down,
             )
         )
         self.open_explorer_action = QAction("Open file in explorer", self)

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -13,7 +13,7 @@ import rawpy
 import structlog
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
-from PySide6.QtCore import Signal, Qt, QSize
+from PySide6.QtCore import Signal, Qt, QSize, QKeyCombination
 from PySide6.QtGui import QResizeEvent, QAction
 from PySide6.QtWidgets import (
     QWidget,
@@ -99,6 +99,12 @@ class PreviewPanel(QWidget):
         image_layout.setContentsMargins(0, 0, 0, 0)
 
         self.open_file_action = QAction("Open file", self)
+        self.open_file_action.setShortcut(
+            QKeyCombination(
+                Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier,
+                Qt.Key.Key_O,
+            )
+        )
         self.open_explorer_action = QAction("Open file in explorer", self)
 
         self.preview_img = QPushButtonWrapper()

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -14,7 +14,7 @@ import structlog
 from humanfriendly import format_size
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
-from PySide6.QtCore import QSize, Qt, Signal, QKeyCombination
+from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtGui import QAction, QResizeEvent
 from PySide6.QtWidgets import (
     QFrame,
@@ -96,12 +96,6 @@ class PreviewPanel(QWidget):
         image_layout.setContentsMargins(0, 0, 0, 0)
 
         self.open_file_action = QAction("Open file", self)
-        self.open_file_action.setShortcut(
-            QKeyCombination(
-                Qt.KeyboardModifier.ControlModifier,
-                Qt.Key.Key_Down,
-            )
-        )
         self.open_explorer_action = QAction("Open file in explorer", self)
 
         self.preview_img = QPushButtonWrapper()

--- a/tagstudio/src/qt/widgets/thumb_button.py
+++ b/tagstudio/src/qt/widgets/thumb_button.py
@@ -4,18 +4,30 @@
 
 
 from PySide6 import QtCore
-from PySide6.QtCore import QEvent
-from PySide6.QtGui import QColor, QEnterEvent, QPainter, QPainterPath, QPaintEvent, QPen
+from PySide6.QtCore import QEvent, Signal
+from PySide6.QtGui import (
+    QColor,
+    QEnterEvent,
+    QMouseEvent,
+    QPainter,
+    QPainterPath,
+    QPaintEvent,
+    QPen,
+)
 from PySide6.QtWidgets import QWidget
 from src.qt.helpers.qbutton_wrapper import QPushButtonWrapper
 
 
 class ThumbButton(QPushButtonWrapper):
+    double_clicked = Signal()
+
     def __init__(self, parent: QWidget, thumb_size: tuple[int, int]) -> None:
         super().__init__(parent)
         self.thumb_size: tuple[int, int] = thumb_size
         self.hovered = False
         self.selected = False
+
+        self.double_click = False
 
         # self.clicked.connect(lambda checked: self.set_selected(True))
 
@@ -81,3 +93,15 @@ class ThumbButton(QPushButtonWrapper):
     def set_selected(self, value: bool) -> None:
         self.selected = value
         self.repaint()
+
+    def mousePressEvent(self, e: QMouseEvent) -> None:  # noqa: N802
+        self.double_click = False
+
+    def mouseDoubleClickEvent(self, e: QMouseEvent) -> None:  # noqa: N802
+        self.double_click = True
+
+    def mouseReleaseEvent(self, e: QMouseEvent) -> None:  # noqa: N802
+        if self.double_click:
+            self.double_clicked.emit()
+        else:
+            self.clicked.emit()

--- a/tagstudio/src/qt/widgets/video_player.py
+++ b/tagstudio/src/qt/widgets/video_player.py
@@ -14,7 +14,6 @@ from PySide6.QtCore import (
     QTimer,
     QUrl,
     QVariantAnimation,
-    QKeyCombination,
 )
 from PySide6.QtGui import (
     QAction,
@@ -123,12 +122,7 @@ class VideoPlayer(QGraphicsView):
 
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)
-        open_file_action.setShortcut(
-            QKeyCombination(
-                Qt.KeyboardModifier.ControlModifier,
-                Qt.Key.Key_Down,
-            )
-        )
+
         open_explorer_action = QAction("Open file in explorer", self)
         open_explorer_action.triggered.connect(self.opener.open_explorer)
         self.addAction(open_file_action)

--- a/tagstudio/src/qt/widgets/video_player.py
+++ b/tagstudio/src/qt/widgets/video_player.py
@@ -131,8 +131,8 @@ class VideoPlayer(QGraphicsView):
         open_file_action.triggered.connect(self.opener.open_file)
         open_file_action.setShortcut(
             QKeyCombination(
-                Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier,
-                Qt.Key.Key_O,
+                Qt.KeyboardModifier.ControlModifier,
+                Qt.Key.Key_Down,
             )
         )
         open_explorer_action = QAction("Open file in explorer", self)

--- a/tagstudio/src/qt/widgets/video_player.py
+++ b/tagstudio/src/qt/widgets/video_player.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import (
     QObject,
     QEvent,
     QRectF,
+    QKeyCombination,
 )
 from PySide6.QtMultimedia import QMediaPlayer, QAudioOutput, QMediaDevices
 from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
@@ -128,6 +129,12 @@ class VideoPlayer(QGraphicsView):
 
         open_file_action = QAction("Open file", self)
         open_file_action.triggered.connect(self.opener.open_file)
+        open_file_action.setShortcut(
+            QKeyCombination(
+                Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier,
+                Qt.Key.Key_O,
+            )
+        )
         open_explorer_action = QAction("Open file in explorer", self)
         open_explorer_action.triggered.connect(self.opener.open_explorer)
         self.addAction(open_file_action)


### PR DESCRIPTION
Adds both double click functionality to thumbnails in the thumbnail grid and an open files shortcut `ctrl+shift+O`.