### PR TITLE
Autocomplete tags in the preview panel

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -429,8 +429,8 @@ class Library:
             if search.tag:
                 query = query.where(
                     or_(
-                        Tag.name.ilike(search.tag),
-                        Tag.shorthand.ilike(search.tag),
+                        Tag.name.icontains(search.tag),
+                        Tag.shorthand.icontains(search.tag),
                     )
                 )
 

--- a/tagstudio/src/qt/flowlayout.py
+++ b/tagstudio/src/qt/flowlayout.py
@@ -140,4 +140,4 @@ class FlowLayout(QLayout):
                 x = next_x
                 line_height = max(line_height, item.sizeHint().height())
 
-        return y + line_height - rect.y() * ((len(self._item_list)) / len(self._item_list))
+        return y + line_height - rect.y()

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -4,6 +4,7 @@
 
 
 import math
+from typing import Optional
 
 import structlog
 from PySide6.QtCore import QSize, Qt, Signal
@@ -16,13 +17,11 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from typing import Optional
-
 from src.core.library import Library
 from src.core.library.alchemy.enums import FilterState
 from src.core.palette import ColorType, get_tag_color
 from src.qt.widgets.panel import PanelWidget
-from src.qt.widgets.tag import TagWidget, Tag
+from src.qt.widgets.tag import Tag, TagWidget
 
 logger = structlog.get_logger(__name__)
 

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -16,12 +16,13 @@ from PySide6.QtWidgets import (
     QScrollArea,
     QFrame,
 )
+from typing import Optional
 
 from src.core.library import Library
 from src.core.library.alchemy.enums import FilterState
 from src.core.palette import ColorType, get_tag_color
 from src.qt.widgets.panel import PanelWidget
-from src.qt.widgets.tag import TagWidget
+from src.qt.widgets.tag import TagWidget, Tag
 
 logger = structlog.get_logger(__name__)
 
@@ -33,7 +34,7 @@ class TagSearchPanel(PanelWidget):
         super().__init__()
         self.lib = library
         # self.callback = callback
-        self.first_tag_id = None
+        self.first_tag: Optional[Tag] = None
         self.tag_limit = 100
         # self.selected_tag: int = 0
         self.setMinimumSize(300, 400)
@@ -88,9 +89,9 @@ class TagSearchPanel(PanelWidget):
     # 	self.search_field.setFocus()
 
     def on_return(self, text: str):
-        if text and self.first_tag_id is not None:
-            # callback(self.first_tag_id)
-            self.tag_chosen.emit(self.first_tag_id)
+        if text and self.first_tag is not None:
+            # callback(self.first_tag)
+            self.tag_chosen.emit(self.first_tag.id)
             self.search_field.setText("")
             self.update_tags()
         else:
@@ -103,10 +104,13 @@ class TagSearchPanel(PanelWidget):
 
         found_tags = self.lib.search_tags(
             FilterState(
-                path=name,
+                tag=name,
                 page_size=self.tag_limit,
             )
         )
+
+        if len(found_tags) > 0:
+            self.first_tag = found_tags[0]
 
         for tag in found_tags:
             c = QWidget()

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -109,8 +109,7 @@ class TagSearchPanel(PanelWidget):
             )
         )
 
-        if len(found_tags) > 0:
-            self.first_tag = found_tags[0]
+        self.first_tag = found_tags[0] if found_tags else None
 
         for tag in found_tags:
             c = QWidget()

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -70,9 +70,11 @@ class TagSearchPanel(PanelWidget):
             self.tag_chosen.emit(self.first_tag.id)
             self.search_field.setText("")
             self.update_tags()
+            return True
         else:
             self.search_field.setFocus()
             self.parentWidget().hide()
+            return False
 
     def update_tags(self, name: str | None = None):
         while self.scroll_layout.count():

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -112,7 +112,7 @@ class TagBoxWidget(FieldWidget):
         self.add_modal = PanelModal(tsp, title, "Add Tags")
 
         self.add_button.clicked.connect(
-            lambda: (self.add_modal.show(), tsp.update_tags(tsp.search_field))
+            lambda: (self.add_modal.show(), tsp.update_tags(tsp.search_field.text()))
         )
         self.tag_entry.textChanged.connect(
             lambda text: (

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -7,10 +7,10 @@ import math
 import typing
 
 import structlog
-from PySide6.QtCore import Qt, Signal, QStringListModel, QObject
-from PySide6.QtWidgets import QPushButton, QLineEdit, QCompleter
-from src.core.constants import TAG_FAVORITE, TAG_ARCHIVED
-from src.core.library import Library, Entry, Tag
+from PySide6.QtCore import QObject, QStringListModel, Qt, Signal
+from PySide6.QtWidgets import QCompleter, QLineEdit, QPushButton
+from src.core.constants import TAG_ARCHIVED, TAG_FAVORITE
+from src.core.library import Entry, Library, Tag
 from src.core.library.alchemy.enums import FilterState
 from src.core.library.alchemy.fields import TagBoxField
 from src.qt.flowlayout import FlowLayout
@@ -35,7 +35,7 @@ class TagCompleter(QCompleter):
     def update(self, exclude: set[str]):
         tags = {tag.name for tag in self.lib.tags}
         tags -= exclude
-        model = QStringListModel(tags, self)
+        model = QStringListModel(list(tags), self)
         self.setModel(model)
 
 

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -103,11 +103,12 @@ class TagBoxWidget(FieldWidget):
         )
         self.add_modal = PanelModal(tsp, title, "Add Tags")
 
-        self.add_button.clicked.connect(self.add_modal.show)
+        self.add_button.clicked.connect(
+            lambda: (self.add_modal.show(), tsp.update_tags(tsp.search_field))
+        )
         self.tag_entry.textChanged.connect(
             lambda text: (
                 tsp.search_field.setText(text),
-                tsp.update_tags(text),
                 self.tag_completer.setCompletionPrefix(text),
                 self.tag_completer.complete(),
             )
@@ -118,8 +119,7 @@ class TagBoxWidget(FieldWidget):
         self.tag_completer.activated.connect(
             lambda selected: (
                 tsp.update_tags(selected),
-                tsp.on_return(selected),
-                self.tag_entry.clear(),
+                self.tag_entry.clear() if tsp.on_return(selected) else (),
             )
         )
 

--- a/tagstudio/tests/qt/test_tag_widget.py
+++ b/tagstudio/tests/qt/test_tag_widget.py
@@ -73,7 +73,7 @@ def test_tag_widget_remove(qtbot, qt_driver, library, entry_full):
 
     qtbot.add_widget(tag_widget)
 
-    tag_widget = tag_widget.base_layout.itemAt(0).widget()
+    tag_widget = tag_widget.tags_layout.itemAt(0).widget()
     assert isinstance(tag_widget, TagWidget)
 
     tag_widget.remove_button.clicked.emit()
@@ -95,7 +95,7 @@ def test_tag_widget_edit(qtbot, qt_driver, library, entry_full):
 
     qtbot.add_widget(tag_box_widget)
 
-    tag_widget = tag_box_widget.base_layout.itemAt(0).widget()
+    tag_widget = tag_box_widget.tags_layout.itemAt(0).widget()
     assert isinstance(tag_widget, TagWidget)
 
     # When

--- a/tagstudio/tests/qt/test_tag_widget.py
+++ b/tagstudio/tests/qt/test_tag_widget.py
@@ -120,6 +120,8 @@ def test_tag_widget_autocomplete(qtbot, qt_driver, library):
 
     qtbot.add_widget(tag_widget)
 
+    assert len(entry.tags) == 1
+
     # Test autocomplete
     tag_widget.tag_entry.setText("arch")
     tag_widget.tag_entry.returnPressed.emit()

--- a/tagstudio/tests/qt/test_tag_widget.py
+++ b/tagstudio/tests/qt/test_tag_widget.py
@@ -108,3 +108,27 @@ def test_tag_widget_edit(qtbot, qt_driver, library, entry_full):
     assert isinstance(panel, BuildTagPanel)
     assert panel.tag.name == tag.name
     assert panel.name_field.text() == tag.name
+
+def test_tag_widget_autocomplete(qtbot, qt_driver, library):
+    # Given
+    entry = next(library.get_entries(with_joins=True))
+    field = entry.tag_box_fields[0]
+
+    tag_widget = TagBoxWidget(field, "title", qt_driver)
+    tag_widget.driver.selected = [0]
+
+    qtbot.add_widget(tag_widget)
+
+    # Test autocomplete
+    tag_widget.tag_entry.setText("arch")
+    tag_widget.tag_entry.returnPressed.emit()
+
+    entry = next(library.get_entries(with_joins=True)) # Update entry
+    assert len(entry.tags) == 2
+
+    # Test unmatched autocomplete
+    tag_widget.tag_completer.activated.emit("missing")
+
+    entry = next(library.get_entries(with_joins=True)) # Update entry
+    assert len(entry.tags) == 2
+

--- a/tagstudio/tests/qt/test_tag_widget.py
+++ b/tagstudio/tests/qt/test_tag_widget.py
@@ -109,6 +109,7 @@ def test_tag_widget_edit(qtbot, qt_driver, library, entry_full):
     assert panel.tag.name == tag.name
     assert panel.name_field.text() == tag.name
 
+
 def test_tag_widget_autocomplete(qtbot, qt_driver, library):
     # Given
     entry = next(library.get_entries(with_joins=True))
@@ -123,12 +124,11 @@ def test_tag_widget_autocomplete(qtbot, qt_driver, library):
     tag_widget.tag_entry.setText("arch")
     tag_widget.tag_entry.returnPressed.emit()
 
-    entry = next(library.get_entries(with_joins=True)) # Update entry
+    entry = next(library.get_entries(with_joins=True))  # Update entry
     assert len(entry.tags) == 2
 
     # Test unmatched autocomplete
     tag_widget.tag_completer.activated.emit("missing")
 
-    entry = next(library.get_entries(with_joins=True)) # Update entry
+    entry = next(library.get_entries(with_joins=True))  # Update entry
     assert len(entry.tags) == 2
-


### PR DESCRIPTION
Adds autocomplete to tags in the preview panel, for all tag fields.
You can now add tags through several methods:
1. Beginning to type a tag's name and
    a. Clicking enter to get the first tag that matches the text
    b. Using the arrow keys to select a tag from the autocomplete popup
    c. Clicking on a tag from the autocomplete popup
2. Clicking the plus button and using the previous tag modal.

Requires #481 