### PR TITLE
Change item select to press instead of release (click)

### DIFF
--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -381,9 +381,9 @@ class ItemThumb(FlowWidget):
     def update_clickable(self, clickable: typing.Callable):
         """Updates attributes of a thumbnail element."""
         if self.thumb_button.is_connected:
-            self.thumb_button.clicked.disconnect()
+            self.thumb_button.pressed.disconnect()
         if clickable:
-            self.thumb_button.clicked.connect(clickable)
+            self.thumb_button.pressed.connect(clickable)
             self.thumb_button.is_connected = True
 
     def refresh_badge(self, entry: Entry | None = None):


### PR DESCRIPTION
For #555. I think it's better to add this to the settings, but leave it as default