### PR TITLE
fix: catch `ParsingError`

### DIFF
--- a/tagstudio/resources/translations/en.json
+++ b/tagstudio/resources/translations/en.json
@@ -205,6 +205,7 @@
     "status.library_version_found": "Found:",
     "status.library_version_mismatch": "Library Version Mismatch!",
     "status.results_found": "{count} Results Found ({time_span})",
+    "status.results.invalid_syntax": "Invalid Search Syntax:",
     "status.results": "Results",
     "tag_manager.title": "Library Tags",
     "tag.add_to_search": "Add to Search",

--- a/tagstudio/src/core/library/alchemy/enums.py
+++ b/tagstudio/src/core/library/alchemy/enums.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import structlog
 from src.core.query_lang import AST as Query  # noqa: N811
 from src.core.query_lang import Constraint, ConstraintType, Parser
-from src.core.query_lang.util import ParsingError
 
 MAX_SQL_VARIABLES = 32766  # 32766 is the max sql bind parameter count as defined here: https://github.com/sqlite/sqlite/blob/master/src/sqliteLimit.h#L140
 
@@ -97,14 +96,7 @@ class FilterState:
 
     @classmethod
     def from_search_query(cls, search_query: str) -> "FilterState":
-        filter_state: FilterState
-        try:
-            filter_state = cls(ast=Parser(search_query).parse())
-        except ParsingError as e:
-            logger.error("[FilterState] Could not parse search query", error=e)
-            filter_state = FilterState(ast=Parser("tag_id:-1").parse())  # Don't return any results
-
-        return filter_state
+        return cls(ast=Parser(search_query).parse())
 
     @classmethod
     def from_tag_id(cls, tag_id: int | str) -> "FilterState":

--- a/tagstudio/src/core/library/alchemy/enums.py
+++ b/tagstudio/src/core/library/alchemy/enums.py
@@ -2,10 +2,14 @@ import enum
 from dataclasses import dataclass, replace
 from pathlib import Path
 
+import structlog
 from src.core.query_lang import AST as Query  # noqa: N811
 from src.core.query_lang import Constraint, ConstraintType, Parser
+from src.core.query_lang.util import ParsingError
 
 MAX_SQL_VARIABLES = 32766  # 32766 is the max sql bind parameter count as defined here: https://github.com/sqlite/sqlite/blob/master/src/sqliteLimit.h#L140
+
+logger = structlog.get_logger(__name__)
 
 
 class TagColorEnum(enum.IntEnum):
@@ -93,7 +97,14 @@ class FilterState:
 
     @classmethod
     def from_search_query(cls, search_query: str) -> "FilterState":
-        return cls(ast=Parser(search_query).parse())
+        filter_state: FilterState
+        try:
+            filter_state = cls(ast=Parser(search_query).parse())
+        except ParsingError as e:
+            logger.error("[FilterState] Could not parse search query", error=e)
+            filter_state = FilterState(ast=Parser("tag_id:-1").parse())  # Don't return any results
+
+        return filter_state
 
     @classmethod
     def from_tag_id(cls, tag_id: int | str) -> "FilterState":

--- a/tagstudio/src/core/library/alchemy/library.py
+++ b/tagstudio/src/core/library/alchemy/library.py
@@ -640,10 +640,11 @@ class Library:
             return session.query(exists().where(Entry.path == path)).scalar()
 
     def get_paths(self, glob: str | None = None) -> list[str]:
+        path_strings: list[str] = []
         with Session(self.engine) as session:
             paths = session.scalars(select(Entry.path)).unique()
+            path_strings = list(map(lambda x: x.as_posix(), paths))
 
-        path_strings: list[str] = list(map(lambda x: x.as_posix(), paths))
         return path_strings
 
     def search_library(

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -66,6 +66,7 @@ from src.core.library.alchemy.enums import (
 from src.core.library.alchemy.fields import _FieldID
 from src.core.library.alchemy.library import Entry, LibraryStatus
 from src.core.media_types import MediaCategories
+from src.core.query_lang.util import ParsingError
 from src.core.ts_core import TagStudioCore
 from src.core.utils.refresh_dir import RefreshDirTracker
 from src.core.utils.web import strip_web_protocol
@@ -666,7 +667,11 @@ class QtDriver(DriverMixin, QObject):
                     .with_sorting_mode(self.sorting_mode)
                     .with_sorting_direction(self.sorting_direction)
                 )
-            except Exception as e:
+            except ParsingError as e:
+                self.main_window.statusbar.showMessage(
+                    f"{Translations["status.results.invalid_syntax"]} "
+                    f"\"{self.main_window.searchField.text()}\""
+                )
                 logger.error("[QtDriver] Could not filter items", error=e)
 
         # Search Button

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -659,24 +659,22 @@ class QtDriver(DriverMixin, QObject):
         # in a global dict for methods to access for different DPIs.
         # adj_font_size = math.floor(12 * self.main_window.devicePixelRatio())
 
+        def _filter_items():
+            try:
+                self.filter_items(
+                    FilterState.from_search_query(self.main_window.searchField.text())
+                    .with_sorting_mode(self.sorting_mode)
+                    .with_sorting_direction(self.sorting_direction)
+                )
+            except Exception as e:
+                logger.error("[QtDriver] Could not filter items", error=e)
+
         # Search Button
         search_button: QPushButton = self.main_window.searchButton
-        search_button.clicked.connect(
-            lambda: self.filter_items(
-                FilterState.from_search_query(self.main_window.searchField.text())
-                .with_sorting_mode(self.sorting_mode)
-                .with_sorting_direction(self.sorting_direction)
-            )
-        )
+        search_button.clicked.connect(_filter_items)
         # Search Field
         search_field: QLineEdit = self.main_window.searchField
-        search_field.returnPressed.connect(
-            lambda: self.filter_items(
-                FilterState.from_search_query(self.main_window.searchField.text())
-                .with_sorting_mode(self.sorting_mode)
-                .with_sorting_direction(self.sorting_direction)
-            )
-        )
+        search_field.returnPressed.connect(_filter_items)
         # Sorting Dropdowns
         sort_mode_dropdown: QComboBox = self.main_window.sorting_mode_combobox
         for sort_mode in SortingModeEnum:

--- a/tagstudio/tests/test_search.py
+++ b/tagstudio/tests/test_search.py
@@ -1,6 +1,7 @@
 import pytest
 from src.core.library.alchemy.enums import FilterState
 from src.core.library.alchemy.library import Library
+from src.core.query_lang.util import ParsingError
 
 
 def verify_count(lib: Library, query: str, count: int):
@@ -133,5 +134,5 @@ def test_parent_tags(search_library: Library, query: str, count: int):
     "invalid_query", ["asd AND", "asd AND AND", "tag:(", "(asd", "asd[]", "asd]", ":", "tag: :"]
 )
 def test_syntax(search_library: Library, invalid_query: str):
-    results = search_library.search_library(FilterState.from_search_query(invalid_query))
-    assert not results
+    with pytest.raises(ParsingError) as e_info:  # noqa: F841
+        search_library.search_library(FilterState.from_search_query(invalid_query))

--- a/tagstudio/tests/test_search.py
+++ b/tagstudio/tests/test_search.py
@@ -1,7 +1,6 @@
 import pytest
 from src.core.library.alchemy.enums import FilterState
 from src.core.library.alchemy.library import Library
-from src.core.query_lang.util import ParsingError
 
 
 def verify_count(lib: Library, query: str, count: int):
@@ -134,5 +133,5 @@ def test_parent_tags(search_library: Library, query: str, count: int):
     "invalid_query", ["asd AND", "asd AND AND", "tag:(", "(asd", "asd[]", "asd]", ":", "tag: :"]
 )
 def test_syntax(search_library: Library, invalid_query: str):
-    with pytest.raises(ParsingError) as e_info:  # noqa: F841
-        search_library.search_library(FilterState.from_search_query(invalid_query))
+    results = search_library.search_library(FilterState.from_search_query(invalid_query))
+    assert not results


### PR DESCRIPTION
This PR introduces better error handing for the search syntax system that prevents various errors from occurring.

> [fix: move path_strings var inside with block](https://github.com/TagStudioDev/TagStudio/commit/c346ea96a75084cfcc094345628048338a658f9b)

This change fixes #776 by preventing the errors that were raised when the `path: ` keyword was used with a space following the colon.

The other commits focus on providing error handling by catching `ParsingError`s raised by the search syntax system. This prevents the errors causing #777 as well as #764, however it's not a full fix for the issues described in #764 and #765 is still required. 

***

Fixes #776, Fixes #777