### PR TITLE
chore: update pytest workflow to 24.04

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -26,7 +26,7 @@ jobs:
             x11-utils \
             libyaml-dev \
             libgl1 \
-            libglx-mesa0 \
+            libegl1 \
             libxcb-icccm4 \
             libxcb-image0 \
             libxcb-keysyms1 \

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
   pytest:
     name: Run tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repo
@@ -25,6 +25,8 @@ jobs:
             libxkbcommon-x11-0 \
             x11-utils \
             libyaml-dev \
+            libgl1 \
+            libglx-mesa-0 \
             libxcb-icccm4 \
             libxcb-image0 \
             libxcb-keysyms1 \

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -26,7 +26,7 @@ jobs:
             x11-utils \
             libyaml-dev \
             libgl1 \
-            libglx-mesa-0 \
+            libglx-mesa0 \
             libxcb-icccm4 \
             libxcb-image0 \
             libxcb-keysyms1 \

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install system dependencies
         run: |
           # dont run update, it is slow
-          sudo apt-get update
+          # sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libxkbcommon-x11-0 \
             x11-utils \

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -25,7 +25,6 @@ jobs:
             libxkbcommon-x11-0 \
             x11-utils \
             libyaml-dev \
-            libegl1 \
             libxcb-icccm4 \
             libxcb-image0 \
             libxcb-keysyms1 \

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install system dependencies
         run: |
           # dont run update, it is slow
-          # sudo apt-get update
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libxkbcommon-x11-0 \
             x11-utils \


### PR DESCRIPTION
This PR updates the pytest workflow to Ubuntu 24.04.