### PR TITLE
fix(PreviewPanel): Use birthtime for creation time on Mac & Windows

### DIFF
--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -492,10 +492,11 @@ class PreviewPanel(QWidget):
     def update_date_label(self, filepath: Path | None = None) -> None:
         """Update the "Date Created" and "Date Modified" file property labels."""
         if filepath and filepath.is_file():
+            created: dt = None
             if platform.system() == "Windows" or platform.system() == "Darwin":
-                created: dt = dt.fromtimestamp(filepath.stat().st_birthtime)
+                created = dt.fromtimestamp(filepath.stat().st_birthtime)  # type: ignore[attr-defined]
             else:
-                created: dt = dt.fromtimestamp(filepath.stat().st_ctime)
+                created = dt.fromtimestamp(filepath.stat().st_ctime)
             modified: dt = dt.fromtimestamp(filepath.stat().st_mtime)
             self.date_created_label.setText(
                 f"<b>Date Created:</b> {dt.strftime(created, "%a, %x, %X")}"

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -492,7 +492,10 @@ class PreviewPanel(QWidget):
     def update_date_label(self, filepath: Path | None = None) -> None:
         """Update the "Date Created" and "Date Modified" file property labels."""
         if filepath and filepath.is_file():
-            created: dt = dt.fromtimestamp(filepath.stat().st_ctime)
+            if platform.system() == "Windows" or platform.system() == "Darwin":
+                created: dt = dt.fromtimestamp(filepath.stat().st_birthtime)
+            else:
+                created: dt = dt.fromtimestamp(filepath.stat().st_ctime)
             modified: dt = dt.fromtimestamp(filepath.stat().st_mtime)
             self.date_created_label.setText(
                 f"<b>Date Created:</b> {dt.strftime(created, "%a, %x, %X")}"


### PR DESCRIPTION
st_ctime does not provide accurate creation time on MacOS, and as Python 3.12 is [deprecated for Windows](https://docs.python.org/3.12/library/os.html#os.stat_result.st_ctime). On these two platforms st_birthtime is used instead.
Tested on Linux and Windows

fixes #469