### PR TITLE
ui: shortcut to add tags to selected entries; change click behavior of tags to edit

### DIFF
--- a/tagstudio/resources/translations/en.json
+++ b/tagstudio/resources/translations/en.json
@@ -183,6 +183,7 @@
     "menu.view": "&View",
     "menu.window": "Window",
     "preview.no_selection": "No Items Selected",
+    "select.add_tag_to_selected": "Add Tag to Selected",
     "select.all": "Select All",
     "select.clear": "Clear Selection",
     "settings.clear_thumb_cache.title": "Clear Thumbnail Cache",

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -51,7 +51,7 @@ class TagBoxWidget(FieldWidget):
             self.base_layout.takeAt(0).widget().deleteLater()
 
         for tag in tags_:
-            tag_widget = TagWidget(tag, has_edit=True, has_remove=True)
+            tag_widget = TagWidget(tag, library=self.driver.lib, has_edit=True, has_remove=True)
             tag_widget.on_click.connect(lambda t=tag: self.edit_tag(t))
 
             tag_widget.on_remove.connect(

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -8,7 +8,6 @@ import typing
 import structlog
 from PySide6.QtCore import Signal
 from src.core.library import Tag
-from src.core.library.alchemy.enums import FilterState
 from src.qt.flowlayout import FlowLayout
 from src.qt.modals.build_tag import BuildTagPanel
 from src.qt.widgets.fields import FieldWidget
@@ -52,13 +51,8 @@ class TagBoxWidget(FieldWidget):
             self.base_layout.takeAt(0).widget().deleteLater()
 
         for tag in tags_:
-            tag_widget = TagWidget(tag, library=self.driver.lib, has_edit=True, has_remove=True)
-            tag_widget.on_click.connect(
-                lambda tag_id=tag.id: (
-                    self.driver.main_window.searchField.setText(f"tag_id:{tag_id}"),
-                    self.driver.filter_items(FilterState.from_tag_id(tag_id)),
-                )
-            )
+            tag_widget = TagWidget(tag, has_edit=True, has_remove=True)
+            tag_widget.on_click.connect(lambda t=tag: self.edit_tag(t))
 
             tag_widget.on_remove.connect(
                 lambda tag_id=tag.id: (


### PR DESCRIPTION
### Summary
This PR adds a new menu shortcut to bring up a tag search box and add a tag to the currently selected entries. This can also be accessed with a new key combination: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>.

This PR also changes the left-click behavior of tags from searching for the tag in the library to editing the tag. This matches the behavior of how selecting tag colors works, and I feel this is much more ergonomic than searching for tags - especially when accidentally clicked. Both the edit and search options still remain in the right-click context menu.