### PR TITLE
Fix: Error searching for tag containing a colon

### DIFF
--- a/tagstudio/src/core/query_lang/tokenizer.py
+++ b/tagstudio/src/core/query_lang/tokenizer.py
@@ -108,7 +108,6 @@ class Tokenizer:
             out += self.current_char
             self.__advance()
 
-
         end = self.pos - 1
         return Token(TokenType.ULITERAL, out, start, end)
 

--- a/tagstudio/src/core/query_lang/tokenizer.py
+++ b/tagstudio/src/core/query_lang/tokenizer.py
@@ -93,22 +93,24 @@ class Tokenizer:
 
         start = self.pos
 
-        while self.current_char not in self.NOT_IN_ULITERAL and self.current_char is not None:
+        while self.current_char is not None:
+            if self.current_char in self.NOT_IN_ULITERAL:
+                if self.current_char == ":":
+                    if len(out) == 0:
+                        raise ParsingError(self.pos, self.pos)
+                    constraint_type = ConstraintType.from_string(out)
+                    if constraint_type is not None:
+                        self.__advance()
+                        return Token(TokenType.CONSTRAINTTYPE, constraint_type, start, self.pos)
+                else:
+                    break
+
             out += self.current_char
             self.__advance()
 
-        end = self.pos - 1
 
-        if self.current_char == ":":
-            if len(out) == 0:
-                raise ParsingError(self.pos, self.pos)
-            self.__advance()
-            constraint_type = ConstraintType.from_string(out)
-            if constraint_type is None:
-                raise ParsingError(start, end, f'Invalid ContraintType "{out}"')
-            return Token(TokenType.CONSTRAINTTYPE, constraint_type, start, end)
-        else:
-            return Token(TokenType.ULITERAL, out, start, end)
+        end = self.pos - 1
+        return Token(TokenType.ULITERAL, out, start, end)
 
     def __quoted_string(self) -> Token:
         start = self.pos


### PR DESCRIPTION
close #764 

This refactors a function in the tokenizer to allow colons to be included in the tag name,
the logic functions exactly the same otherwise

![image](https://github.com/user-attachments/assets/ba1f6581-3a42-4516-a1c6-7aa897fef321)
![image](https://github.com/user-attachments/assets/26a25ded-a71f-483d-ade7-13475cb72d42)
![image](https://github.com/user-attachments/assets/6c11418f-0830-428a-a5fa-1dfa78ef50b1)
