### PR TITLE
fix(ui): use consistent dark mode colors for all systems

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -25,6 +25,7 @@ from PySide6 import QtCore
 from PySide6.QtCore import QObject, QSettings, Qt, QThread, QThreadPool, QTimer, Signal
 from PySide6.QtGui import (
     QAction,
+    QColor,
     QDragEnterEvent,
     QDragMoveEvent,
     QDropEvent,
@@ -32,6 +33,7 @@ from PySide6.QtGui import (
     QGuiApplication,
     QIcon,
     QMouseEvent,
+    QPalette,
 )
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import (
@@ -243,6 +245,18 @@ class QtDriver(DriverMixin, QObject):
         app = QApplication(sys.argv)
         app.setStyle("Fusion")
         icon_path = Path(__file__).parents[2] / "resources/icon.png"
+
+        if QGuiApplication.styleHints().colorScheme() is Qt.ColorScheme.Dark:
+            pal: QPalette = app.palette()
+            pal.setColor(QPalette.ColorGroup.Normal, QPalette.ColorRole.Window, QColor("#1e1e1e"))
+            pal.setColor(QPalette.ColorGroup.Normal, QPalette.ColorRole.Button, QColor("#1e1e1e"))
+            pal.setColor(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Window, QColor("#232323"))
+            pal.setColor(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Button, QColor("#232323"))
+            pal.setColor(
+                QPalette.ColorGroup.Inactive, QPalette.ColorRole.ButtonText, QColor("#666666")
+            )
+
+            app.setPalette(pal)
 
         # Handle OS signals
         self.setup_signals()


### PR DESCRIPTION
This PR addresses an "issue" where macOS (and probably Linux) uses a lighter/different dark theme than the one found on Windows 10, along with some other odd color palette quirks such as the inactive button text turning black.

This PR sets the window and button background colors to a specific value, rather than relying on the OS to hint at which color to use.
<img width="798" alt="mac dark mode fix" src="https://github.com/user-attachments/assets/c5b437e5-4f89-496c-b655-a2a64d74f831" />
