### PR TITLE
feat: add smartcase and globless path searches

### DIFF
--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -697,8 +697,6 @@ class Library:
         with Session(self.engine) as session:
             paths = session.scalars(select(Entry.path)).unique()
             path_strings = list(map(lambda x: x.as_posix(), paths))
-
-            path_strings: list[str] = list(map(lambda x: x.as_posix(), paths))
             return path_strings
 
     def search_library(

--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -692,10 +692,13 @@ class Library:
         with Session(self.engine) as session:
             return session.query(exists().where(Entry.path == path)).scalar()
 
-    def get_paths(self, glob: str | None = None) -> list[str]:
+    def get_paths(self, glob: str | None = None, limit: int = -1) -> list[str]:
         path_strings: list[str] = []
         with Session(self.engine) as session:
-            paths = session.scalars(select(Entry.path)).unique()
+            if limit > 0:
+                paths = session.scalars(select(Entry.path).limit(limit)).unique()
+            else:
+                paths = session.scalars(select(Entry.path)).unique()
             path_strings = list(map(lambda x: x.as_posix(), paths))
             return path_strings
 

--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -698,7 +698,8 @@ class Library:
             paths = session.scalars(select(Entry.path)).unique()
             path_strings = list(map(lambda x: x.as_posix(), paths))
 
-        return path_strings
+            path_strings: list[str] = list(map(lambda x: x.as_posix(), paths))
+            return path_strings
 
     def search_library(
         self,

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1506,7 +1506,9 @@ class QtDriver(DriverMixin, QObject):
         elif query_type == "tag_id":
             completion_list = list(map(lambda x: prefix + "tag_id:" + str(x.id), self.lib.tags))
         elif query_type == "path":
-            completion_list = list(map(lambda x: prefix + "path:" + x, self.lib.get_paths()))
+            completion_list = list(
+                map(lambda x: prefix + "path:" + x, self.lib.get_paths(limit=100))
+            )
         elif query_type == "mediatype":
             single_word_completions = map(
                 lambda x: prefix + "mediatype:" + x.name,

--- a/tagstudio/tests/test_library.py
+++ b/tagstudio/tests/test_library.py
@@ -414,6 +414,24 @@ def test_library_prefs_multiple_identical_vals():
         assert TestPrefs.BAR.value
 
 
+def test_path_search_ilike(library: Library):
+    results = library.search_library(FilterState.from_path("bar.md"))
+    assert results.total_count == 1
+    assert len(results.items) == 1
+
+
+def test_path_search_like(library: Library):
+    results = library.search_library(FilterState.from_path("BAR.MD"))
+    assert results.total_count == 0
+    assert len(results.items) == 0
+
+
+def test_path_search_default_with_sep(library: Library):
+    results = library.search_library(FilterState.from_path("one/two"))
+    assert results.total_count == 1
+    assert len(results.items) == 1
+
+
 def test_path_search_glob_after(library: Library):
     results = library.search_library(FilterState.from_path("foo*"))
     assert results.total_count == 1
@@ -430,6 +448,50 @@ def test_path_search_glob_both_sides(library: Library):
     results = library.search_library(FilterState.from_path("*one/two*"))
     assert results.total_count == 1
     assert len(results.items) == 1
+
+
+def test_path_search_ilike_glob_equality(library: Library):
+    results_ilike = library.search_library(FilterState.from_path("one/two"))
+    results_glob = library.search_library(FilterState.from_path("*one/two*"))
+    assert [e.id for e in results_ilike.items] == [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
+
+    results_ilike = library.search_library(FilterState.from_path("bar.md"))
+    results_glob = library.search_library(FilterState.from_path("*bar.md*"))
+    assert [e.id for e in results_ilike.items] == [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
+
+    results_ilike = library.search_library(FilterState.from_path("bar"))
+    results_glob = library.search_library(FilterState.from_path("*bar*"))
+    assert [e.id for e in results_ilike.items] == [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
+
+    results_ilike = library.search_library(FilterState.from_path("bar.md"))
+    results_glob = library.search_library(FilterState.from_path("*bar.md*"))
+    assert [e.id for e in results_ilike.items] == [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
+
+
+def test_path_search_like_glob_equality(library: Library):
+    results_ilike = library.search_library(FilterState.from_path("ONE/two"))
+    results_glob = library.search_library(FilterState.from_path("*ONE/two*"))
+    assert [e.id for e in results_ilike.items] == [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
+
+    results_ilike = library.search_library(FilterState.from_path("BAR.MD"))
+    results_glob = library.search_library(FilterState.from_path("*BAR.MD*"))
+    assert [e.id for e in results_ilike.items] == [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
+
+    results_ilike = library.search_library(FilterState.from_path("BAR.MD"))
+    results_glob = library.search_library(FilterState.from_path("*bar.md*"))
+    assert [e.id for e in results_ilike.items] != [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
+
+    results_ilike = library.search_library(FilterState.from_path("bar.md"))
+    results_glob = library.search_library(FilterState.from_path("*BAR.MD*"))
+    assert [e.id for e in results_ilike.items] != [e.id for e in results_glob.items]
+    results_ilike, results_glob = None, None
 
 
 @pytest.mark.parametrize(["filetype", "num_of_filetype"], [("md", 1), ("txt", 1), ("png", 0)])


### PR DESCRIPTION
### Summary
This PR adds "smartcase" style path searches and allows for non-glob searches to still return results. Smartcase searches will act as case-insensitive when the entire query is lowercase, but will turn case-sensitive if one or more capital letters are present in the query. Meanwhile the glob detection is now based on whether or not a query starts or ends with a "*" character.

This PR also limits the number of results in the path autocomplete list to 100 items to avoid sluggish search typing that scales with the size of the library.

### Smartcase Search (New)
`path: temp`
- Returns all paths that have "temp" **(Case insensitive)** somewhere in the name. 

`path: Temp`
- Returns all paths that have "Temp" **(Case sensitive)** somewhere in the name.

#### Glob Patterns (Expanded)
`path: *temp*`
- Returns all paths that have "temp" **(Case insensitive)** somewhere in the name.
 
`path: *Temp*`
- Returns all paths that have "Temp" **(Case sensitive)** somewhere in the name.

`path: temp*`
- Returns all paths that start with "temp" **(Case insensitive)** somewhere in the name. 

`path: Temp*`
- Returns all paths that start with "Temp" **(Case sensitive)** somewhere in the name.

`path: *temp`
- Returns all paths that end with "temp" **(Case insensitive)** somewhere in the name. 

`path: *TEmP`
- Returns all paths that end with "TEmP" **(Case sensitive)** somewhere in the name.