### PR TITLE
Small fix: Remove unnecessary warning in console

### DIFF
--- a/tagstudio/src/qt/widgets/fields.py
+++ b/tagstudio/src/qt/widgets/fields.py
@@ -113,7 +113,7 @@ class FieldContainer(QWidget):
 
         self.copy_callback = callback
         self.copy_button.clicked.connect(callback)
-        self.copy_button.is_connected = isinstance(callback, Callable)
+        self.copy_button.is_connected = callable(callback)
 
     def set_edit_callback(self, callback: Callable):
         if self.edit_button.is_connected:
@@ -121,7 +121,7 @@ class FieldContainer(QWidget):
 
         self.edit_callback = callback
         self.edit_button.clicked.connect(callback)
-        self.edit_button.is_connected = isinstance(callback, Callable)
+        self.edit_button.is_connected = callable(callback)
 
     def set_remove_callback(self, callback: Callable):
         if self.remove_button.is_connected:
@@ -129,7 +129,7 @@ class FieldContainer(QWidget):
 
         self.remove_callback = callback
         self.remove_button.clicked.connect(callback)
-        self.remove_button.is_connected = isinstance(callback, Callable)
+        self.remove_button.is_connected = callable(callback)
 
     def set_inner_widget(self, widget: "FieldWidget"):
         if self.field_layout.itemAt(0):

--- a/tagstudio/src/qt/widgets/fields.py
+++ b/tagstudio/src/qt/widgets/fields.py
@@ -113,8 +113,7 @@ class FieldContainer(QWidget):
 
         self.copy_callback = callback
         self.copy_button.clicked.connect(callback)
-        if callback is not None:
-            self.copy_button.is_connected = True
+        self.copy_button.is_connected = isinstance(callback, Callable)
 
     def set_edit_callback(self, callback: Callable):
         if self.edit_button.is_connected:
@@ -122,8 +121,7 @@ class FieldContainer(QWidget):
 
         self.edit_callback = callback
         self.edit_button.clicked.connect(callback)
-        if callback is not None:
-            self.edit_button.is_connected = True
+        self.edit_button.is_connected = isinstance(callback, Callable)
 
     def set_remove_callback(self, callback: Callable):
         if self.remove_button.is_connected:
@@ -131,7 +129,7 @@ class FieldContainer(QWidget):
 
         self.remove_callback = callback
         self.remove_button.clicked.connect(callback)
-        self.remove_button.is_connected = True
+        self.remove_button.is_connected = isinstance(callback, Callable)
 
     def set_inner_widget(self, widget: "FieldWidget"):
         if self.field_layout.itemAt(0):

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -857,10 +857,6 @@ class PreviewPanel(QWidget):
         else:
             container = self.containers[index]
 
-        container.set_copy_callback(None)
-        container.set_edit_callback(None)
-        container.set_remove_callback(None)
-
         if isinstance(field, TagBoxField):
             container.set_title(field.type.name)
             container.set_inline(False)


### PR DESCRIPTION
Hi,
I removed the Warning that is shown in the console that occurs when Tagstudio is opened and a thumbnail is clicked for the first time.

Bug:
![grafik](https://github.com/user-attachments/assets/bc298a73-ffcb-41a7-966d-031a26583b05)

Fix:
Check if provided callback function is actually a Callable and preventing it from trying to disconnect when the callback is None.