### PR TITLE
fix(ui): restore Windows accent color on PySide 6.8.0.1 (Fix #668)

### DIFF
--- a/tagstudio/src/qt/widgets/thumb_button.py
+++ b/tagstudio/src/qt/widgets/thumb_button.py
@@ -36,6 +36,12 @@ class ThumbButton(QPushButtonWrapper):
                 QPalette.ColorGroup.Active,
                 QPalette.ColorRole.AlternateBase,
             )
+            self.select_color.setHsl(
+                self.select_color.hslHue(),
+                self.select_color.hslSaturation(),
+                max(self.select_color.lightness(), 100),
+                255,
+            )
         else:
             self.select_color = QPalette.color(
                 self.palette(),
@@ -57,6 +63,12 @@ class ThumbButton(QPushButtonWrapper):
                 self.palette(),
                 QPalette.ColorGroup.Active,
                 QPalette.ColorRole.AlternateBase,
+            )
+            self.hover_color.setHsl(
+                self.hover_color.hslHue(),
+                self.hover_color.hslSaturation(),
+                max(self.hover_color.lightness(), 100),
+                255,
             )
         else:
             self.hover_color = QPalette.color(

--- a/tagstudio/src/qt/widgets/thumb_button.py
+++ b/tagstudio/src/qt/widgets/thumb_button.py
@@ -3,6 +3,8 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 
+import sys
+
 from PySide6 import QtCore
 from PySide6.QtCore import QEvent
 from PySide6.QtGui import (
@@ -25,11 +27,21 @@ class ThumbButton(QPushButtonWrapper):
         self.hovered = False
         self.selected = False
 
-        self.select_color: QColor = QPalette.color(
-            self.palette(),
-            QPalette.ColorGroup.Active,
-            QPalette.ColorRole.Accent,
-        )
+        # NOTE: As of PySide 6.8.0.1, the QPalette.ColorRole.Accent role no longer works on Windows.
+        # The QPalette.ColorRole.AlternateBase does for some reason, but not on macOS.
+        self.select_color: QColor
+        if sys.platform == "win32":
+            self.select_color = QPalette.color(
+                self.palette(),
+                QPalette.ColorGroup.Active,
+                QPalette.ColorRole.AlternateBase,
+            )
+        else:
+            self.select_color = QPalette.color(
+                self.palette(),
+                QPalette.ColorGroup.Active,
+                QPalette.ColorRole.Accent,
+            )
 
         self.select_color_faded: QColor = QColor(self.select_color)
         self.select_color_faded.setHsl(
@@ -39,11 +51,20 @@ class ThumbButton(QPushButtonWrapper):
             127,
         )
 
-        self.hover_color: QColor = QPalette.color(
-            self.palette(),
-            QPalette.ColorGroup.Active,
-            QPalette.ColorRole.Accent,
-        )
+        self.hover_color: QColor
+        if sys.platform == "win32":
+            self.hover_color = QPalette.color(
+                self.palette(),
+                QPalette.ColorGroup.Active,
+                QPalette.ColorRole.AlternateBase,
+            )
+        else:
+            self.hover_color = QPalette.color(
+                self.palette(),
+                QPalette.ColorGroup.Active,
+                QPalette.ColorRole.Accent,
+            )
+
         self.hover_color.setHsl(
             self.hover_color.hslHue(),
             self.hover_color.hslSaturation(),


### PR DESCRIPTION
This PR changes which `ColorRole` is used on Windows to select the system accent color. This seems to be a change made in PySide 6.8.0, however I can't find the change documented anywhere. The `QPalette.ColorRole.AlternateBase` `ColorRole` also doesn't seem to be quite the same as the old `QPalette.ColorRole.Accent` color, so I've had to boost the lightness value a bit here. Other platforms (only tested on macOS) still use the `QPalette.ColorRole.Accent` value since it works, while the `QPalette.ColorRole.AlternateBase` does not.

Fixes #668.