### PR TITLE
fix: have pydub use known ffmpeg+ffprobe locations

### DIFF
--- a/tagstudio/src/qt/helpers/vendored/ffmpeg.py
+++ b/tagstudio/src/qt/helpers/vendored/ffmpeg.py
@@ -23,11 +23,23 @@ def _get_ffprobe_location() -> str:
             if shutil.which(loc + cmd):
                 cmd = loc + cmd
                 break
-    logger.info(f"[FFPROBE] Using FFmpeg location: {cmd}")
+    logger.info(f"[FFMPEG] Using FFprobe location: {cmd}")
+    return cmd
+
+
+def _get_ffmpeg_location() -> str:
+    cmd: str = "ffmpeg"
+    if platform.system() == "Darwin":
+        for loc in FFMPEG_MACOS_LOCATIONS:
+            if shutil.which(loc + cmd):
+                cmd = loc + cmd
+                break
+    logger.info(f"[FFMPEG] Using FFmpeg location: {cmd}")
     return cmd
 
 
 FFPROBE_CMD = _get_ffprobe_location()
+FFMPEG_CMD = _get_ffmpeg_location()
 
 
 def _probe(filename, cmd=FFPROBE_CMD, timeout=None, **kwargs):

--- a/tagstudio/src/qt/helpers/vendored/pydub/audio_segment.py
+++ b/tagstudio/src/qt/helpers/vendored/pydub/audio_segment.py
@@ -17,6 +17,7 @@ from tempfile import NamedTemporaryFile
 
 from pydub.logging_utils import log_conversion, log_subprocess_output
 from pydub.utils import fsdecode
+from src.qt.helpers.vendored.ffmpeg import FFMPEG_CMD
 
 try:
     from itertools import izip
@@ -37,7 +38,6 @@ from pydub.utils import (
     audioop,
     db_to_float,
     get_array_type,
-    get_encoder_name,
     ratio_to_db,
 )
 from src.qt.helpers.silent_popen import promptless_Popen
@@ -159,7 +159,7 @@ class _AudioSegment:
         slice = a[5000:10000] # get a slice from 5 to 10 seconds of an mp3
     """
 
-    converter = get_encoder_name()  # either ffmpeg or avconv
+    converter = FFMPEG_CMD
 
     # TODO: remove in 1.0 release
     # maintain backwards compatibility for ffmpeg attr (now called converter)
@@ -725,7 +725,7 @@ class _AudioSegment:
             stdin_parameter = None
             stdin_data = None
         else:
-            if cls.converter == "ffmpeg":
+            if cls.converter == FFMPEG_CMD:
                 conversion_command += [
                     "-read_ahead_limit",
                     str(read_ahead_limit),
@@ -737,14 +737,8 @@ class _AudioSegment:
             stdin_parameter = subprocess.PIPE
             stdin_data = file.read()
 
-        if codec:
-            info = None
-        else:
-            # PATCHED
-            try:
-                info = _mediainfo_json(orig_file, read_ahead_limit=read_ahead_limit)
-            except FileNotFoundError:
-                raise ChildProcessError
+        # PATCHED
+        info = None if codec else _mediainfo_json(orig_file, read_ahead_limit=read_ahead_limit)
         if info:
             audio_streams = [x for x in info["streams"] if x["codec_type"] == "audio"]
             # This is a workaround for some ffprobe versions that always say

--- a/tagstudio/src/qt/helpers/vendored/pydub/utils.py
+++ b/tagstudio/src/qt/helpers/vendored/pydub/utils.py
@@ -6,14 +6,14 @@ from pydub.utils import (
     _fd_or_path_or_tempfile,
     fsdecode,
     get_extra_info,
-    get_prober_name,
 )
 from src.qt.helpers.silent_popen import promptless_Popen
+from src.qt.helpers.vendored.ffmpeg import FFPROBE_CMD
 
 
 def _mediainfo_json(filepath, read_ahead_limit=-1):
     """Return json dictionary with media info(codec, duration, size, bitrate...) from filepath."""
-    prober = get_prober_name()
+    prober = FFPROBE_CMD
     command_args = [
         "-v",
         "info",

--- a/tagstudio/src/qt/helpers/vendored/pydub/utils.py
+++ b/tagstudio/src/qt/helpers/vendored/pydub/utils.py
@@ -10,6 +10,7 @@ from pydub.utils import (
 from src.qt.helpers.silent_popen import silent_Popen
 from src.qt.helpers.vendored.ffmpeg import FFPROBE_CMD
 
+
 def _mediainfo_json(filepath, read_ahead_limit=-1):
     """Return json dictionary with media info(codec, duration, size, bitrate...) from filepath."""
     prober = FFPROBE_CMD

--- a/tagstudio/src/qt/modals/ffmpeg_checker.py
+++ b/tagstudio/src/qt/modals/ffmpeg_checker.py
@@ -6,7 +6,7 @@ import structlog
 from PySide6.QtCore import Qt, QUrl
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QMessageBox
-from src.qt.helpers.vendored.ffmpeg import FFPROBE_CMD
+from src.qt.helpers.vendored.ffmpeg import FFMPEG_CMD, FFPROBE_CMD
 
 logger = structlog.get_logger(__name__)
 
@@ -39,7 +39,7 @@ class FfmpegChecker(QMessageBox):
 
     def installed(self):
         """Checks if both FFmpeg and FFprobe are installed and in the PATH."""
-        if which("ffmpeg"):
+        if which(FFMPEG_CMD):
             self.ffmpeg = True
         if which(FFPROBE_CMD):
             self.ffprobe = True
@@ -60,7 +60,7 @@ class FfmpegChecker(QMessageBox):
                     version["ffprobe"] = ret.stdout.split("\n")[1].replace("-", "=").split("=")[1]
         if self.ffmpeg:
             ret = subprocess.run(
-                ["ffmpeg", "-version"], shell=False, capture_output=True, text=True
+                [FFMPEG_CMD, "-version"], shell=False, capture_output=True, text=True
             )
             if ret.returncode == 0:
                 with contextlib.suppress(Exception):
@@ -68,7 +68,7 @@ class FfmpegChecker(QMessageBox):
         return version
 
     def show_warning(self):
-        """Displays the warning to the user and awaits respone."""
+        """Displays the warning to the user and awaits response."""
         missing = "FFmpeg"
         # If ffmpeg is installed but not ffprobe
         if not self.ffprobe and self.ffmpeg:

--- a/tagstudio/src/qt/widgets/thumb_renderer.py
+++ b/tagstudio/src/qt/widgets/thumb_renderer.py
@@ -29,7 +29,6 @@ from PIL import (
 )
 from PIL.Image import DecompressionBombError
 from pillow_heif import register_avif_opener, register_heif_opener
-from pydub import exceptions
 from PySide6.QtCore import (
     QBuffer,
     QFile,
@@ -555,7 +554,7 @@ class ThumbRenderer(QObject):
 
             im.resize((size, size), Image.Resampling.BILINEAR)
 
-        except exceptions.CouldntDecodeError as e:
+        except Exception as e:
             logger.error("Couldn't render waveform", path=filepath.name, error=type(e).__name__)
 
         return im


### PR DESCRIPTION
### Summary
This PR aims to fix audio waveforms not rendering in macOS builds, plus ensuring that the location of FFmpeg is used by pydub and the new "About" screen.

### Previous behavior (main branch):
![image](https://github.com/user-attachments/assets/f60ed914-afc0-4635-8ac3-43e832954b90)
![image](https://github.com/user-attachments/assets/82bd6e2c-f6f6-4526-87a0-57c7177766ee)

### Correct behavior:
![image](https://github.com/user-attachments/assets/7cff8f82-cc3e-4806-8a4a-2498da249665)
![image](https://github.com/user-attachments/assets/3c9ba708-67d9-41e9-8b8e-6950d0343ed1)

Note that video thumbnail rendering, video playback, and audio playback all functioned before and after this PR.