### PR TITLE
Improve relink performance

### DIFF
--- a/tagstudio/src/core/library/json/library.py
+++ b/tagstudio/src/core/library/json/library.py
@@ -304,8 +304,6 @@ class Library:
     def __init__(self) -> None:
         # Library Info =========================================================
         self.library_dir: Path = None
-        # Cached result of os.walk when relinking library files
-        self._library_file_cache: list[(string, list[string], list[string])] = None
 
         # Entries ==============================================================
         # List of every Entry object.
@@ -1094,7 +1092,6 @@ class Library:
                     yield (i, True)
                 else:
                     yield (i, False)
-        self._library_file_cache = None
 
         # self._purge_empty_missing_entries()
 
@@ -1127,12 +1124,9 @@ class Library:
 
         matches = []
 
-        if self._library_file_cache is None:
-            self._library_file_cache = list(os.walk(self.library_dir))
-
         # for file in self.missing_files:
         path = Path(file)
-        for root, dirs, files in self._library_file_cache:
+        for root, dirs, files in os.walk(self.library_dir):
             for f in files:
                 # print(f'{tail} --- {f}')
                 if path.name == f and "$recycle.bin" not in str(root).lower():

--- a/tagstudio/src/core/library/json/library.py
+++ b/tagstudio/src/core/library/json/library.py
@@ -304,6 +304,8 @@ class Library:
     def __init__(self) -> None:
         # Library Info =========================================================
         self.library_dir: Path = None
+        # Cached result of os.walk when relinking library files
+        self._library_file_cache: list[(string, list[string], list[string])] = None
 
         # Entries ==============================================================
         # List of every Entry object.
@@ -1092,6 +1094,7 @@ class Library:
                     yield (i, True)
                 else:
                     yield (i, False)
+        self._library_file_cache = None
 
         # self._purge_empty_missing_entries()
 
@@ -1124,9 +1127,12 @@ class Library:
 
         matches = []
 
+        if self._library_file_cache is None:
+            self._library_file_cache = list(os.walk(self.library_dir))
+
         # for file in self.missing_files:
         path = Path(file)
-        for root, dirs, files in os.walk(self.library_dir):
+        for root, dirs, files in self._library_file_cache:
             for f in files:
                 # print(f'{tail} --- {f}')
                 if path.name == f and "$recycle.bin" not in str(root).lower():

--- a/tagstudio/src/core/utils/missing_files.py
+++ b/tagstudio/src/core/utils/missing_files.py
@@ -42,7 +42,8 @@ class MissingRegistry:
         """
         matches = []
         # TODO - implement IGNORE_ITEMS
-        for matched_path in filter(lambda file: file.name == match_item.path.name, self.library_file_cache):
+        item_name = match_item.path.name
+        for matched_path in filter(lambda file: file.name == item_name, self.library_file_cache):
             logger.info("match_missing_files", matched_path=matched_path)
             new_path = Path(matched_path).relative_to(self.library.library_dir)
             matches.append(new_path)


### PR DESCRIPTION
Cache library files instead of rewalking library for every missing entry
Improved PR of #611 that also improves performance for sqlite
Fixes #610

Only a rudimentary fix that could probably be improved by putting the cache somewhere more sensible but this works:tm: