### PR TITLE
refactor(ui): recycle tag list in `TagSearchPanel`

### DIFF
--- a/tagstudio/src/qt/modals/tag_database.py
+++ b/tagstudio/src/qt/modals/tag_database.py
@@ -18,12 +18,13 @@ logger = structlog.get_logger(__name__)
 
 # TODO: Once this class is removed, the `is_tag_chooser` option of `TagSearchPanel`
 # will most likely be enabled in every case
-# and the possibilty of disabling it can therefore be removed
+# and the possibility of disabling it can therefore be removed
 
 
 class TagDatabasePanel(TagSearchPanel):
-    def __init__(self, library: Library):
+    def __init__(self, driver, library: Library):
         super().__init__(library, is_tag_chooser=False)
+        self.driver = driver
 
         self.create_tag_button = QPushButton()
         Translations.translate_qobject(self.create_tag_button, "tag.create")
@@ -39,7 +40,7 @@ class TagDatabasePanel(TagSearchPanel):
             has_save=True,
         )
         Translations.translate_with_setter(self.modal.setTitle, "tag.new")
-        Translations.translate_with_setter(self.modal.setWindowTitle, "tag.add")
+        Translations.translate_with_setter(self.modal.setWindowTitle, "tag.new")
         if name.strip():
             panel.name_field.setText(name)
 

--- a/tagstudio/src/qt/modals/tag_search.py
+++ b/tagstudio/src/qt/modals/tag_search.py
@@ -163,7 +163,7 @@ class TagSearchPanel(PanelWidget):
         # Remove the create button if one exists
         create_button: QPushButton | None = None
         if self.create_button_in_layout and self.scroll_layout.count():
-            create_button = self.scroll_layout.takeAt(self.scroll_layout.count() - 1).widget()
+            create_button = self.scroll_layout.takeAt(self.scroll_layout.count() - 1).widget()  # type: ignore
             create_button.deleteLater()
             self.create_button_in_layout = False
 
@@ -203,7 +203,7 @@ class TagSearchPanel(PanelWidget):
             self.set_tag_widget(tag=tag, index=i)
 
         if query and query.strip():
-            cb: QPushButton = self.build_create_button(query)  # type: ignore
+            cb: QPushButton = self.build_create_button(query)
             with catch_warnings(record=True):
                 cb.clicked.disconnect()
             cb.clicked.connect(lambda: self.create_and_add_tag(query or ""))

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -293,6 +293,7 @@ class QtDriver(DriverMixin, QObject):
 
         # Initialize the main window's tag search panel
         self.tag_search_panel = TagSearchPanel(self.lib, is_tag_chooser=True)
+        self.tag_search_panel.set_driver(self)
         self.add_tag_modal = PanelModal(
             widget=self.tag_search_panel,
             title=Translations.translate_formatted("tag.add.plural"),
@@ -875,7 +876,7 @@ class QtDriver(DriverMixin, QObject):
 
     def show_tag_database(self):
         self.modal = PanelModal(
-            widget=TagDatabasePanel(self.lib),
+            widget=TagDatabasePanel(self, self.lib),
             done_callback=lambda: self.preview_panel.update_widgets(update_preview=False),
             has_save=False,
         )


### PR DESCRIPTION
### Summary
This PR greatly improves the performance of the `TagSearchPanel` by recycling the `TagWidget`s in the scroll layout rather than constantly destroying and recreating them. There's also a few minor fixes in related areas:

### Miscellaneous Changes and Fixes
- Use the "New Tag" title for both title and window of the "New Tag" modal
- Can now search library for tags from the Tag Manager and "Add Tag" preview panel modal
- The build tag panel spawned by the "Create & Add" button now correctly keeps focus on the tag name. This allows <kbd>Esc</kbd> to be used to quickly close the modal