### PR TITLE
[Bug] Allow files with non latin paths to be opened from preview

### DIFF
--- a/tagstudio/src/qt/helpers/file_opener.py
+++ b/tagstudio/src/qt/helpers/file_opener.py
@@ -46,11 +46,9 @@ def open_file(path: str | Path, file_manager: bool = False):
                     | subprocess.CREATE_BREAKAWAY_FROM_JOB,
                 )
             else:
-                command_name = "start"
-                # first parameter is for title, NOT filepath
-                command_args = ["", normpath]
+                command = f'"{normpath}"'
                 subprocess.Popen(
-                    [command_name] + command_args,
+                    command,
                     shell=True,
                     close_fds=True,
                     creationflags=subprocess.CREATE_NEW_PROCESS_GROUP


### PR DESCRIPTION
this change fixes #666 and #350.

entering files full path into cmd opens it in its associated program, and using that instead of "start" fixes the issues.


im assuming it has something to do with "start" being almost 30 years old at this point but this seems to fix it for me