### PR TITLE
fix: preview panel + main window fixes and optimizations

### DIFF
--- a/tagstudio/src/qt/modals/folders_to_tags.py
+++ b/tagstudio/src/qt/modals/folders_to_tags.py
@@ -226,7 +226,7 @@ class FoldersToTagsModal(QWidget):
     def on_apply(self, event):
         folders_to_tags(self.library)
         self.close()
-        self.driver.preview_panel.update_widgets()
+        self.driver.preview_panel.update_widgets(update_preview=False)
 
     def on_open(self, event):
         for i in reversed(range(self.scroll_layout.count())):

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -665,6 +665,10 @@ class QtDriver(DriverMixin, QObject):
         self.settings.setValue(SettingItems.LAST_LIBRARY, str(self.lib.library_dir))
         self.settings.sync()
 
+        self.preview_panel.update_widgets()
+        self.main_window.searchField.setText("")
+        self.filter = FilterState.show_all()
+
         self.lib.close()
 
         self.thumb_job_queue.queue.clear()
@@ -1407,9 +1411,9 @@ class QtDriver(DriverMixin, QObject):
             Translations.translate_formatted(**translation_params), 3
         )
         self.main_window.repaint()
-        self.preview_panel.update_widgets()
-        self.main_window.searchField.setText("")
-        self.filter = FilterState.show_all()
+
+        if self.lib.library_dir:
+            self.close_library()
 
         open_status: LibraryStatus = None
         try:

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -665,8 +665,11 @@ class QtDriver(DriverMixin, QObject):
         self.settings.setValue(SettingItems.LAST_LIBRARY, str(self.lib.library_dir))
         self.settings.sync()
 
+        # Reset library state
         self.preview_panel.update_widgets()
         self.main_window.searchField.setText("")
+        scrollbar: QScrollArea = self.main_window.scrollArea
+        scrollbar.verticalScrollBar().setValue(0)
         self.filter = FilterState.show_all()
 
         self.lib.close()

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -626,7 +626,6 @@ class QtDriver(DriverMixin, QObject):
         self.main_window.pagination.index.connect(lambda i: self.page_move(page_id=i))
 
         self.splash.finish(self.main_window)
-        self.preview_panel.update_widgets()
 
     def show_grid_filenames(self, value: bool):
         for thumb in self.item_thumbs:
@@ -1408,6 +1407,9 @@ class QtDriver(DriverMixin, QObject):
             Translations.translate_formatted(**translation_params), 3
         )
         self.main_window.repaint()
+        self.preview_panel.update_widgets()
+        self.main_window.searchField.setText("")
+        self.filter = FilterState.show_all()
 
         open_status: LibraryStatus = None
         try:

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -459,7 +459,7 @@ class QtDriver(DriverMixin, QObject):
         self.autofill_action.triggered.connect(
             lambda: (
                 self.run_macros(MacroID.AUTOFILL, self.selected),
-                self.preview_panel.update_widgets(),
+                self.preview_panel.update_widgets(update_preview=False),
             )
         )
         macros_menu.addAction(self.autofill_action)
@@ -736,7 +736,7 @@ class QtDriver(DriverMixin, QObject):
                 item.thumb_button.set_selected(True)
 
         self.set_macro_menu_viability()
-        self.preview_panel.update_widgets()
+        self.preview_panel.update_widgets(update_preview=False)
 
     def clear_select_action_callback(self):
         self.selected.clear()
@@ -749,7 +749,7 @@ class QtDriver(DriverMixin, QObject):
     def show_tag_database(self):
         self.modal = PanelModal(
             widget=TagDatabasePanel(self.lib),
-            done_callback=self.preview_panel.update_widgets,
+            done_callback=lambda: self.preview_panel.update_widgets(update_preview=False),
             has_save=False,
         )
         Translations.translate_with_setter(self.modal.setTitle, "tag_manager.title")

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -500,7 +500,7 @@ class ItemThumb(FlowWidget):
             self.lib.remove_tags_from_entry(entry_id, tag_id)
 
         if self.driver.preview_panel.is_open:
-            self.driver.preview_panel.update_widgets()
+            self.driver.preview_panel.update_widgets(update_preview=False)
 
     def mouseMoveEvent(self, event):  # noqa: N802
         if event.buttons() is not Qt.MouseButton.LeftButton:

--- a/tagstudio/src/qt/widgets/preview_panel.py
+++ b/tagstudio/src/qt/widgets/preview_panel.py
@@ -131,8 +131,13 @@ class PreviewPanel(QWidget):
         root_layout.addWidget(splitter)
         root_layout.addWidget(add_buttons_container)
 
-    def update_widgets(self) -> bool:
-        """Render the panel widgets with the newest data from the Library."""
+    def update_widgets(self, update_preview: bool = True) -> bool:
+        """Render the panel widgets with the newest data from the Library.
+
+        Args:
+            update_preview(bool): Should the file preview be updated?
+            (Only works with one or more items selected)
+        """
         # No Items Selected
         try:
             if len(self.driver.selected) == 0:
@@ -151,8 +156,9 @@ class PreviewPanel(QWidget):
                 filepath: Path = self.lib.library_dir / entry.path
                 ext: str = filepath.suffix.lower()
 
-                stats: dict = self.thumb.update_preview(filepath, ext)
-                self.file_attrs.update_stats(filepath, ext, stats)
+                if update_preview:
+                    stats: dict = self.thumb.update_preview(filepath, ext)
+                    self.file_attrs.update_stats(filepath, ext, stats)
                 self.file_attrs.update_date_label(filepath)
                 self.fields.update_from_entry(entry_id)
                 self.update_add_tag_button(entry_id)

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -63,7 +63,7 @@ class TagBoxWidget(FieldWidget):
             tag_widget.on_remove.connect(
                 lambda tag_id=tag.id: (
                     self.remove_tag(tag_id),
-                    self.driver.preview_panel.update_widgets(),
+                    self.driver.preview_panel.update_widgets(update_preview=False),
                 )
             )
             tag_widget.on_edit.connect(lambda t=tag: self.edit_tag(t))
@@ -77,7 +77,7 @@ class TagBoxWidget(FieldWidget):
             build_tag_panel,
             tag.name,  # TODO - display name including parent tags
             "Edit Tag",
-            done_callback=self.driver.preview_panel.update_widgets,
+            done_callback=lambda: self.driver.preview_panel.update_widgets(update_preview=False),
             has_save=True,
         )
         # TODO - this was update_tag()


### PR DESCRIPTION
### Summary
This PR provides a few fixes and optimizations regarding refreshing the preview panel and resetting the state of the main window UI as a whole when closing or switching libraries:
- The media file preview for the preview panel now only updates when necessary
    - Before this would always update when information about the entry was modified, including when tags were added or even simply edited. Now operations such as adding tags no longer cause image thumbnails to re-render or for videos to restart.
- The preview panel is now cleared when closing or switching libraries
- The search bar is now cleared when closing or switching libraries
- The scrollbar position is now reset when closing or switching libraries
- The filter state, notably the page number, is now reset when switching libraries