### PR TITLE
Fix tag search to not require wildcards

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -429,8 +429,8 @@ class Library:
             if search.tag:
                 query = query.where(
                     or_(
-                        Tag.name.ilike(search.tag),
-                        Tag.shorthand.ilike(search.tag),
+                        Tag.name.icontains(search.tag),
+                        Tag.shorthand.icontains(search.tag),
                     )
                 )
 

--- a/tagstudio/tests/test_library.py
+++ b/tagstudio/tests/test_library.py
@@ -85,9 +85,7 @@ def test_tag_search(library):
         FilterState(tag=tag.name.upper()),
     )
 
-    assert library.search_tags(
-        FilterState(tag=tag.name[2:-2])
-    )
+    assert library.search_tags(FilterState(tag=tag.name[2:-2]))
 
     assert not library.search_tags(
         FilterState(tag=tag.name * 2),

--- a/tagstudio/tests/test_library.py
+++ b/tagstudio/tests/test_library.py
@@ -85,6 +85,10 @@ def test_tag_search(library):
         FilterState(tag=tag.name.upper()),
     )
 
+    assert library.search_tags(
+        FilterState(tag=tag.name[2:-2])
+    )
+
     assert not library.search_tags(
         FilterState(tag=tag.name * 2),
     )


### PR DESCRIPTION
Previously, searching for tags required % wildcards to be added either side in order to search for a tag without an exact match, however this removes that requirement.