### PR TITLE
fix(ThumbRenderer): Use audio icon when no ffmpeg

### DIFF
--- a/tagstudio/src/qt/helpers/vendored/pydub/audio_segment.py
+++ b/tagstudio/src/qt/helpers/vendored/pydub/audio_segment.py
@@ -1,7 +1,7 @@
 # type: ignore
 # Copyright (C) 2022  James Robert (jiaaro).
 # Licensed under the MIT License.
-# Vendored from ffmpeg-python and ffmpeg-python PR#790 by amamic1803
+# Vendored from pydub
 
 from __future__ import division
 
@@ -729,7 +729,10 @@ class _AudioSegment(object):
             info = None
         else:
             # PATCHED
-            info = _mediainfo_json(orig_file, read_ahead_limit=read_ahead_limit)
+            try:
+                info = _mediainfo_json(orig_file, read_ahead_limit=read_ahead_limit)
+            except FileNotFoundError:
+                raise ChildProcessError
         if info:
             audio_streams = [x for x in info['streams']
                              if x['codec_type'] == 'audio']

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -565,6 +565,7 @@ class ThumbRenderer(QObject):
             logging.error(
                 f"[ThumbRenderer][WAVEFORM][ERROR]: Couldn't render waveform for {filepath.name} ({type(e).__name__})"
             )
+
         return im
 
     def _blender(self, filepath: Path) -> Image.Image:
@@ -1057,7 +1058,7 @@ class ThumbRenderer(QObject):
                     size=(adj_size, adj_size),
                     pixel_ratio=pixel_ratio,
                 )
-            except (UnidentifiedImageError, DecompressionBombError, ValueError) as e:
+            except (UnidentifiedImageError, DecompressionBombError, ValueError, ChildProcessError) as e:
                 logging.info(
                     f"[ThumbRenderer][ERROR]: Couldn't render thumbnail for {_filepath.name} ({type(e).__name__})"
                 )

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -1058,7 +1058,12 @@ class ThumbRenderer(QObject):
                     size=(adj_size, adj_size),
                     pixel_ratio=pixel_ratio,
                 )
-            except (UnidentifiedImageError, DecompressionBombError, ValueError, ChildProcessError) as e:
+            except (
+                UnidentifiedImageError,
+                DecompressionBombError,
+                ValueError,
+                ChildProcessError,
+            ) as e:
                 logging.info(
                     f"[ThumbRenderer][ERROR]: Couldn't render thumbnail for {_filepath.name} ({type(e).__name__})"
                 )


### PR DESCRIPTION
When FFmpeg is missing, Popen raises a FileNotFound error. This would be caught as an Unlinked file and use the broken file icon. The exception is now caught and a more appropriate exception is raised in its place.

Fixes: #461
![image](https://github.com/user-attachments/assets/1d44e82f-8c3f-41f6-8d47-27482a206afa)
