### PR TITLE
fix(ui): revert all `item_thumb` "pressed" changes (Fix #732)

### DIFF
--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -440,10 +440,8 @@ class ItemThumb(FlowWidget):
         """Updates attributes of a thumbnail element."""
         if clickable:
             with catch_warnings(record=True):
-                self.thumb_button.pressed.disconnect()
-            self.thumb_button.pressed.connect(
-                lambda: clickable() if not self.thumb_button.selected else None
-            )
+                self.thumb_button.clicked.disconnect()
+            self.thumb_button.clicked.connect(clickable)
 
     def set_item_id(self, item_id: int):
         self.item_id = item_id


### PR DESCRIPTION
This PR fixes the critical issue of not being able to ctrl+deselect items in the thumbnail grid (#732) by reverting the "thumb_button.clicked -> thumb_button.pressed" changes made in #556, which caused the drag and drop issue described in #706, which was later addressed in #710, however with the side effect of causing the selection issue described in #732.

This PR knowingly comes with a regression to the click behavior prior to #555, however the time sensitivity and severity of #732 outweighs the enhancement requested in #555.