### PR TITLE
feat: increase file scanning performance

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -898,7 +898,7 @@ class Library:
                 ):
                     # If the file/path is not mapped in the Library:
                     if self.filename_to_entry_id_map.get(f) is None:
-                        # Discord paths and files in unwanted folders.
+                        # Discard paths and files in unwanted folders.
                         if (
                             "$RECYCLE.BIN" not in f.parts
                             and TS_FOLDER_NAME not in f.parts

--- a/tagstudio/src/qt/modals/drop_import.py
+++ b/tagstudio/src/qt/modals/drop_import.py
@@ -106,6 +106,7 @@ class DropImport:
                 continue
 
             dest_file = self.get_relative_path(file)
+            full_dest_path: Path = self.driver.lib.library_dir / dest_file
 
             if file in self.duplicate_files:
                 duplicated_files_progress += 1
@@ -115,14 +116,12 @@ class DropImport:
                 if self.choice == 2:  # rename
                     new_name = self.get_renamed_duplicate_filename_in_lib(dest_file)
                     dest_file = dest_file.with_name(new_name)
-                    self.driver.lib.files_not_in_library.append(dest_file)
+                    self.driver.lib.files_not_in_library.append(full_dest_path)
             else:  # override is simply copying but not adding a new entry
-                self.driver.lib.files_not_in_library.append(dest_file)
+                self.driver.lib.files_not_in_library.append(full_dest_path)
 
-            (self.driver.lib.library_dir / dest_file).parent.mkdir(
-                parents=True, exist_ok=True
-            )
-            shutil.copyfile(file, self.driver.lib.library_dir / dest_file)
+            (full_dest_path).parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(file, full_dest_path)
 
             fileCount += 1
             yield [fileCount, duplicated_files_progress]


### PR DESCRIPTION
This pull request significantly increases file scanning performance, especially for rescanning libraries and for libraries with a large file to folder ratio.

Using a test library with around ~200k files (~100k filtered out via the exclusion list) on a standard 5400 RPM HDD, and found an average increase in library rescanning times of around 23x:
```yaml
v9.4.0:
[LIBRARY]: Scanned directories in 88.160 seconds
[LIBRARY]: Scanned directories in 87.398 seconds
[LIBRARY]: Scanned directories in 90.164 seconds
[LIBRARY]: Scanned directories in 88.031 seconds
[LIBRARY]: Scanned directories in 87.657 seconds

Optimized:
[LIBRARY]: Scanned directories in 3.823 seconds
[LIBRARY]: Scanned directories in 3.796 seconds
[LIBRARY]: Scanned directories in 3.771 seconds
[LIBRARY]: Scanned directories in 3.804 seconds
[LIBRARY]: Scanned directories in 3.901 seconds
```

Much of the existing scanning code was either in an unideal order, could have been deferred elsewhere, or was straight up unnecessary. The most impactful changes I made were:
- Only performing the `f.parts` and `f.is_dir()` checks for files that weren't already mapped in the library.
- Removing the need for the `relative_to()` method entirely by including the `library_dir` inside the `filename_to_entry_id_map` keys themselves. Most of the code accessing these keys had to tack on the `library_dir` anyway, so this improves performance in those areas as well.

Some of these techniques can be ported to `main`, however I started with the v9.4 branch since I was more familiar with this codebase and figured it would be a nice inclusion for a patch. 