### PR TITLE
fix running mypy from project directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ disable_error_code = ["func-returns-value", "import-untyped"]
 explicit_package_bases = true
 warn_unused_ignores = true
 check_untyped_defs = true
+mypy_path = ["tagstudio"]
 
 [[tool.mypy.overrides]]
 module = "tests.*"


### PR DESCRIPTION
Prior to this change, running mypy from the root directory of the repo would log errors, because mypy couldn't find the referenced implementations for import statements like this one: `from src.qt.ts_qt import QtDriver`. This change tells mypy that it can find these implementations in the `tagstudio` directory.
Fixing this is necessary for the MyPy Extension for VSCode to work and it shouldn't break the existing workflows since running mypy in the `tagstudio` directory still yields the same results as before.