### PR TITLE
 fix: preview panel aliases not staying up to date with database

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -656,7 +656,11 @@ class QtDriver(DriverMixin, QObject):
 
     def show_tag_database(self):
         self.modal = PanelModal(
-            TagDatabasePanel(self.lib), "Library Tags", "Library Tags", has_save=False
+            widget=TagDatabasePanel(self.lib), 
+            title="Library Tags", 
+            window_title="Library Tags", 
+            done_callback=self.preview_panel.update_widgets,
+            has_save=False
         )
         self.modal.show()
 

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -656,11 +656,11 @@ class QtDriver(DriverMixin, QObject):
 
     def show_tag_database(self):
         self.modal = PanelModal(
-            widget=TagDatabasePanel(self.lib), 
-            title="Library Tags", 
-            window_title="Library Tags", 
+            widget=TagDatabasePanel(self.lib),
+            title="Library Tags",
+            window_title="Library Tags",
             done_callback=self.preview_panel.update_widgets,
-            has_save=False
+            has_save=False,
         )
         self.modal.show()
 

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -139,7 +139,9 @@ class TagBoxWidget(FieldWidget):
         self.edit_modal.saved.connect(
             lambda: self.driver.lib.update_tag(
                 build_tag_panel.build_tag(),
-                subtag_ids=build_tag_panel.subtag_ids,
+                subtag_ids=set(build_tag_panel.subtag_ids),
+                alias_names=set(build_tag_panel.alias_names),
+                alias_ids=set(build_tag_panel.alias_ids),
             )
         )
         self.edit_modal.show()


### PR DESCRIPTION
When changes were made to a tag using the tagDatabasePanel, those changes would not be reflected in the previewPanel.

When changes where made to a tag using the previewPanel, those changes would not be reflected in the database.