### PR TITLE
fix: clear all setting values when opening a library

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1183,7 +1183,7 @@ class QtDriver(DriverMixin, QObject):
         all_libs_list = sorted(all_libs.items(), key=lambda item: item[0], reverse=True)
 
         # remove previously saved items
-        self.settings.clear()
+        self.settings.remove("")
 
         for item_key, item_value in all_libs_list[:item_limit]:
             self.settings.setValue(item_key, item_value)


### PR DESCRIPTION
Replaced `self.settings.clear()` with `self.settings.remove("")` in the `update_libs_list()` method. the original implementation was clearing all settings. this bug prevented the app from reopening the last library also. and surprisingly no one noticed or reported it. this change ensures only the intended group of settings is cleared without affecting other values.