### PR TITLE
perf: add all new library entries at once

### DIFF
--- a/tagstudio/resources/translations/en.json
+++ b/tagstudio/resources/translations/en.json
@@ -20,7 +20,7 @@
     "entries.mirror.title": "Mirroring Entries",
     "entries.mirror.window_title": "Mirror Entries",
     "entries.mirror": "&Mirror",
-    "entries.running.dialog.new_entries": "Adding {count}/{total} New File Entries...",
+    "entries.running.dialog.new_entries": "Adding {total} New File Entries...",
     "entries.running.dialog.title": "Adding New File Entries",
     "entries.tags": "Tags",
     "entries.unlinked.delete_alt": "De&lete Unlinked Entries",

--- a/tagstudio/src/core/utils/refresh_dir.py
+++ b/tagstudio/src/core/utils/refresh_dir.py
@@ -33,24 +33,22 @@ class RefreshDirTracker:
     def files_count(self) -> int:
         return len(self.files_not_in_library)
 
-    def save_new_files(self) -> Iterator[int]:
+    def save_new_files(self):
         """Save the list of files that are not in the library."""
-        if not self.files_not_in_library:
-            yield 0
-
-        for idx, entry_path in enumerate(self.files_not_in_library):
-            self.library.add_entries(
-                [
-                    Entry(
-                        path=entry_path,
-                        folder=self.library.folder,
-                        fields=[],
-                    )
-                ]
-            )
-            yield idx
+        if self.files_not_in_library:
+            entries = [
+                Entry(
+                    path=entry_path,
+                    folder=self.library.folder,
+                    fields=[],
+                )
+                for entry_path in self.files_not_in_library
+            ]
+            self.library.add_entries(entries)
 
         self.files_not_in_library = []
+
+        yield
 
     def refresh_dir(self, lib_path: Path) -> Iterator[int]:
         """Scan a directory for files, and add those relative filenames to internal variables."""

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -786,8 +786,8 @@ class QtDriver(DriverMixin, QObject):
                         "library.refresh.scanning.plural"
                         if x + 1 != 1
                         else "library.refresh.scanning.singular",
-                        searched_count=x + 1,
-                        found_count=tracker.files_count,
+                        searched_count=f"{x+1:n}",
+                        found_count=f"{tracker.files_count:n}",
                     )
                 ),
             )
@@ -813,20 +813,19 @@ class QtDriver(DriverMixin, QObject):
         pw = ProgressWidget(
             cancel_button_text=None,
             minimum=0,
-            maximum=files_count,
+            maximum=0,
         )
         Translations.translate_with_setter(pw.setWindowTitle, "entries.running.dialog.title")
         Translations.translate_with_setter(
-            pw.update_label, "entries.running.dialog.new_entries", count=1, total=files_count
+            pw.update_label, "entries.running.dialog.new_entries", total=f"{files_count:n}"
         )
         pw.show()
 
         iterator.value.connect(
-            lambda x: (
-                pw.update_progress(x + 1),
+            lambda: (
                 pw.update_label(
                     Translations.translate_formatted(
-                        "entries.running.dialog.new_entries", count=x + 1, total=files_count
+                        "entries.running.dialog.new_entries", total=f"{files_count:n}"
                     )
                 ),
             )


### PR DESCRIPTION
This PR drastically reduces the amount of time needed to add new file entries to the library after refreshing by adding all entries to the database in a single operation.