### PR TITLE
fix(QtDriver): Retain filter on directory refresh

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1091,7 +1091,13 @@ class QtDriver(QObject):
             )
         )
         r = CustomRunnable(lambda: iterator.run())
-        r.done.connect(lambda: (pw.hide(), pw.deleteLater(), self.filter_items(self.main_window.searchField.text())))
+        r.done.connect(
+            lambda: (
+                pw.hide(),
+                pw.deleteLater(),
+                self.filter_items(self.main_window.searchField.text()),
+            )
+        )
         QThreadPool.globalInstance().start(r)
 
     def new_file_macros_runnable(self, new_ids):

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1091,7 +1091,7 @@ class QtDriver(QObject):
             )
         )
         r = CustomRunnable(lambda: iterator.run())
-        r.done.connect(lambda: (pw.hide(), pw.deleteLater(), self.filter_items("")))
+        r.done.connect(lambda: (pw.hide(), pw.deleteLater(), self.filter_items(self.main_window.searchField.text())))
         QThreadPool.globalInstance().start(r)
 
     def new_file_macros_runnable(self, new_ids):


### PR DESCRIPTION
Keeps the filtered query thumbnails in the main window, rather than before where the search would remain in the bar but the filter would be reset to none.

Fixes #482 