### PR TITLE
fix: ui/ux parity fixes for thumbnails and files

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -131,6 +131,7 @@ class Library:
     storage_path: Path | str | None
     engine: Engine | None
     folder: Folder | None
+    included_files: set[Path] = set()
 
     FILENAME: str = "ts_library.sqlite"
 
@@ -140,6 +141,7 @@ class Library:
         self.library_dir = None
         self.storage_path = None
         self.folder = None
+        self.included_files = set()
 
     def open_library(self, library_dir: Path, storage_path: str | None = None) -> LibraryStatus:
         if storage_path == ":memory:":

--- a/tagstudio/src/qt/modals/build_tag.py
+++ b/tagstudio/src/qt/modals/build_tag.py
@@ -203,7 +203,7 @@ class BuildTagPanel(PanelWidget):
         self.color_field.setMaxVisibleItems(10)
         self.color_field.setStyleSheet("combobox-popup:0;")
         for color in TagColor:
-            self.color_field.addItem(color.name, userData=color.value)
+            self.color_field.addItem(color.name.replace("_", " ").title(), userData=color.value)
         # self.color_field.setProperty("appearance", "flat")
         self.color_field.currentIndexChanged.connect(
             lambda c: (

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1203,7 +1203,8 @@ class QtDriver(DriverMixin, QObject):
         self.filter.page_size = self.lib.prefs(LibraryPrefs.PAGE_SIZE)
 
         # TODO - make this call optional
-        self.add_new_files_callback()
+        if self.lib.entries_count < 10000:
+            self.add_new_files_callback()
 
         self.update_libs_list(path)
         title_text = f"{self.base_title} - Library '{self.lib.library_dir}'"

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1055,6 +1055,9 @@ class QtDriver(DriverMixin, QObject):
         for idx, (entry, item_thumb) in enumerate(
             zip_longest(self.frame_content, self.item_thumbs)
         ):
+            if not entry:
+                continue
+
             filepath = self.lib.library_dir / entry.path
             is_loading = False
 

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1030,25 +1030,38 @@ class QtDriver(DriverMixin, QObject):
         self.flow_container.layout().update()
         self.main_window.update()
 
-        for idx, (entry, item_thumb) in enumerate(
-            zip_longest(self.frame_content, self.item_thumbs)
-        ):
+        is_grid_thumb = True
+        # Show loading placeholder icons
+        for entry, item_thumb in zip_longest(self.frame_content, self.item_thumbs):
             if not entry:
                 item_thumb.hide()
                 continue
 
-            filepath = self.lib.library_dir / entry.path
-            item_thumb = self.item_thumbs[idx]
             item_thumb.set_mode(ItemType.ENTRY)
             item_thumb.set_item_id(entry)
 
             # TODO - show after item is rendered
             item_thumb.show()
 
+            is_loading = True
             self.thumb_job_queue.put(
                 (
                     item_thumb.renderer.render,
-                    (sys.float_info.max, "", base_size, ratio, True, True),
+                    (sys.float_info.max, "", base_size, ratio, is_loading, is_grid_thumb),
+                )
+            )
+
+        # Show rendered thumbnails
+        for idx, (entry, item_thumb) in enumerate(
+            zip_longest(self.frame_content, self.item_thumbs)
+        ):
+            filepath = self.lib.library_dir / entry.path
+            is_loading = False
+
+            self.thumb_job_queue.put(
+                (
+                    item_thumb.renderer.render,
+                    (time.time(), filepath, base_size, ratio, is_loading, is_grid_thumb),
                 )
             )
 

--- a/tagstudio/src/qt/widgets/fields.py
+++ b/tagstudio/src/qt/widgets/fields.py
@@ -135,7 +135,10 @@ class FieldContainer(QWidget):
 
     def set_inner_widget(self, widget: "FieldWidget"):
         if self.field_layout.itemAt(0):
-            self.field_layout.itemAt(0).widget().deleteLater()
+            old: QWidget = self.field_layout.itemAt(0).widget()
+            self.field_layout.removeWidget(old)
+            old.deleteLater()
+
         self.field_layout.addWidget(widget)
 
     def get_inner_widget(self):

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -480,7 +480,7 @@ class PreviewPanel(QWidget):
         if filepath and filepath.is_file():
             created: dt = None
             if platform.system() == "Windows" or platform.system() == "Darwin":
-                created = dt.fromtimestamp(filepath.stat().st_birthtime)  # type: ignore[attr-defined]
+                created = dt.fromtimestamp(filepath.stat().st_birthtime)  # type: ignore[attr-defined, unused-ignore]
             else:
                 created = dt.fromtimestamp(filepath.stat().st_ctime)
             modified: dt = dt.fromtimestamp(filepath.stat().st_mtime)

--- a/tagstudio/tests/macros/test_refresh_dir.py
+++ b/tagstudio/tests/macros/test_refresh_dir.py
@@ -15,10 +15,11 @@ def test_refresh_new_files(library, exclude_mode):
     library.set_prefs(LibraryPrefs.IS_EXCLUDE_LIST, exclude_mode)
     library.set_prefs(LibraryPrefs.EXTENSION_LIST, [".md"])
     registry = RefreshDirTracker(library=library)
+    library.included_files.clear()
     (library.library_dir / "FOO.MD").touch()
 
     # When
-    assert not list(registry.refresh_dir(library.library_dir))
+    assert len(list(registry.refresh_dir(library.library_dir))) == 1
 
     # Then
     assert registry.files_not_in_library == [pathlib.Path("FOO.MD")]


### PR DESCRIPTION
This PR adds various fixes and improvements for increased parity of thumbnail and file entry behavior between v9.4 and v9.5. This includes:
- Fix: Thumbnail loading icons are properly displayed before the main render jobs start
- Fix: Tag color names now show correct display names
- Fix: Preview panel fields no longer leave previous UI elements around when browsing
- Parity: Optimized file refreshing by removing string manipulation operations and re-introducing a cache of known files to skip when re-scanning
- Feat: Add new folder names to always ignore when scanning
- Fix/Parity/Feat: Automatic library refreshing on start is now only enabled for libraries with <10,000 previously known files