### PR TITLE
Fix: [Bug] Accent colors show as Gray on windows

### DIFF
--- a/tagstudio/src/qt/widgets/thumb_button.py
+++ b/tagstudio/src/qt/widgets/thumb_button.py
@@ -47,7 +47,7 @@ class ThumbButton(QPushButtonWrapper):
         self.hover_color.setHsl(
             self.hover_color.hslHue(),
             self.hover_color.hslSaturation(),
-            min(self.hover_color.lightness() + 80, 255),
+            min(self.hover_color.lightness() + 80, 200),
             self.hover_color.alpha(),
         )
 


### PR DESCRIPTION
I'm not too sure why the behaviour changed between versions of PySide but this seems to fix it on the newest version.
the colour limit was set too high so if you had a bright accent colour it would become closer to white/gray due to being too bright.

i cant speak for how this change looks on other platforms though so it should be tested there but on windows at least it brings back the colour and still creates an obvious select effect

close #668 