### PR TITLE
Parity: Port create and add from v9.4 to v 9.5

### DIFF
--- a/tagstudio/resources/translations/en.json
+++ b/tagstudio/resources/translations/en.json
@@ -197,7 +197,7 @@
     "tag.color": "Color",
     "tag.confirm_delete": "Are you sure you want to delete the tag \"{tag_name}\"?",
     "tag.create": "Create Tag",
-	"tag.create_quick": "Create \"{query}\"",
+    "tag.create_quick": "Create \"{query}\"",
     "tag.edit": "Edit Tag",
     "tag.name": "Name",
     "tag.new": "New Tag",

--- a/tagstudio/resources/translations/en.json
+++ b/tagstudio/resources/translations/en.json
@@ -197,7 +197,7 @@
     "tag.color": "Color",
     "tag.confirm_delete": "Are you sure you want to delete the tag \"{tag_name}\"?",
     "tag.create": "Create Tag",
-    "tag.create_quick": "Create && Add \"{query}\"",
+    "tag.create_add": "Create && Add \"{query}\"",
     "tag.edit": "Edit Tag",
     "tag.name": "Name",
     "tag.new": "New Tag",

--- a/tagstudio/resources/translations/en.json
+++ b/tagstudio/resources/translations/en.json
@@ -197,6 +197,7 @@
     "tag.color": "Color",
     "tag.confirm_delete": "Are you sure you want to delete the tag \"{tag_name}\"?",
     "tag.create": "Create Tag",
+	"tag.create_quick": "Create \"{query}\"",
     "tag.edit": "Edit Tag",
     "tag.name": "Name",
     "tag.new": "New Tag",

--- a/tagstudio/resources/translations/en.json
+++ b/tagstudio/resources/translations/en.json
@@ -197,7 +197,7 @@
     "tag.color": "Color",
     "tag.confirm_delete": "Are you sure you want to delete the tag \"{tag_name}\"?",
     "tag.create": "Create Tag",
-    "tag.create_quick": "Create \"{query}\"",
+    "tag.create_quick": "Create && Add \"{query}\"",
     "tag.edit": "Edit Tag",
     "tag.name": "Name",
     "tag.new": "New Tag",

--- a/tagstudio/resources/translations/fr.json
+++ b/tagstudio/resources/translations/fr.json
@@ -115,7 +115,7 @@
     "tag.add_to_search": "Ajouter à la Recherche",
     "tag.aliases": "Alias",
     "tag.color": "Couleur",
-	"tag.create_quick": "Créer \"{query}\""
+    "tag.create_quick": "Créer \"{query}\""
     "tag.name": "Nom",
     "tag.new": "Nouveau Label",
     "tag.parent_tags": "Labels Parent",

--- a/tagstudio/resources/translations/fr.json
+++ b/tagstudio/resources/translations/fr.json
@@ -115,6 +115,7 @@
     "tag.add_to_search": "Ajouter à la Recherche",
     "tag.aliases": "Alias",
     "tag.color": "Couleur",
+	"tag.create_quick": "Créer \"{query}\""
     "tag.name": "Nom",
     "tag.new": "Nouveau Label",
     "tag.parent_tags": "Labels Parent",

--- a/tagstudio/resources/translations/fr.json
+++ b/tagstudio/resources/translations/fr.json
@@ -115,7 +115,7 @@
     "tag.add_to_search": "Ajouter à la Recherche",
     "tag.aliases": "Alias",
     "tag.color": "Couleur",
-    "tag.create_quick": "Créer && Adjouter \"{query}\""
+    "tag.create_add": "Créer && Adjouter \"{query}\""
     "tag.name": "Nom",
     "tag.new": "Nouveau Label",
     "tag.parent_tags": "Labels Parent",

--- a/tagstudio/resources/translations/fr.json
+++ b/tagstudio/resources/translations/fr.json
@@ -115,7 +115,7 @@
     "tag.add_to_search": "Ajouter à la Recherche",
     "tag.aliases": "Alias",
     "tag.color": "Couleur",
-    "tag.create_quick": "Créer \"{query}\""
+    "tag.create_quick": "Créer && Adjouter \"{query}\""
     "tag.name": "Nom",
     "tag.new": "Nouveau Label",
     "tag.parent_tags": "Labels Parent",

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -25,6 +25,7 @@ from src.core.palette import ColorType, get_tag_color
 from src.qt.translations import Translations
 from src.qt.widgets.panel import PanelModal, PanelWidget
 from src.qt.widgets.tag import TagWidget
+from src.qt import translations
 
 logger = structlog.get_logger(__name__)
 
@@ -127,14 +128,8 @@ class TagSearchPanel(PanelWidget):
         row.setSpacing(3)
 
         create_button = QPushButton(self)
+        Translations.translate_qobject(create_button, "tag.create_quick", query=query)
         create_button.setFlat(True)
-        create_button.setText(f"Create \"{query.replace('&', '&&')}\"")
-
-        row.setSpacing(3)
-
-        create_button = QPushButton(self)
-        create_button.setFlat(True)
-        create_button.setText(f"Create \"{query.replace("&", "&&")}\"")
 
         inner_layout = QHBoxLayout()
         inner_layout.setObjectName("innerLayout")

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -119,7 +119,7 @@ class TagSearchPanel(PanelWidget):
             row.addWidget(add_button)
         return container
 
-    def create_tag_button(self, query: str | None):
+    def construct_tag_button(self, query: str | None):
         """Constructs a Create Tag Button."""
         container = QWidget()
         row = QHBoxLayout(container)
@@ -204,7 +204,7 @@ class TagSearchPanel(PanelWidget):
 
         # If query doesnt exist add create button
         if len(tag_results) == 0:
-            c = self.create_tag_button(query)
+            c = self.construct_tag_button(query)
             self.scroll_layout.addWidget(c)
 
         self.search_field.setFocus()

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -209,11 +209,14 @@ class TagSearchPanel(PanelWidget):
         self.search_field.setFocus()
 
     def on_return(self, text: str):
-        if text and self.first_tag_id is not None:
-            if self.is_tag_chooser:
-                self.tag_chosen.emit(self.first_tag_id)
-            self.search_field.setText("")
-            self.update_tags()
+        if text:
+            if self.first_tag_id is not None:
+                if self.is_tag_chooser:
+                    self.tag_chosen.emit(self.first_tag_id)
+                self.search_field.setText("")
+                self.update_tags()
+            else:
+                self.create_and_add_tag(text)
         else:
             self.search_field.setFocus()
             self.parentWidget().hide()

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -5,7 +5,7 @@
 
 import math
 
-import src.qt.modals.build_tag as bt
+import src.qt.modals.build_tag as build_tag
 import structlog
 from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtGui import QShowEvent
@@ -127,7 +127,7 @@ class TagSearchPanel(PanelWidget):
         row.setSpacing(3)
 
         create_button = QPushButton(self)
-        Translations.translate_qobject(create_button, "tag.create_quick", query=query)
+        Translations.translate_qobject(create_button, "tag.create_add", query=query)
         create_button.setFlat(True)
 
         inner_layout = QHBoxLayout()
@@ -162,7 +162,7 @@ class TagSearchPanel(PanelWidget):
 
     def create_and_add_tag(self, name: str):
         """Opens "Create Tag" panel to create and add a new tag with given name."""
-        logger.info("Quick Create Tag", name=name)
+        logger.info("Create and Add Tag", name=name)
 
         def on_tag_modal_saved():
             """Callback for actions to perform when a new tag is confirmed created."""
@@ -171,12 +171,14 @@ class TagSearchPanel(PanelWidget):
             self.add_tag_modal.hide()
 
             self.tag_chosen.emit(tag.id)
+            self.search_field.setText("")
             self.update_tags()
 
-        self.build_tag_modal: bt.BuildTagPanel = bt.BuildTagPanel(self.lib)
-        self.add_tag_modal: PanelModal = PanelModal(
-            self.build_tag_modal, "New Tag", "Add Tag", has_save=True
-        )
+        self.build_tag_modal: build_tag.BuildTagPanel = build_tag.BuildTagPanel(self.lib)
+        self.add_tag_modal: PanelModal = PanelModal(self.build_tag_modal, has_save=True)
+        Translations.translate_with_setter(self.add_tag_modal.setTitle, "tag.new")
+        Translations.translate_with_setter(self.add_tag_modal.setWindowTitle, "tag.add")
+
         self.build_tag_modal.name_field.setText(name)
         self.add_tag_modal.saved.connect(on_tag_modal_saved)
         self.add_tag_modal.save_button.setFocus()
@@ -226,13 +228,13 @@ class TagSearchPanel(PanelWidget):
         pass
 
     def edit_tag(self, tag: Tag):
-        def callback(btp: bt.BuildTagPanel):
+        def callback(btp: build_tag.BuildTagPanel):
             self.lib.update_tag(
                 btp.build_tag(), set(btp.parent_ids), set(btp.alias_names), set(btp.alias_ids)
             )
             self.update_tags(self.search_field.text())
 
-        build_tag_panel = bt.BuildTagPanel(self.lib, tag=tag)
+        build_tag_panel = build_tag.BuildTagPanel(self.lib, tag=tag)
 
         self.edit_modal = PanelModal(
             build_tag_panel,

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -166,8 +166,11 @@ class TagSearchPanel(PanelWidget):
 
         def on_tag_modal_saved():
             """Callback for actions to perform when a new tag is confirmed created."""
-            self.lib.add_tag(self.build_tag_modal.build_tag())
+            tag: Tag = self.build_tag_modal.build_tag()
+            self.lib.add_tag(tag)
             self.add_tag_modal.hide()
+
+            self.tag_chosen.emit(tag.id)
             self.update_tags()
 
         self.build_tag_modal: bt.BuildTagPanel = bt.BuildTagPanel(self.lib)


### PR DESCRIPTION
close #688 

- Ports the Create & Add tag to v9.5
- added translation keys (only one) for English and French
- unify use of BuildTagPanel to avoid multiple imports within functions

hope this is alright

(edit: to add images) 
Clicking create opens the Add Tag modal
![image](https://github.com/user-attachments/assets/ac660854-a6b1-4f19-a790-db847c7e55bd)

