### PR TITLE
fix(ui): (mostly) fix right-click search option on tags

### DIFF
--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -3,6 +3,8 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 
+import typing
+
 import src.qt.modals.build_tag as build_tag
 import structlog
 from PySide6.QtCore import QSize, Qt, Signal
@@ -32,6 +34,10 @@ from src.qt.widgets.tag import (
 
 logger = structlog.get_logger(__name__)
 
+# Only import for type checking/autocompletion, will not be imported at runtime.
+if typing.TYPE_CHECKING:
+    from src.qt.modals.build_tag import BuildTagPanel
+
 
 class TagSearchPanel(PanelWidget):
     tag_chosen = Signal(int)
@@ -41,7 +47,12 @@ class TagSearchPanel(PanelWidget):
     is_tag_chooser: bool
     exclude: list[int]
 
-    def __init__(self, library: Library, exclude: list[int] = None, is_tag_chooser: bool = True):
+    def __init__(
+        self,
+        library: Library,
+        exclude: list[int] = None,
+        is_tag_chooser: bool = True,
+    ):
         super().__init__()
         self.lib = library
         self.exclude = exclude or []
@@ -93,6 +104,17 @@ class TagSearchPanel(PanelWidget):
 
         tag_widget.on_edit.connect(lambda t=tag: self.edit_tag(t))
         tag_widget.on_remove.connect(lambda t=tag: self.remove_tag(t))
+
+        # NOTE: A solution to this would be to pass the driver to TagSearchPanel, however that
+        # creates an exponential amount of work trying to fix the preexisting tests.
+
+        # tag_widget.search_for_tag_action.triggered.connect(
+        #     lambda checked=False, tag_id=tag.id: (
+        #         self.driver.main_window.searchField.setText(f"tag_id:{tag_id}"),
+        #         self.driver.filter_items(FilterState.from_tag_id(tag_id)),
+        #     )
+        # )
+
         row.addWidget(tag_widget)
 
         primary_color = get_primary_color(tag)
@@ -196,7 +218,7 @@ class TagSearchPanel(PanelWidget):
             self.search_field.setText("")
             self.update_tags()
 
-        self.build_tag_modal: build_tag.BuildTagPanel = build_tag.BuildTagPanel(self.lib)
+        self.build_tag_modal: BuildTagPanel = build_tag.BuildTagPanel(self.lib)
         self.add_tag_modal: PanelModal = PanelModal(self.build_tag_modal, has_save=True)
         Translations.translate_with_setter(self.add_tag_modal.setTitle, "tag.new")
         Translations.translate_with_setter(self.add_tag_modal.setWindowTitle, "tag.add")

--- a/tagstudio/src/qt/widgets/tag.py
+++ b/tagstudio/src/qt/widgets/tag.py
@@ -141,10 +141,9 @@ class TagWidget(QWidget):
 
         # TODO: This currently doesn't work in "Add Tag" menus. Either fix this or
         # disable it in that context.
-        search_for_tag_action = QAction(self)
-        search_for_tag_action.setText(Translations.translate_formatted("tag.search_for_tag"))
-        search_for_tag_action.triggered.connect(self.on_click.emit)
-        self.bg_button.addAction(search_for_tag_action)
+        self.search_for_tag_action = QAction(self)
+        self.search_for_tag_action.setText(Translations.translate_formatted("tag.search_for_tag"))
+        self.bg_button.addAction(self.search_for_tag_action)
         # add_to_search_action = QAction(self)
         # add_to_search_action.setText(Translations.translate_formatted("tag.add_to_search"))
         # self.bg_button.addAction(add_to_search_action)

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -8,6 +8,7 @@ import typing
 import structlog
 from PySide6.QtCore import Signal
 from src.core.library import Tag
+from src.core.library.alchemy.enums import FilterState
 from src.qt.flowlayout import FlowLayout
 from src.qt.modals.build_tag import BuildTagPanel
 from src.qt.widgets.fields import FieldWidget
@@ -61,6 +62,14 @@ class TagBoxWidget(FieldWidget):
                 )
             )
             tag_widget.on_edit.connect(lambda t=tag: self.edit_tag(t))
+
+            tag_widget.search_for_tag_action.triggered.connect(
+                lambda checked=False, tag_id=tag.id: (
+                    self.driver.main_window.searchField.setText(f"tag_id:{tag_id}"),
+                    self.driver.filter_items(FilterState.from_tag_id(tag_id)),
+                )
+            )
+
             self.base_layout.addWidget(tag_widget)
 
     def edit_tag(self, tag: Tag):


### PR DESCRIPTION
This PR partially fixes where the "Search for Tag" right-click option for tags. This feature remains broken for the "Tag Manager" modal, as fixing that would require annoyingly modifying a wasps nest of UI tests which is way beyond what I'd like to fix right now.