### PR TITLE
fix: don't allow blank tag alias values in db (Fix #627)

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -170,6 +170,8 @@ class Library:
         # Tag Aliases
         for tag in json_lib.tags:
             for alias in tag.aliases:
+                if not alias:
+                    break
                 self.add_alias(name=alias, tag_id=tag.id)
 
         # Tag Subtags
@@ -1027,6 +1029,9 @@ class Library:
 
     def add_alias(self, name: str, tag_id: int) -> bool:
         with Session(self.engine) as session:
+            if not name:
+                logger.warning("[LIBRARY][add_alias] Alias value must not be empty")
+                return False
             alias = TagAlias(
                 name=name,
                 tag_id=tag_id,

--- a/tagstudio/src/core/library/alchemy/models.py
+++ b/tagstudio/src/core/library/alchemy/models.py
@@ -23,7 +23,7 @@ class TagAlias(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(nullable=False)
 
     tag_id: Mapped[int] = mapped_column(ForeignKey("tags.id"))
     tag: Mapped["Tag"] = relationship(back_populates="aliases")

--- a/tagstudio/src/qt/widgets/migration_modal.py
+++ b/tagstudio/src/qt/widgets/migration_modal.py
@@ -699,7 +699,7 @@ class JsonMigrationModal(QObject):
                 sql_aliases = set(
                     session.scalars(select(TagAlias.name).where(TagAlias.tag_id == tag.id))
                 )
-                json_aliases = set(self.json_lib.get_tag(tag_id).aliases)
+                json_aliases = set([x for x in self.json_lib.get_tag(tag_id).aliases if x])
 
                 logger.info(
                     "[Alias Parity]",


### PR DESCRIPTION
This PR fixes #627 by not allowing empty string values for tag aliases inside the database.