### PR TITLE
fix(Flake): Add missing x11 dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@
                     mypy
                     ruff
                     xorg.libxcb
+                    xorg.libX11
                     zstd
                   ])
                   ++ (with qt6Pkgs; [
@@ -162,6 +163,7 @@
                       stdenv.cc.cc.lib
                       wayland
                       xorg.libxcb
+                      xorg.libX11
                       xorg.libXrandr
                       zlib
                       zstd


### PR DESCRIPTION
Follow #332, tagstudio would no longer start (on wayland) without adding x11 as a dependency to the library path.
