### PR TITLE
Switch Linux CI to python docker image

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,17 +6,22 @@ jobs:
   pytest:
     name: Run tests
     runs-on: ubuntu-latest
-    container:
-      image: python:3.12-bullseye
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
       - name: Install system dependencies
         run: |
-          apt-get update && \
-          apt-get install -y --no-install-recommends \
+          # dont run update, it is slow 
+          # sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
             libxkbcommon-x11-0 \
             x11-utils \
             libyaml-dev \
@@ -29,9 +34,7 @@ jobs:
             libxcb-xinerama0 \
             libopengl0 \
             libxcb-cursor0 \
-            libpulse0 \
-            xvfb \
-            xauth
+            libpulse0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,22 +6,17 @@ jobs:
   pytest:
     name: Run tests
     runs-on: ubuntu-latest
+    container:
+      image: python:3.12-bullseye
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
       - name: Install system dependencies
         run: |
-          # dont run update, it is slow 
-          # sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          apt-get update && \
+          apt-get install -y --no-install-recommends \
             libxkbcommon-x11-0 \
             x11-utils \
             libyaml-dev \
@@ -34,7 +29,9 @@ jobs:
             libxcb-xinerama0 \
             libopengl0 \
             libxcb-cursor0 \
-            libpulse0
+            libpulse0 \
+            xvfb \
+            xauth
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,11 @@ jobs:
             build-flag: --portable
             suffix: _portable
     runs-on: ubuntu-22.04
+    container:
+      image: python:3.12-bullseye
+
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
       - run: pip install -Ur requirements.txt pyinstaller
       - run: pyinstaller tagstudio.spec -- ${{ matrix.build-flag }}
       - run: tar czfC dist/tagstudio_linux_x86_64${{ matrix.suffix }}.tar.gz dist tagstudio


### PR DESCRIPTION
Currently, the build CI for Linux uses Github's Ubuntu 22.04 VM image. Ubuntu 22.04 comes with Glibc 2.35, so this means that the Linux builds of TagStudio will only run on distributions that also come with Glibc >= 2.35. 

This PR changes that around so Githubs VM image is still being used, but inside that image it uses a Debian Bullseye docker container image with Python 3.12. Bullseye is a fair bit older and comes with Glibc 2.31. 

This change should add support for running TagStudio under Debian Bullseye (11), Ubuntu 20.04 (Focal) and Rocky Linux 9 (see #386), and any other Linux distributions coming with glibc < 2.35 and >= 2.31.  

I'm not sure if this change will have unintended side effects, but at least for me, TagStudio built with this change will actually start on Ubuntu 20.04 where before it just complained about a wrong Glibc version.

EDIT: Is this the correct target branch or should this target alpha-v9.4? Looks like the CI is a bit different between the two branches.