### PR TITLE
fix: stop sqlite db from being updated while running tests

### DIFF
--- a/tagstudio/src/core/library/alchemy/db.py
+++ b/tagstudio/src/core/library/alchemy/db.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import structlog
 from sqlalchemy import Dialect, Engine, String, TypeDecorator, create_engine, text
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 logger = structlog.getLogger(__name__)
 
@@ -37,10 +37,19 @@ def make_tables(engine: Engine) -> None:
     # tag IDs < 1000 are reserved
     # create tag and delete it to bump the autoincrement sequence
     # TODO - find a better way
-    with engine.connect() as conn:
-        conn.execute(text("INSERT INTO tags (id, name, color) VALUES (999, 'temp', 1)"))
-        conn.execute(text("DELETE FROM tags WHERE id = 999"))
-        conn.commit()
+    # is this the better way?
+    Session = sessionmaker(bind=engine)  # noqa: N806
+    session = Session()
+    result = session.execute(text("SELECT SEQ FROM sqlite_sequence WHERE name='tags'"))
+    autoincrement_val = result.fetchone()
+    if autoincrement_val:
+        # fetchone returns a tuple even when there is only one value
+        autoincrement_val = autoincrement_val[0]
+    if not autoincrement_val or autoincrement_val < 1000:
+        with engine.connect() as conn:
+            conn.execute(text("INSERT INTO tags (id, name, color) VALUES (999, 'temp', 1)"))
+            conn.execute(text("DELETE FROM tags WHERE id = 999"))
+            conn.commit()
 
 
 def drop_tables(engine: Engine) -> None:


### PR DESCRIPTION
This PR fixes #644 by having `make_tables` check the current autoincrement value (what the next inserted row would have as its id) on the `tags` table. Previously, an `INSERT` and a `DELETE` were always being run when a library was opened, causing the file change counter to increase

close #644 
close #646 