### PR TITLE
fix: keep initial id order in `get_entries_full()` (Fix #723)

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -455,7 +455,7 @@ class Library:
             entries: ScalarResult[Entry] | list[Entry] = session.execute(statement).scalars()
             entries = entries.unique()  # type: ignore
 
-            entry_order_dict = {order: e_id for e_id, order in enumerate(entry_ids)}
+            entry_order_dict = {e_id: order for order, e_id in enumerate(entry_ids)}
             entries = sorted(entries, key=lambda e: entry_order_dict[e.id])
 
             for entry in entries:

--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     ColumnExpressionArgument,
     Engine,
     NullPool,
+    ScalarResult,
     and_,
     asc,
     create_engine,
@@ -451,9 +452,11 @@ class Library:
                 ),
             )
             statement = statement.distinct()
+            entries: ScalarResult[Entry] | list[Entry] = session.execute(statement).scalars()
+            entries = entries.unique()  # type: ignore
 
-            entries = session.execute(statement).scalars()
-            entries = entries.unique()
+            entry_order_dict = {order: e_id for e_id, order in enumerate(entry_ids)}
+            entries = sorted(entries, key=lambda e: entry_order_dict[e.id])
 
             for entry in entries:
                 yield entry


### PR DESCRIPTION
Fixes #723 by retaining the initial entry ID order when returning results from `get_entries_full().