### PR TITLE
feat: show audio/video file lengths

### DIFF
--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Travis Abendshien (CyanVoxel).
 # Licensed under the GPL-3.0 License.
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+import subprocess
 import time
 import typing
 from enum import Enum
@@ -10,9 +11,8 @@ from typing import TYPE_CHECKING
 from warnings import catch_warnings
 
 import structlog
-import subprocess
 from PIL import Image, ImageQt
-from PySide6.QtCore import QEvent, QMimeData, QSize, QThreadPool, Qt, QUrl
+from PySide6.QtCore import QEvent, QMimeData, QSize, Qt, QThreadPool, QUrl
 from PySide6.QtGui import QAction, QDrag, QEnterEvent, QPixmap
 from PySide6.QtWidgets import (
     QBoxLayout,
@@ -29,13 +29,13 @@ from src.core.constants import (
 from src.core.library import ItemType, Library
 from src.core.media_types import MediaCategories, MediaType
 from src.qt.flowlayout import FlowWidget
+from src.qt.helpers.custom_runnable import CustomRunnable
 from src.qt.helpers.file_opener import FileOpenerHelper
+from src.qt.helpers.vendored.ffmpeg import FFPROBE_CMD
 from src.qt.platform_strings import open_file_str, trash_term
 from src.qt.translations import Translations
 from src.qt.widgets.thumb_button import ThumbButton
 from src.qt.widgets.thumb_renderer import ThumbRenderer
-from src.qt.helpers.vendored.ffmpeg import FFPROBE_CMD
-from src.qt.helpers.custom_runnable import CustomRunnable
 
 if TYPE_CHECKING:
     from src.qt.ts_qt import QtDriver
@@ -431,7 +431,7 @@ class ItemThumb(FlowWidget):
 
     def update_count_badge(self, filename) -> None:
         """Updates the count badge."""
-        if self.count_badge_set:
+        if self.count_badge_set or self.filename is None:
             return
 
         def set_video_audio():


### PR DESCRIPTION
this pr gets and sets the file lengths for video and audio, upon hovering over a thumbnail, this can work as a temporary fix until I can get it to work without a performance hit (thanks @Nginearing for the idea)

![image](https://github.com/user-attachments/assets/46ba0283-552d-47c1-8ed9-9bf559c3b160)
![image](https://github.com/user-attachments/assets/03a516e2-0fb1-43c6-a763-4430dd087ccc)

this doesnt block the main thread and i havent noticed any performance hit (my audio libraries arent huge, 30 at best).
