### PR TITLE
feat: add autocomplete for search engine

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -395,6 +395,13 @@ class Library:
         with Session(self.engine) as session:
             return session.query(exists().where(Entry.path == path)).scalar()
 
+    def get_paths(self, glob: str | None = None) -> list[str]:
+        with Session(self.engine) as session:
+            paths = session.scalars(select(Entry.path)).unique()
+
+        path_strings: list[str] = list(map(lambda x: x.as_posix(), paths))
+        return path_strings
+
     def search_library(
         self,
         search: FilterState,

--- a/tagstudio/src/qt/main_window.py
+++ b/tagstudio/src/qt/main_window.py
@@ -15,13 +15,13 @@
 
 import logging
 import typing
-from PySide6.QtCore import (QCoreApplication, QMetaObject, QRect,QSize, Qt)
+from PySide6.QtCore import (QCoreApplication, QMetaObject, QRect,QSize, Qt, QStringListModel)
 from PySide6.QtGui import QFont
 from PySide6.QtWidgets import (QComboBox, QFrame, QGridLayout,
                                QHBoxLayout, QVBoxLayout, QLayout, QLineEdit, QMainWindow,
                                QPushButton, QScrollArea, QSizePolicy,
                                QStatusBar, QWidget, QSplitter, QCheckBox,
-                               QSpacerItem)
+                               QSpacerItem, QCompleter)
 from src.qt.pagination import Pagination
 from src.qt.widgets.landing import LandingWidget
 
@@ -166,6 +166,11 @@ class Ui_MainWindow(QMainWindow):
         font2.setPointSize(11)
         font2.setBold(False)
         self.searchField.setFont(font2)
+
+        self.searchFieldCompletionList = QStringListModel()
+        self.searchFieldCompleter = QCompleter(self.searchFieldCompletionList, self.searchField)
+        self.searchFieldCompleter.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.searchField.setCompleter(self.searchFieldCompleter)
 
         self.horizontalLayout_2.addWidget(self.searchField)
 

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -957,7 +957,7 @@ class QtDriver(DriverMixin, QObject):
 
         completion_list: list[str] = []
         if len(text) < 3:
-            completion_list: list[str] = ["mediatype:", "filetype:", "path:", "tag:"]
+            completion_list = ["mediatype:", "filetype:", "path:", "tag:"]
             self.main_window.searchFieldCompletionList.setStringList(completion_list)
 
         if not matches:

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -955,6 +955,7 @@ class QtDriver(DriverMixin, QObject):
     def update_completions_list(self, text: str) -> None:
         matches = re.search(r"(mediatype|filetype|path|tag):(\"?[A-Za-z0-9\ \t]+\"?)?", text)
 
+        completion_list: list[str] = []
         if len(text) < 3:
             completion_list: list[str] = ["mediatype:", "filetype:", "path:", "tag:"]
             self.main_window.searchFieldCompletionList.setStringList(completion_list)
@@ -968,8 +969,6 @@ class QtDriver(DriverMixin, QObject):
 
         if not query_value:
             return
-
-        completion_list: list[str] = []
 
         if query_type == "tag":
             completion_list = list(map(lambda x: "tag:" + x.name, self.lib.tags))


### PR DESCRIPTION
currently, the autocomplete will automatically show up when the user types something that can be autocompleted (right now, "filetype:", "mediatype:", "tag:", "tag_id:", and "path:"). 

`filetype` and `mediatype`: autocompletes with all filetypes/mediatypes currently registered in tagstudio, regardless of whether the current library contains any files of a type.

`tag`: autocompletes with all tag names, case-insensitive

`tag_id`: autocompletes with ids of all tags

`path`: autocompletes with all paths currently stored in the library