### PR TITLE
fix: replace calls to `translate_qobject` with `translate_formatted` inside `TagWidget` (Fix #733)

### DIFF
--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -52,7 +52,7 @@ class TagSearchPanel(PanelWidget):
         self.search_field.setObjectName("searchField")
         self.search_field.setMinimumSize(QSize(0, 32))
         Translations.translate_with_setter(self.search_field.setPlaceholderText, "home.search_tags")
-        self.search_field.textEdited.connect(lambda: self.update_tags(self.search_field.text()))
+        self.search_field.textEdited.connect(lambda text: self.update_tags(text))
         self.search_field.returnPressed.connect(lambda: self.on_return(self.search_field.text()))
 
         self.scroll_contents = QWidget()
@@ -119,7 +119,7 @@ class TagSearchPanel(PanelWidget):
             row.addWidget(add_button)
         return container
 
-    def construct_tag_button(self, query: str | None):
+    def build_create_tag_button(self, query: str | None):
         """Constructs a Create Tag Button."""
         container = QWidget()
         row = QHBoxLayout(container)
@@ -208,7 +208,7 @@ class TagSearchPanel(PanelWidget):
         else:
             # If query doesnt exist add create button
             self.first_tag_id = None
-            c = self.construct_tag_button(query)
+            c = self.build_create_tag_button(query)
             self.scroll_layout.addWidget(c)
         self.search_field.setFocus()
 

--- a/tagstudio/src/qt/widgets/tag.py
+++ b/tagstudio/src/qt/widgets/tag.py
@@ -126,20 +126,22 @@ class TagWidget(QWidget):
         self.bg_button.setText(tag.name)
         if has_edit:
             edit_action = QAction(self)
-            Translations.translate_qobject(edit_action, "generic.edit")
+            edit_action.setText(Translations.translate_formatted("generic.edit"))
             edit_action.triggered.connect(on_edit_callback)
             edit_action.triggered.connect(self.on_edit.emit)
             self.bg_button.addAction(edit_action)
         # if on_click_callback:
         self.bg_button.setContextMenuPolicy(Qt.ContextMenuPolicy.ActionsContextMenu)
 
+        # TODO: This currently doesn't work in "Add Tag" menus. Either fix this or
+        # disable it in that context.
         search_for_tag_action = QAction(self)
-        Translations.translate_qobject(search_for_tag_action, "tag.search_for_tag")
+        search_for_tag_action.setText(Translations.translate_formatted("tag.search_for_tag"))
         search_for_tag_action.triggered.connect(self.on_click.emit)
         self.bg_button.addAction(search_for_tag_action)
-        add_to_search_action = QAction(self)
-        Translations.translate_qobject(add_to_search_action, "tag.add_to_search")
-        self.bg_button.addAction(add_to_search_action)
+        # add_to_search_action = QAction(self)
+        # add_to_search_action.setText(Translations.translate_formatted("tag.add_to_search"))
+        # self.bg_button.addAction(add_to_search_action)
 
         self.inner_layout = QHBoxLayout()
         self.inner_layout.setObjectName("innerLayout")

--- a/tagstudio/src/qt/widgets/tag.py
+++ b/tagstudio/src/qt/widgets/tag.py
@@ -4,10 +4,8 @@
 
 
 import math
-from pathlib import Path
 from types import FunctionType
 
-from PIL import Image
 from PySide6.QtCore import QEvent, Qt, Signal
 from PySide6.QtGui import QAction, QEnterEvent, QFontMetrics
 from PySide6.QtWidgets import (
@@ -93,10 +91,6 @@ class TagAliasWidget(QWidget):
 
 
 class TagWidget(QWidget):
-    edit_icon_128: Image.Image = Image.open(
-        str(Path(__file__).parents[3] / "resources/qt/images/edit_icon_128.png")
-    ).resize((math.floor(14 * 1.25), math.floor(14 * 1.25)))
-    edit_icon_128.load()
     on_remove = Signal()
     on_click = Signal()
     on_edit = Signal()


### PR DESCRIPTION
This PR aims to fix #733 by replacing calls to `translate_qobject` with `translate_formatted` inside the `TagWidget` class, as for an unknown reason this seems to cause the application to progressively slow down as more TagWidgets are created and removed over time, and also seemingly causes a memory leak.

The `translate_qobject` issue should be investigated further, however for now this fix should hopefully address the specific issue raised in #733. I've also included a couple small fixes and tweaks to nearby code that I discovered while tracking this down.