### PR TITLE
ci: pin pytest ubuntu version to 22.04

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
   pytest:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
This pins the Ubuntu version for the pytest workflow to 22.04. This restores the workflow functionality, at least in the meantime while a proper fix for the Ubuntu 24 error is created. 