### PR TITLE
feat: allow multiple directories per library

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           python -m pip install --upgrade uv
           uv pip install --system -r requirements.txt
-          uv pip install --system mypy==1.11.2
+          uv pip install --system mypy==1.13.0
           mkdir tagstudio/.mypy_cache
 
       - uses: tsuyoshicho/action-mypy@v4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ ruff==0.6.4
 pre-commit==3.7.0
 pytest==8.2.0
 Pyinstaller==6.6.0
-mypy==1.11.2
+mypy==1.13.0
 syrupy==4.7.1
 pytest-qt==4.4.0
 pytest-cov==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ PySide6_Addons==6.7.1
 PySide6_Essentials==6.7.1
 PySide6==6.7.1
 rawpy==0.21.0
-SQLAlchemy==2.0.34
+SQLAlchemy==2.0.36
 structlog==24.4.0
 typing_extensions>=3.10.0.0,<=4.11.0
 ujson>=5.8.0,<=5.9.0

--- a/tagstudio/src/core/constants.py
+++ b/tagstudio/src/core/constants.py
@@ -2,9 +2,9 @@ VERSION: str = "9.5.0"  # Major.Minor.Patch
 VERSION_BRANCH: str = "EXPERIMENTAL"  # Usually "" or "Pre-Release"
 
 # The folder & file names where TagStudio keeps its data relative to a library.
-TS_FOLDER_NAME: str = ".TagStudio"
 BACKUP_FOLDER_NAME: str = "backups"
 COLLAGE_FOLDER_NAME: str = "collages"
+TS_FOLDER_NOINDEX: str = ".ts_noindex"
 
 FONT_SAMPLE_TEXT: str = (
     """ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?@$%(){}[]"""

--- a/tagstudio/src/core/driver.py
+++ b/tagstudio/src/core/driver.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import structlog
 from PySide6.QtCore import QSettings
-from src.core.constants import TS_FOLDER_NAME
 from src.core.enums import SettingItems
 from src.core.library.alchemy.library import LibraryStatus
 
@@ -14,27 +13,26 @@ class DriverMixin:
 
     def evaluate_path(self, open_path: str | None) -> LibraryStatus:
         """Check if the path of library is valid."""
-        library_path: Path | None = None
+        storage_path: Path | None = None
         if open_path:
-            library_path = Path(open_path)
-            if not library_path.exists():
+            storage_path = Path(open_path)
+            if not storage_path.exists():
                 logger.error("Path does not exist.", open_path=open_path)
                 return LibraryStatus(success=False, message="Path does not exist.")
         elif self.settings.value(
             SettingItems.START_LOAD_LAST, defaultValue=True, type=bool
         ) and self.settings.value(SettingItems.LAST_LIBRARY):
-            library_path = Path(str(self.settings.value(SettingItems.LAST_LIBRARY)))
-            if not (library_path / TS_FOLDER_NAME).exists():
+            storage_path = Path(str(self.settings.value(SettingItems.LAST_LIBRARY)))
+            if not storage_path.exists():
                 logger.error(
                     "TagStudio folder does not exist.",
-                    library_path=library_path,
-                    ts_folder=TS_FOLDER_NAME,
+                    storage_path=storage_path,
                 )
                 self.settings.setValue(SettingItems.LAST_LIBRARY, "")
                 # dont consider this a fatal error, just skip opening the library
-                library_path = None
+                storage_path = None
 
         return LibraryStatus(
             success=True,
-            library_path=library_path,
+            storage_path=storage_path,
         )

--- a/tagstudio/src/core/enums.py
+++ b/tagstudio/src/core/enums.py
@@ -3,13 +3,14 @@ from typing import Any
 from uuid import uuid4
 
 
-class SettingItems(str, enum.Enum):
+class SettingItems(enum.StrEnum):
     """List of setting item names."""
 
     START_LOAD_LAST = "start_load_last"
-    LAST_LIBRARY = "last_library"
+    LAST_LIBRARY = "last_storage"
     LIBS_LIST = "libs_list"
     WINDOW_SHOW_LIBS = "window_show_libs"
+    WINDOW_SHOW_DIRS = "window_show_dirs"
     AUTOPLAY = "autoplay_videos"
 
 
@@ -23,12 +24,6 @@ class Theme(str, enum.Enum):
     COLOR_PRESSED = "#65EEEEEE"
     COLOR_DISABLED = "#65F39CAA"
     COLOR_DISABLED_BG = "#65440D12"
-
-
-class OpenStatus(enum.IntEnum):
-    NOT_FOUND = 0
-    SUCCESS = 1
-    CORRUPTED = 2
 
 
 class MacroID(enum.Enum):
@@ -64,4 +59,4 @@ class LibraryPrefs(DefaultEnum):
     IS_EXCLUDE_LIST = True
     EXTENSION_LIST: list[str] = [".json", ".xmp", ".aae"]
     PAGE_SIZE: int = 500
-    DB_VERSION: int = 2
+    LIBRARY_NAME: str = "TS Library"

--- a/tagstudio/src/core/library/alchemy/models.py
+++ b/tagstudio/src/core/library/alchemy/models.py
@@ -117,7 +117,7 @@ class Entry(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
 
     folder_id: Mapped[int] = mapped_column(ForeignKey("folders.id"))
-    folder: Mapped[Folder] = relationship("Folder")
+    folder: Mapped[Folder] = relationship("Folder", lazy=False)
 
     path: Mapped[Path] = mapped_column(PathType, unique=True)
     suffix: Mapped[str] = mapped_column()
@@ -134,6 +134,10 @@ class Entry(Base):
         back_populates="entry",
         cascade="all, delete",
     )
+
+    @property
+    def absolute_path(self) -> Path:
+        return self.folder.path / self.path
 
     @property
     def fields(self) -> list[BaseField]:

--- a/tagstudio/src/core/library/json/enums.py
+++ b/tagstudio/src/core/library/json/enums.py
@@ -1,0 +1,9 @@
+import enum
+
+TS_FOLDER_NAME = ".TagStudio"
+
+
+class OpenStatus(enum.IntEnum):
+    NOT_FOUND = 0
+    SUCCESS = 1
+    CORRUPTED = 2

--- a/tagstudio/src/core/library/json/library.py
+++ b/tagstudio/src/core/library/json/library.py
@@ -20,14 +20,13 @@ from pathlib import Path
 from typing import cast, Generator
 from typing_extensions import Self
 
+from .enums import OpenStatus, TS_FOLDER_NAME
 from .fields import DEFAULT_FIELDS, TEXT_FIELDS
-from src.core.enums import OpenStatus
 from src.core.utils.str import strip_punctuation
 from src.core.utils.web import strip_web_protocol
 from src.core.constants import (
     BACKUP_FOLDER_NAME,
     COLLAGE_FOLDER_NAME,
-    TS_FOLDER_NAME,
     VERSION,
 )
 

--- a/tagstudio/src/core/ts_core.py
+++ b/tagstudio/src/core/ts_core.py
@@ -7,7 +7,6 @@
 import json
 from pathlib import Path
 
-from src.core.constants import TS_FOLDER_NAME
 from src.core.library import Entry, Library
 from src.core.library.alchemy.fields import _FieldID
 from src.core.utils.missing_files import logger
@@ -97,7 +96,7 @@ class TagStudioCore:
         """Match defined conditions against a file to add Entry data."""
         # TODO - what even is this file format?
         # TODO: Make this stored somewhere better instead of temporarily in this JSON file.
-        cond_file = lib.library_dir / TS_FOLDER_NAME / "conditions.json"
+        cond_file = lib.storage_path / "conditions.json"
         if not cond_file.is_file():
             return False
 

--- a/tagstudio/src/core/utils/dupe_files.py
+++ b/tagstudio/src/core/utils/dupe_files.py
@@ -20,50 +20,52 @@ class DupeRegistry:
     def groups_count(self) -> int:
         return len(self.groups)
 
-    def refresh_dupe_files(self, results_filepath: str | Path):
+    def refresh_dupe_files(self, dupe_results: str | Path):
         """Refresh the list of duplicate files.
 
         A duplicate file is defined as an identical or near-identical file as determined
         by a DupeGuru results file.
         """
-        library_dir = self.library.library_dir
-        if not isinstance(results_filepath, Path):
-            results_filepath = Path(results_filepath)
+        if not isinstance(dupe_results, Path):
+            dupe_results = Path(dupe_results)
 
-        if not results_filepath.is_file():
+        if not dupe_results.is_file():
             raise ValueError("invalid file path")
 
         self.groups.clear()
-        tree = ET.parse(results_filepath)
+        tree = ET.parse(dupe_results)
         root = tree.getroot()
+        folders = self.library.get_folders()
+
         for group in root:
-            # print(f'-------------------- Match Group {i}---------------------')
-            files: list[Entry] = []
+            files: dict = {}
             for element in group:
-                if element.tag == "file":
-                    file_path = Path(element.attrib.get("path"))
-
-                    try:
-                        path_relative = file_path.relative_to(library_dir)
-                    except ValueError:
-                        # The file is not in the library directory
-                        continue
-
-                    results = self.library.search_library(
-                        FilterState(path=path_relative),
-                    )
-
-                    if not results:
-                        # file not in library
-                        continue
-
-                    files.append(results[0])
-
-                if not len(files) > 1:
-                    # only one file in the group, nothing to do
+                if element.tag != "file":
                     continue
 
-            self.groups.append(files)
+                file_path = Path(element.attrib.get("path"))
+                for folder in folders:
+                    if file_path.is_relative_to(folder.path):
+                        path_relative = file_path.relative_to(folder.path)
+                        results = self.library.search_library(
+                            FilterState(
+                                include_folders={folder.id},
+                                path=path_relative,
+                            ),
+                        )
+
+                        if results:
+                            for item in results.items:
+                                files[item.path] = item
+                            break
+                else:
+                    continue
+
+            if not len(files) > 1:
+                # only one file in the group, nothing to do
+                continue
+
+            self.groups.append(list(files.values()))
 
     def merge_dupe_entries(self):
         """Merge the duplicate Entry items.

--- a/tagstudio/src/core/utils/missing_files.py
+++ b/tagstudio/src/core/utils/missing_files.py
@@ -29,21 +29,23 @@ class MissingRegistry:
         logger.info("refresh_missing_files running")
         self.missing_files = []
         for i, entry in enumerate(self.library.get_entries()):
-            full_path = self.library.library_dir / entry.path
+            full_path = entry.absolute_path
             if not full_path.exists() or not full_path.is_file():
                 self.missing_files.append(entry)
             yield i
 
     def match_missing_file(self, match_item: Entry) -> list[Path]:
-        """Try to find missing entry files within the library directory.
+        """Try to find missing entry files within the library directories.
 
         Works if files were just moved to different subfolders and don't have duplicate names.
         """
         matches = []
-        for item in self.library.library_dir.glob(f"**/{match_item.path.name}"):
-            if item.name == match_item.path.name:  # TODO - implement IGNORE_ITEMS
-                new_path = Path(item).relative_to(self.library.library_dir)
-                matches.append(new_path)
+        folders = self.library.get_folders()
+        for folder in folders:
+            for item in folder.path.glob(f"**/{match_item.path.name}"):
+                if item.name == match_item.path.name:  # TODO - implement IGNORE_ITEMS
+                    new_path = Path(item).relative_to(folder.path)
+                    matches.append(new_path)
 
         return matches
 

--- a/tagstudio/src/core/utils/refresh_dir.py
+++ b/tagstudio/src/core/utils/refresh_dir.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from time import time
 
 import structlog
-from src.core.constants import TS_FOLDER_NAME
+from src.core import constants
 from src.core.library import Entry, Library
+from src.core.library.alchemy.models import Folder
 
 logger = structlog.get_logger(__name__)
 
@@ -13,7 +14,8 @@ logger = structlog.get_logger(__name__)
 @dataclass
 class RefreshDirTracker:
     library: Library
-    files_not_in_library: list[Path] = field(default_factory=list)
+    dir_files_count: int = 0
+    files_not_in_library: list[tuple[Folder, Path]] = field(default_factory=list)
 
     @property
     def files_count(self) -> int:
@@ -24,12 +26,12 @@ class RefreshDirTracker:
         if not self.files_not_in_library:
             yield 0
 
-        for idx, entry_path in enumerate(self.files_not_in_library):
+        for idx, (folder, entry_path) in enumerate(self.files_not_in_library):
             self.library.add_entries(
                 [
                     Entry(
                         path=entry_path,
-                        folder=self.library.folder,
+                        folder=folder,
                         fields=self.library.default_fields,
                     )
                 ]
@@ -38,40 +40,68 @@ class RefreshDirTracker:
 
         self.files_not_in_library = []
 
-    def refresh_dir(self, lib_path: Path) -> Iterator[int]:
-        """Scan a directory for files, and add those relative filenames to internal variables."""
-        if self.library.library_dir is None:
-            raise ValueError("No library directory set.")
+    def refresh_dirs(self, folders: list[Folder]) -> Iterator[int]:
+        """Scan a directory for changes.
+
+        - Keep track of files which are not in library.
+        - Remove files from library which are in ignored dirs.
+        """
+        if isinstance(folders, Folder):
+            folders = [folders]
 
         start_time_total = time()
-        start_time_loop = time()
 
         self.files_not_in_library = []
-        dir_file_count = 0
+        self.dir_files_count = 0
 
-        for path in lib_path.glob("**/*"):
-            str_path = str(path)
-            if path.is_dir():
-                continue
-
-            if "$RECYCLE.BIN" in str_path or TS_FOLDER_NAME in str_path:
-                continue
-
-            dir_file_count += 1
-            relative_path = path.relative_to(lib_path)
-            # TODO - load these in batch somehow
-            if not self.library.has_path_entry(relative_path):
-                self.files_not_in_library.append(relative_path)
-
-            # Yield output every 1/30 of a second
-            if (time() - start_time_loop) > 0.034:
-                yield dir_file_count
-                start_time_loop = time()
+        for folder in folders:
+            # yield values from self._refresh_dir
+            yield from self._refresh_dir(folder)
 
         end_time_total = time()
         logger.info(
             "Directory scan time",
-            path=lib_path,
             duration=(end_time_total - start_time_total),
-            new_files_count=dir_file_count,
+            new_files_count=self.dir_files_count,
         )
+
+    def _refresh_dir(self, folder: Folder) -> Iterator[int]:
+        start_time_loop = time()
+        folder_path = folder.path
+        for root, _, files in folder_path.walk():
+            if "$RECYCLE.BIN" in str(root).upper():
+                continue
+
+            # - if directory contains file `.ts_noindex` then skip the directory
+            if constants.TS_FOLDER_NOINDEX in files:
+                logger.info("TS Ignore File found, skipping", directory=root)
+                # however check if the ignored files aren't in the library; if so, remove them
+                entries_to_remove = []
+                for file in files:
+                    file_path = root / file
+                    entry_path = file_path.relative_to(folder_path)
+                    if entry := self.library.get_path_entry(entry_path):
+                        entries_to_remove.append(entry.id)
+
+                    # Yield output every 1/30 of a second
+                    if (time() - start_time_loop) > 0.034:
+                        # yield but dont increase the count
+                        yield self.dir_files_count
+                        start_time_loop = time()
+
+                self.library.remove_entries(entries_to_remove)
+                continue
+
+            for file in files:
+                path = root / file
+                self.dir_files_count += 1
+
+                relative_path = path.relative_to(folder_path)
+                # TODO - load these in batch somehow
+                if not self.library.get_path_entry(relative_path):
+                    self.files_not_in_library.append((folder, relative_path))
+
+                # Yield output every 1/30 of a second
+                if (time() - start_time_loop) > 0.034:
+                    yield self.dir_files_count
+                    start_time_loop = time()

--- a/tagstudio/src/qt/enums.py
+++ b/tagstudio/src/qt/enums.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class WindowContent(enum.Enum):
+    LANDING_PAGE = 0
+    LIBRARY_EMPTY = 1
+    LIBRARY_CONTENT = 2

--- a/tagstudio/src/qt/modals/fix_dupes.py
+++ b/tagstudio/src/qt/modals/fix_dupes.py
@@ -108,7 +108,7 @@ class FixDupeFilesModal(QWidget):
         self.set_dupe_count(-1)
 
     def select_file(self):
-        qfd = QFileDialog(self, "Open DupeGuru Results File", str(self.lib.library_dir))
+        qfd = QFileDialog(self, "Open DupeGuru Results File", str(self.lib.storage_path))
         qfd.setFileMode(QFileDialog.FileMode.ExistingFile)
         qfd.setNameFilter("DupeGuru Files (*.dupeguru)")
         if qfd.exec_():

--- a/tagstudio/src/qt/modals/library_name.py
+++ b/tagstudio/src/qt/modals/library_name.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+)
+
+
+class LABELS:
+    NO_FOLDER = "No folder selected."
+    CHOOSE_NAME = "Choose Library Name"
+    SELECT_FOLDER = "Select Metadata Folder"
+
+
+class LibraryNameDialog(QDialog):
+    chosen_path: Path | None
+
+    def __init__(self):
+        super().__init__()
+
+        self.setFixedWidth(400)
+
+        self.chosen_path = None
+
+        self.setWindowTitle(LABELS.CHOOSE_NAME)
+
+        layout = QVBoxLayout()
+
+        label = QLabel(LABELS.CHOOSE_NAME)
+        layout.addWidget(label)
+
+        self.library_name_input = QLineEdit(self)
+        self.library_name_input.textChanged.connect(self.update_storage_label)
+        layout.addWidget(self.library_name_input)
+
+        self.storage_explanation = QLabel("Select a folder where library metadata will be stored.")
+        layout.addWidget(self.storage_explanation)
+
+        choose_directory_button = QPushButton(LABELS.SELECT_FOLDER, self)
+        choose_directory_button.clicked.connect(self.choose_directory)
+        layout.addWidget(choose_directory_button)
+
+        self.directory_label = QLabel(LABELS.NO_FOLDER)
+        layout.addWidget(self.directory_label)
+
+        cancel_button = QPushButton("Cancel", self)
+        cancel_button.clicked.connect(self.reject)
+
+        ok_button = QPushButton("OK", self)
+        ok_button.clicked.connect(self.accept)
+
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(cancel_button)
+        button_layout.addWidget(ok_button)
+
+        layout.addLayout(button_layout)
+        self.setLayout(layout)
+
+    def get_storage_path(self) -> Path:
+        # return self.chosen_path / f"TS {self.get_library_name()}"
+        return self.chosen_path / self.get_library_name()
+
+    def get_library_name(self):
+        return self.library_name_input.text().strip()
+
+    def choose_directory(self):
+        """Open a dialog to choose a directory and display the selected path."""
+        directory = QFileDialog.getExistingDirectory(self, LABELS.SELECT_FOLDER)
+        if directory:
+            self.chosen_path = Path(directory)
+            self.update_storage_label()
+
+    def update_storage_label(self):
+        if self.chosen_path:
+            self.directory_label.setText(f"Metadata Storage Folder: {self.get_storage_path()}")
+        else:
+            self.directory_label.setText(LABELS.NO_FOLDER)

--- a/tagstudio/src/qt/widgets/collage_icon.py
+++ b/tagstudio/src/qt/widgets/collage_icon.py
@@ -38,7 +38,7 @@ class CollageIconRenderer(QObject):
         keep_aspect,
     ):
         entry = self.lib.get_entry(entry_id)
-        filepath = self.lib.library_dir / entry.path
+        filepath = entry.absolute_path
         color: str = ""
 
         try:
@@ -79,7 +79,7 @@ class CollageIconRenderer(QObject):
                 ext: str = filepath.suffix.lower()
                 if MediaCategories.is_ext_in_category(ext, MediaCategories.IMAGE_TYPES):
                     try:
-                        with Image.open(str(self.lib.library_dir / entry.path)) as pic:
+                        with Image.open(str(entry.absolute_path)) as pic:
                             if keep_aspect:
                                 pic.thumbnail(size)
                             else:

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -295,8 +295,8 @@ class ItemThumb(FlowWidget):
     def is_archived(self):
         return self.badge_active[BadgeType.ARCHIVED]
 
-    def set_mode(self, mode: ItemType | None) -> None:
-        if mode is None:
+    def set_mode(self, mode: ItemType) -> None:
+        if mode == ItemType.NONE:
             self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, on=True)
             self.unsetCursor()
             self.thumb_button.setHidden(True)
@@ -401,14 +401,13 @@ class ItemThumb(FlowWidget):
         self.assign_badge(BadgeType.FAVORITE, entry.is_favorited)
 
     def set_item_id(self, entry: Entry):
-        filepath = self.lib.library_dir / entry.path
-        self.opener.set_filepath(filepath)
+        self.opener.set_filepath(entry.absolute_path)
         self.item_id = entry.id
 
     def assign_badge(self, badge_type: BadgeType, value: bool) -> None:
         mode = self.mode
-        # blank mode to avoid recursive badge updates
-        self.mode = None
+        # none mode to avoid recursive badge updates
+        self.mode = ItemType.NONE
         badge = self.badges[badge_type]
         self.badge_active[badge_type] = value
         if badge.isChecked() != value:
@@ -433,7 +432,7 @@ class ItemThumb(FlowWidget):
 
     @badge_update_lock
     def on_badge_check(self, badge_type: BadgeType):
-        if self.mode is None:
+        if self.mode == ItemType.NONE:
             return
 
         toggle_value = self.badges[badge_type].isChecked()

--- a/tagstudio/src/qt/widgets/library_dirs.py
+++ b/tagstudio/src/qt/widgets/library_dirs.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+from src.core.library import Library
+from src.core.library.alchemy.models import Folder
+from src.qt.enums import WindowContent
+
+if TYPE_CHECKING:
+    from src.qt.ts_qt import QtDriver
+
+
+class LibraryDirsWidget(QWidget):
+    library_dirs: list[Folder]
+
+    def __init__(self, library: Library, driver: QtDriver):
+        super().__init__()
+
+        self.root_layout = QVBoxLayout(self)
+        self.root_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.setSizePolicy(
+            QSizePolicy.Policy.Preferred,
+            QSizePolicy.Policy.Maximum,
+        )
+
+        self.driver = driver
+        self.library = library
+
+        # label and button
+        self.create_panel()
+
+        # actual library dirs
+        self.items_layout = QVBoxLayout()
+        self.root_layout.addLayout(self.items_layout)
+
+        self.library_dirs = []
+        # check if library is open
+        self.refresh()
+
+    def refresh(self):
+        if not self.library.storage_path:
+            return
+
+        self.driver.main_window.set_main_content(WindowContent.LIBRARY_CONTENT)
+
+        library_dirs = self.library.get_folders()
+        if len(library_dirs) == len(self.library_dirs):
+            # most likely no reason to refresh
+            return
+
+        self.library_dirs = library_dirs
+        self.fill_dirs(self.library_dirs)
+
+    def create_panel(self):
+        label = QLabel("Library Folders")
+        label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        row_layout = QHBoxLayout()
+        row_layout.addWidget(label)
+        self.root_layout.addLayout(row_layout)
+
+        # add a button which will open a library folder dialog
+        button = QPushButton("Add Folder")
+        button.setCursor(Qt.CursorShape.PointingHandCursor)
+        button.clicked.connect(self.add_folder)
+        self.root_layout.addWidget(button)
+
+    def add_folder(self):
+        """Open QT dialog to select a folder to add into library."""
+        if not self.library.storage_path:
+            # no library open, dont do anything
+            return
+
+        directory = QFileDialog.getExistingDirectory(self, "Select Directory")
+        if directory and (folder := self.library.add_folder(Path(directory))):
+            self.driver.add_new_files_callback([folder])
+            self.driver.filter_items()
+            self.refresh()
+
+    def fill_dirs(self, folders: list[Folder]) -> None:
+        def clear_layout(layout_item: QVBoxLayout):
+            for i in reversed(range(layout_item.count())):
+                child = layout_item.itemAt(i)
+                if child.widget() is not None:
+                    child.widget().deleteLater()
+                elif child.layout() is not None:
+                    clear_layout(child.layout())  # type: ignore
+                    # remove any potential previous items
+
+        clear_layout(self.items_layout)
+
+        for folder in folders:
+            self.create_item(folder)
+
+    def create_item(self, folder: Folder):
+        def toggle_folder():
+            self.driver.filter.toggle_folder(folder.id)
+            self.driver.filter_items()
+
+        button_toggle = QCheckBox()
+        button_toggle.setCursor(Qt.CursorShape.PointingHandCursor)
+        button_toggle.setFixedWidth(30)
+        # TODO - figure out which one to check
+        button_toggle.setChecked(True)  # item.id not in self.driver.filter.exclude_folders)
+
+        button_toggle.clicked.connect(toggle_folder)
+
+        folder_label = QLabel(folder.path.name)
+
+        row_layout = QHBoxLayout()
+        row_layout.addWidget(button_toggle)
+        row_layout.addWidget(folder_label)
+
+        self.items_layout.addLayout(row_layout)

--- a/tagstudio/src/qt/widgets/library_nodirs.py
+++ b/tagstudio/src/qt/widgets/library_nodirs.py
@@ -1,0 +1,16 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class LibraryNoFolders(QWidget):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.lib_nofolders_layout = QVBoxLayout(self)
+        self.lib_nofolders_layout.setContentsMargins(0, 0, 0, 0)
+        self.lib_nofolders_layout.setSpacing(0)
+        self.lib_nofolders_label = QLabel(self)
+        self.lib_nofolders_label.setObjectName("lib_nofolders_label")
+        self.lib_nofolders_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.lib_nofolders_label.setText("No folders found in library.")
+        self.lib_nofolders_layout.addWidget(self.lib_nofolders_label)

--- a/tagstudio/tag_studio.py
+++ b/tagstudio/tag_studio.py
@@ -63,7 +63,7 @@ def main():
     # Run the chosen frontend driver.
     try:
         driver.start()
-    except Exception:
+    except BaseException:
         traceback.print_exc()
         logging.info(f"\nTagStudio Frontend ({ui_name}) Crashed! Press Enter to Continue...")
         input()

--- a/tagstudio/tests/conftest.py
+++ b/tagstudio/tests/conftest.py
@@ -24,15 +24,15 @@ def cwd():
 @pytest.fixture
 def library(request):
     # when no param is passed, use the default
-    library_path = "/dev/null/"
+    folder_path = "/dev/null/"
     if hasattr(request, "param"):
         if isinstance(request.param, TemporaryDirectory):
-            library_path = request.param.name
+            folder_path = request.param.name
         else:
-            library_path = request.param
+            folder_path = request.param
 
     lib = Library()
-    status = lib.open_library(pathlib.Path(library_path), ":memory:")
+    status = lib.open_library(":memory:", folder_path)
     assert status.success
 
     tag = Tag(
@@ -52,9 +52,11 @@ def library(request):
         subtags={subtag},
     )
 
+    folder = lib.add_folder(folder_path)
+
     # default item with deterministic name
     entry = Entry(
-        folder=lib.folder,
+        folder=folder,
         path=pathlib.Path("foo.txt"),
         fields=lib.default_fields,
     )
@@ -68,7 +70,7 @@ def library(request):
     ]
 
     entry2 = Entry(
-        folder=lib.folder,
+        folder=folder,
         path=pathlib.Path("one/two/bar.md"),
         fields=lib.default_fields,
     )

--- a/tagstudio/tests/macros/test_dupe_entries.py
+++ b/tagstudio/tests/macros/test_dupe_entries.py
@@ -7,15 +7,17 @@ CWD = pathlib.Path(__file__).parent
 
 
 def test_refresh_dupe_files(library):
-    library.library_dir = "/tmp/"
+    folder = library.add_folder(pathlib.Path("/tmp/"))
+    assert folder.path == pathlib.Path("/tmp/")
+
     entry = Entry(
-        folder=library.folder,
+        folder=folder,
         path=pathlib.Path("bar/foo.txt"),
         fields=library.default_fields,
     )
 
     entry2 = Entry(
-        folder=library.folder,
+        folder=folder,
         path=pathlib.Path("foo/foo.txt"),
         fields=library.default_fields,
     )
@@ -31,6 +33,5 @@ def test_refresh_dupe_files(library):
     paths = [entry.path for entry in registry.groups[0]]
     assert paths == [
         pathlib.Path("bar/foo.txt"),
-        pathlib.Path("foo.txt"),
         pathlib.Path("foo/foo.txt"),
-    ]
+    ], f"obtained paths: {paths}"

--- a/tagstudio/tests/macros/test_missing_files.py
+++ b/tagstudio/tests/macros/test_missing_files.py
@@ -14,7 +14,8 @@ def test_refresh_missing_files(library: Library):
     registry = MissingRegistry(library=library)
 
     # touch the file `one/two/bar.md` but in wrong location to simulate a moved file
-    (library.library_dir / "bar.md").touch()
+    folder = library.get_folders()[0]
+    (folder.path / "bar.md").touch()
 
     # no files actually exist, so it should return all entries
     assert list(registry.refresh_missing_files()) == [0, 1]

--- a/tagstudio/tests/macros/test_refresh_dir.py
+++ b/tagstudio/tests/macros/test_refresh_dir.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 from src.core.enums import LibraryPrefs
+from src.core.library import Entry
 from src.core.utils.refresh_dir import RefreshDirTracker
 
 CWD = pathlib.Path(__file__).parent
@@ -13,12 +14,54 @@ CWD = pathlib.Path(__file__).parent
 def test_refresh_new_files(library, exclude_mode):
     # Given
     library.set_prefs(LibraryPrefs.IS_EXCLUDE_LIST, exclude_mode)
-    library.set_prefs(LibraryPrefs.EXTENSION_LIST, [".md"])
+    library.set_prefs(LibraryPrefs.EXTENSION_LIST, ["md"])
     registry = RefreshDirTracker(library=library)
-    (library.library_dir / "FOO.MD").touch()
+
+    folder = library.get_folders()[0]
+    (folder.path / "FOO.MD").touch()
 
     # When
-    assert not list(registry.refresh_dir(library.library_dir))
+    list(registry.refresh_dirs(folder))
 
     # Then
-    assert registry.files_not_in_library == [pathlib.Path("FOO.MD")]
+    assert registry.files_not_in_library == [(folder, pathlib.Path("FOO.MD"))]
+
+
+@pytest.mark.parametrize("library", [TemporaryDirectory()], indirect=True)
+def test_refresh_removes_noindex_content(library):
+    # Given
+    registry = RefreshDirTracker(library=library)
+
+    folder = library.get_folders()[0]
+
+    # create subdirectory with .ts_noindex file in it
+    (folder.path / "subdir").mkdir()
+    (folder.path / "subdir" / ".ts_noindex").touch()
+
+    # add entry into library
+    entry = Entry(
+        path=pathlib.Path("subdir/FOO.MD"),
+        folder=library.get_folders()[0],
+        fields=library.default_fields,
+    )
+
+    # create its file in noindex directory
+    assert entry.folder
+    assert entry.folder.path
+    entry.absolute_path.touch()
+    library.add_entries([entry])
+
+    # create another file in the same directory
+    (folder.path / "subdir" / "test.txt").touch()
+
+    # add non-ignored entry into library
+    (folder.path / "root.txt").touch()
+
+    # When
+    list(registry.refresh_dirs(folder))
+
+    # Then
+    # file in noindex folder should be removed
+    assert not library.get_path_entry(entry.path)
+    # file in index folder should be registered
+    assert registry.files_not_in_library == [(folder, pathlib.Path("root.txt"))]

--- a/tagstudio/tests/macros/test_sidecar.py
+++ b/tagstudio/tests/macros/test_sidecar.py
@@ -12,9 +12,9 @@ def test_sidecar_macro(qt_driver, library, cwd, entry_full):
     entry_full.path = Path("newgrounds/foo.txt")
 
     fixture = cwd / "fixtures/sidecar_newgrounds.json"
-    dst = library.library_dir / "newgrounds" / (entry_full.path.stem + ".json")
-    dst.parent.mkdir()
-    shutil.copy(fixture, dst)
+    entry_dir = entry_full.absolute_path.parent
+    entry_dir.mkdir()
+    shutil.copy(fixture, entry_dir / "foo.json")  # matches entry name + json
 
     qt_driver.frame_content = [entry_full]
     qt_driver.run_macro(MacroID.SIDECAR, 0)

--- a/tagstudio/tests/qt/test_preview_panel.py
+++ b/tagstudio/tests/qt/test_preview_panel.py
@@ -34,7 +34,7 @@ def test_update_widgets_multiple_selected(qt_driver, library):
     # entry with no tag fields
     entry = Entry(
         path=Path("test.txt"),
-        folder=library.folder,
+        folder=library.get_folders()[0],
         fields=[TextField(type_key=_FieldID.TITLE.name, position=0)],
     )
 

--- a/tagstudio/tests/qt/test_qt_driver.py
+++ b/tagstudio/tests/qt/test_qt_driver.py
@@ -1,20 +1,12 @@
-from pathlib import Path
 from unittest.mock import Mock
 
-from src.core.library import Entry
 from src.core.library.alchemy.enums import FilterState
 from src.core.library.json.library import ItemType
 from src.qt.widgets.item_thumb import ItemThumb
 
 
-def test_update_thumbs(qt_driver):
-    qt_driver.frame_content = [
-        Entry(
-            folder=qt_driver.lib.folder,
-            path=Path("/tmp/foo"),
-            fields=qt_driver.lib.default_fields,
-        )
-    ]
+def test_update_thumbs(qt_driver, entry_full):
+    qt_driver.frame_content = [entry_full]
 
     qt_driver.item_thumbs = []
     for i in range(3):
@@ -106,7 +98,7 @@ def test_close_library(qt_driver):
     qt_driver.close_library()
 
     # Then
-    assert qt_driver.lib.library_dir is None
+    assert qt_driver.lib.storage_path is None
     assert not qt_driver.frame_content
     assert not qt_driver.selected
     assert not any(x.mode for x in qt_driver.item_thumbs)

--- a/tagstudio/tests/test_driver.py
+++ b/tagstudio/tests/test_driver.py
@@ -1,15 +1,13 @@
-from os import makedirs
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from PySide6.QtCore import QSettings
-from src.core.constants import TS_FOLDER_NAME
 from src.core.driver import DriverMixin
 from src.core.enums import SettingItems
 from src.core.library.alchemy.library import LibraryStatus
 
 
-class TestDriver(DriverMixin):
+class DriverTest(DriverMixin):
     def __init__(self, settings):
         self.settings = settings
 
@@ -17,7 +15,7 @@ class TestDriver(DriverMixin):
 def test_evaluate_path_empty():
     # Given
     settings = QSettings()
-    driver = TestDriver(settings)
+    driver = DriverTest(settings)
 
     # When
     result = driver.evaluate_path(None)
@@ -29,7 +27,7 @@ def test_evaluate_path_empty():
 def test_evaluate_path_missing():
     # Given
     settings = QSettings()
-    driver = TestDriver(settings)
+    driver = DriverTest(settings)
 
     # When
     result = driver.evaluate_path("/0/4/5/1/")
@@ -42,13 +40,13 @@ def test_evaluate_path_last_lib_not_exists():
     # Given
     settings = QSettings()
     settings.setValue(SettingItems.LAST_LIBRARY, "/0/4/5/1/")
-    driver = TestDriver(settings)
+    driver = DriverTest(settings)
 
     # When
     result = driver.evaluate_path(None)
 
     # Then
-    assert result == LibraryStatus(success=True, library_path=None, message=None)
+    assert result == LibraryStatus(success=True, storage_path=None, message=None)
 
 
 def test_evaluate_path_last_lib_present():
@@ -56,11 +54,11 @@ def test_evaluate_path_last_lib_present():
     settings = QSettings()
     with TemporaryDirectory() as tmpdir:
         settings.setValue(SettingItems.LAST_LIBRARY, tmpdir)
-        makedirs(Path(tmpdir) / TS_FOLDER_NAME)
-        driver = TestDriver(settings)
+        storage_path = Path(tmpdir)
+        driver = DriverTest(settings)
 
         # When
         result = driver.evaluate_path(None)
 
         # Then
-        assert result == LibraryStatus(success=True, library_path=Path(tmpdir))
+        assert result == LibraryStatus(success=True, storage_path=storage_path)

--- a/tagstudio/tests/test_library.py
+++ b/tagstudio/tests/test_library.py
@@ -14,15 +14,15 @@ def test_library_add_file(library):
 
     entry = Entry(
         path=Path("bar.txt"),
-        folder=library.folder,
+        folder=library.get_folders()[0],
         fields=library.default_fields,
     )
 
-    assert not library.has_path_entry(entry.path)
+    assert not library.get_path_entry(entry.path)
 
     assert library.add_entries([entry])
 
-    assert library.has_path_entry(entry.path)
+    assert library.get_path_entry(entry.path) is not None
 
 
 def test_create_tag(library, generate_tag):
@@ -85,7 +85,15 @@ def test_get_entry(library, entry_min):
 
 
 def test_entries_count(library):
-    entries = [Entry(path=Path(f"{x}.txt"), folder=library.folder, fields=[]) for x in range(10)]
+    folder = library.get_folders()[0]
+    entries = [
+        Entry(
+            path=Path(f"{x}.txt"),
+            folder=folder,
+            fields=[],
+        )
+        for x in range(10)
+    ]
     new_ids = library.add_entries(entries)
     assert len(new_ids) == 10
 
@@ -102,7 +110,7 @@ def test_entries_count(library):
 def test_add_field_to_entry(library):
     # Given
     entry = Entry(
-        folder=library.folder,
+        folder=library.get_folders()[0],
         path=Path("xxx"),
         fields=library.default_fields,
     )
@@ -205,7 +213,7 @@ def test_save_windows_path(library, generate_tag):
 
     entry = Entry(
         path=PureWindowsPath("foo\\bar.txt"),
-        folder=library.folder,
+        folder=library.get_folders()[0],
         fields=library.default_fields,
     )
     tag = generate_tag("win_path")
@@ -283,7 +291,7 @@ def test_update_entry_with_multiple_identical_fields(library, entry_full):
 
 def test_mirror_entry_fields(library, entry_full):
     target_entry = Entry(
-        folder=library.folder,
+        folder=library.get_folders()[0],
         path=Path("xxx"),
         fields=[
             TextField(


### PR DESCRIPTION
- this PR allows to have multiple individual directories in the same library. This means there's no such thing as "root" of the library, so there's a new dialog where metadata of the library should be stored

- this also means that "open library" and "create library" are now two different actions as "open library" doesnt implicitly create the library subfolder (ie `.TagStudio`) automatically in given folder

- each directory can be then toggled to show/hide its content in the library

![Screenshot 2024-10-26 at 14 26 39](https://github.com/user-attachments/assets/6a0833c2-3bb8-4ac5-81d1-76042bbda1ef)


![Screenshot 2024-10-26 at 14 27 00](https://github.com/user-attachments/assets/df0c0cef-6ef8-43f7-9423-0c6c682ee099)
