### PR TITLE
remove queued thumnail jobs when closing library

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -586,6 +586,7 @@ class QtDriver(DriverMixin, QObject):
 
         self.lib.close()
 
+        self.thumb_job_queue.queue.clear()
         if is_shutdown:
             # no need to do other things on shutdown
             return


### PR DESCRIPTION
No need to keep rendering the queued thumbnails when closing library and/or quitting the app