### PR TITLE
feat: start storing date_created and date_modified

### DIFF
--- a/tagstudio/src/core/library/alchemy/enums.py
+++ b/tagstudio/src/core/library/alchemy/enums.py
@@ -63,6 +63,8 @@ class ItemType(enum.Enum):
 
 class SortingModeEnum(enum.Enum):
     DATE_ADDED = "file.date_added"
+    Date_CREATED = "file.date_created"
+    DATE_MODIFIED = "file.date_modified"
 
 
 @dataclass

--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -517,6 +517,15 @@ class Library:
             make_transient(entry)
             return entry
 
+    def get_entry_by_path(self, path: Path) -> Entry | None:
+        """Get the entry with the corresponding path."""
+        with Session(self.engine) as session:
+            entry = session.scalar(select(Entry).where(Entry.path == path))
+            if entry:
+                session.expunge(entry)
+                make_transient(entry)
+            return entry
+
     @property
     def entries_count(self) -> int:
         with Session(self.engine) as session:


### PR DESCRIPTION
This PR implements population of the date_created and date_modified column within entries. Also implements logic for updating dates_modified on refresh_dir.

Chose to no implement updating date_created on refresh_dir as the two scenarios it could be used: file is replaced and file is recreated, are very unlikely (second one being very unlikely) and could instead be counted as file being modified. 