### PR TITLE
fix: shut up mypy

### DIFF
--- a/tagstudio/src/qt/helpers/file_opener.py
+++ b/tagstudio/src/qt/helpers/file_opener.py
@@ -34,11 +34,11 @@ def open_file(path: str | Path, file_manager: bool = False):
             normpath = Path(path).resolve().as_posix()
             if file_manager:
                 command_name = "explorer"
-                command_args = '/select,"' + normpath + '"'
+                command_arg = '/select,"' + normpath + '"'
                 # For some reason, if the args are passed in a list, this will error when the
                 # path has spaces, even while surrounded in double quotes.
                 subprocess.Popen(
-                    command_name + command_args,
+                    command_name + command_arg,
                     shell=True,
                     close_fds=True,
                     creationflags=subprocess.CREATE_NEW_PROCESS_GROUP

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -254,7 +254,7 @@ class QtDriver(DriverMixin, QObject):
 
         if os.name == "nt":
             appid = "cyanvoxel.tagstudio.9"
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)  # type: ignore
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)
 
         if sys.platform != "darwin":
             icon = QIcon()

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -254,7 +254,7 @@ class QtDriver(DriverMixin, QObject):
 
         if os.name == "nt":
             appid = "cyanvoxel.tagstudio.9"
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)  # type: ignore[attr-defined,unused-ignore]
 
         if sys.platform != "darwin":
             icon = QIcon()

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -823,6 +823,7 @@ class QtDriver(DriverMixin, QObject):
                 if field.type.type == FieldTypeEnum.TEXT_LINE and field.value:
                     self.lib.update_entry_field(
                         entry_ids=entry.id,
+                        field=field,
                         content=strip_web_protocol(field.value),
                     )
 

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -480,7 +480,7 @@ class PreviewPanel(QWidget):
         if filepath and filepath.is_file():
             created: dt = None
             if platform.system() == "Windows" or platform.system() == "Darwin":
-                created = dt.fromtimestamp(filepath.stat().st_birthtime)  # type: ignore[attr-defined]
+                created = dt.fromtimestamp(filepath.stat().st_birthtime)
             else:
                 created = dt.fromtimestamp(filepath.stat().st_ctime)
             modified: dt = dt.fromtimestamp(filepath.stat().st_mtime)

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -480,7 +480,7 @@ class PreviewPanel(QWidget):
         if filepath and filepath.is_file():
             created: dt = None
             if platform.system() == "Windows" or platform.system() == "Darwin":
-                created = dt.fromtimestamp(filepath.stat().st_birthtime)
+                created = dt.fromtimestamp(filepath.stat().st_birthtime)  # type: ignore[attr-defined,unused-ignore]
             else:
                 created = dt.fromtimestamp(filepath.stat().st_ctime)
             modified: dt = dt.fromtimestamp(filepath.stat().st_mtime)

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -480,7 +480,7 @@ class PreviewPanel(QWidget):
         if filepath and filepath.is_file():
             created: dt = None
             if platform.system() == "Windows" or platform.system() == "Darwin":
-                created = dt.fromtimestamp(filepath.stat().st_birthtime)  # type: ignore[attr-defined,unused-ignore]
+                created = dt.fromtimestamp(filepath.stat().st_birthtime)  # type: ignore[attr-defined]
             else:
                 created = dt.fromtimestamp(filepath.stat().st_ctime)
             modified: dt = dt.fromtimestamp(filepath.stat().st_mtime)


### PR DESCRIPTION
Just four extremly short fixes in order to stop mypy from complaining constantly. Specifically:
- two type ignore comments threw unused-ignore on windows (but didn't on linux), the type ignores now also ignore unused-ignore
- a call in ts_qt was missing a trivial argument
- two variables in file_opener had the same name but different type and mypy wasn't happy about that, I renamed one appropriately