### PR TITLE
[9.4.x] Create auto-backup of library for use in save failures (Fix #343)

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -507,24 +507,25 @@ class Library:
 
         except (ujson.JSONDecodeError, FileNotFoundError):
             logging.info(
-                "[LIBRARY][WARNING] Blank/Corrupted Library file found. Searching for Auto Backup..."
+                "[LIBRARY][ERROR] Blank/Corrupted Library file found. Searching for Auto Backup..."
             )
             backup_folder: Path = (
                 self._fix_lib_path(path) / TS_FOLDER_NAME / BACKUP_FOLDER_NAME
             )
-            auto_backup: Path = None
-            dir_obj = os.scandir(backup_folder)
+            if backup_folder.exists():
+                auto_backup: Path = None
+                dir_obj = os.scandir(backup_folder)
 
-            for backup_file in dir_obj:
-                if backup_file.is_file() and "ts_library_backup_auto" in str(
-                    backup_file
-                ):
-                    auto_backup = Path(backup_file)
-                    break
+                for backup_file in dir_obj:
+                    if backup_file.is_file() and "ts_library_backup_auto" in str(
+                        backup_file
+                    ):
+                        auto_backup = Path(backup_file)
+                        break
 
-            if auto_backup and "ts_library_backup_auto" not in str(path):
-                logging.info(f"[LIBRARY] Loading Auto Backup: {auto_backup}")
-                return self.open_library(auto_backup, is_path_file=True)
+                if auto_backup and "ts_library_backup_auto" not in str(path):
+                    logging.info(f"[LIBRARY] Loading Auto Backup: {auto_backup}")
+                    return self.open_library(auto_backup, is_path_file=True)
 
         else:
             self.library_dir = self._fix_lib_path(path)
@@ -727,7 +728,7 @@ class Library:
                     c = Collation(
                         id=id,
                         title=title,
-                        e_ids_and_pages=e_ids_and_pages,  # type: ignore
+                        e_ids_and_pages=e_ids_and_pages,
                         sort_order=sort_order,
                         cover_id=cover_id,
                     )

--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -799,12 +799,13 @@ class Library:
 
         self.verify_ts_folders()
 
+        json_library: JsonLibary = self.to_json()
         with open(
             self.library_dir / TS_FOLDER_NAME / filename, "w", encoding="utf-8"
         ) as outfile:
             outfile.flush()
             ujson.dump(
-                self.to_json(),
+                json_library,
                 outfile,
                 ensure_ascii=False,
                 escape_forward_slashes=False,


### PR DESCRIPTION
This PR adds a basic library autosave feature which creates a copy of the library on load which can be automatically loaded in the event that the main library becomes blank or missing. In addition, this moves the `self.to_json()` call inside the library save method to outside of the `with` block as suggested in #343, which should prevent most cases of TagStudio writing a blank library to disk.

I'm looking at this as a bugfix to be added in a future 9.4.2 patch. Since 9.5/main uses a completely different SQLite backend, this change is really just to provide a bit more safety and stability for the current 9.4.x releases in the meantime. This "feature" will die with that branch and is effectively obsolete as-is (not to sound somber). 