### PR TITLE
fix: sort tag results

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -632,7 +632,7 @@ class Library:
 
     def search_tags(
         self,
-        name: str,
+        name: str | None,
     ) -> list[Tag]:
         """Return a list of Tag records matching the query."""
         tag_limit = 100

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -202,7 +202,7 @@ class TagSearchPanel(PanelWidget):
                     results_2.append(tag)
             results_1.sort(key=lambda tag: len(tag.name))
             results_2.sort()
-            for tag in results_1 + results_2: 
+            for tag in results_1 + results_2:
                 self.scroll_layout.addWidget(self.__build_row_item_widget(tag))
         else:
             # If query doesnt exist add create button

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -186,26 +186,28 @@ class TagSearchPanel(PanelWidget):
 
     def update_tags(self, query: str | None = None):
         logger.info("[Tag Search Super Class] Updating Tags")
-
         # TODO: Look at recycling rather than deleting and re-initializing
         while self.scroll_layout.count():
             self.scroll_layout.takeAt(0).widget().deleteLater()
-
         tag_results = self.lib.search_tags(name=query)
         if len(tag_results) > 0:
-            self.first_tag_id = tag_results[0].id
-        else:
-            self.first_tag_id = None
-
-        for tag in tag_results:
-            if tag.id not in self.exclude:
+            results_1 = []
+            results_2 = []
+            for tag in tag_results:
+                if tag.id in self.exclude:
+                    continue
+                elif query and tag.name.lower().startswith(query.lower()):
+                    results_1.append(tag)
+                else:
+                    results_2.append(tag)
+            results_1.sort(key=lambda tag: len(tag.name))
+            results_2.sort()
+            for tag in results_1 + results_2: 
                 self.scroll_layout.addWidget(self.__build_row_item_widget(tag))
-
-        # If query doesnt exist add create button
-        if len(tag_results) == 0:
+        else:
+            # If query doesnt exist add create button
             c = self.construct_tag_button(query)
             self.scroll_layout.addWidget(c)
-
         self.search_field.setFocus()
 
     def on_return(self, text: str):


### PR DESCRIPTION
fix for #687. added logic to sort the results of a tag search. currently prioritizing results that start with the correct string and sorting them by length, and then sorting all other results alphabetically. saw the todo comment, but i could not figure out a simple way of reusing the widgets, theyd probably have to be stored in a dict between updates or something.