### PR TITLE
fix: use tag aliases in tag search

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -638,7 +638,7 @@ class Library:
         tag_limit = 100
 
         with Session(self.engine) as session:
-            query = select(Tag)
+            query = select(Tag).outerjoin(TagAlias)
             query = query.options(
                 selectinload(Tag.parent_tags),
                 selectinload(Tag.aliases),
@@ -649,12 +649,12 @@ class Library:
                     or_(
                         Tag.name.icontains(name),
                         Tag.shorthand.icontains(name),
+                        TagAlias.name.icontains(name),
                     )
                 )
 
             tags = session.scalars(query)
-
-            res = list(tags)
+            res = list(set(tags))
 
             logger.info(
                 "searching tags",


### PR DESCRIPTION
Tag searches now include searching for tag aliases. Fixes #682
![image](https://github.com/user-attachments/assets/cf271092-256b-463c-9478-8f818abd9645)