### PR TITLE
docs: discourage force-pushes on prs that are open for review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Most of the style guidelines can be checked, fixed, and enforced via Ruff. Older
 -   Pull requests should ideally be limited to **a single** feature or fix.
 
 > [!IMPORTANT]
-> Please do not force push after a review of your PR has been made!
+> Please do not force push if your PR is open for review!
 > 
 > Force pushing makes it impossible to discern which changes have already been reviewed and which haven't. This means a reviewer will then have to rereview all the already reviewed code, which is a lot of unnecessary work for reviewers.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,11 @@ Most of the style guidelines can be checked, fixed, and enforced via Ruff. Older
 -   Pull requests should have an adequate title and description which clearly outline your intentions and changes/additions. Feel free to provide screenshots, GIFs, or videos, especially for UI changes.
 -   Pull requests should ideally be limited to **a single** feature or fix.
 
+> [!IMPORTANT]
+> Please do not force push after a review of your PR has been made!
+> 
+> Force pushing makes it impossible to discern which changes have already been reviewed and which haven't. This means a reviewer will then have to rereview all the already reviewed code, which is a lot of unnecessary work for reviewers.
+
 > [!TIP]
 > If you're unsure where to stop the scope of your PR, ask yourself: _"If I broke this up, could any parts of it still be used by the project in the meantime?"_
 


### PR DESCRIPTION
As agreed on the discord, a change to the contribution guidelines to discourage force-pushing on PRs that are open for review.

This change is meant to lighten the work of reviewers, because - due to the way that git works - when a force push happens after a review has already been made, or while a review is being made, it is not really possible to figure out which changes were already reviewed and which weren't. Thus a reviewer in this situation is forced to rereview a bunch of code that they have already reviewed (which is quite frustrating in my experience).