### PR TITLE
perf: optimize query methods and reduce preview panel updates

### DIFF
--- a/tagstudio/src/qt/modals/folders_to_tags.py
+++ b/tagstudio/src/qt/modals/folders_to_tags.py
@@ -73,7 +73,7 @@ def folders_to_tags(library: Library):
 
         tag = add_folders_to_tree(library, tree, folders).tag
         if tag and not entry.has_tag(tag):
-            library.add_tags_to_entry(entry.id, tag.id)
+            library.add_tags_to_entries(entry.id, tag.id)
 
     logger.info("Done")
 

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -506,7 +506,7 @@ class ItemThumb(FlowWidget):
         else:
             self.lib.remove_tags_from_entry(entry_id, tag_id)
 
-        if self.driver.preview_panel.is_open:
+        if entry_id in self.driver.selected and self.driver.preview_panel.is_open:
             self.driver.preview_panel.update_widgets(update_preview=False)
 
     def mouseMoveEvent(self, event):  # noqa: N802

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -499,15 +499,7 @@ class ItemThumb(FlowWidget):
         toggle_value: bool,
         tag_id: int,
     ):
-        logger.info("toggle_item_tag", entry_id=entry_id, toggle_value=toggle_value, tag_id=tag_id)
-
-        if toggle_value:
-            self.lib.add_tags_to_entry(entry_id, tag_id)
-        else:
-            self.lib.remove_tags_from_entry(entry_id, tag_id)
-
         if entry_id in self.driver.selected and self.driver.preview_panel.is_open:
-            # self.driver.preview_panel.update_widgets(update_preview=False)
             if len(self.driver.selected) == 1:
                 self.driver.preview_panel.fields.update_toggled_tag(tag_id, toggle_value)
             else:

--- a/tagstudio/src/qt/widgets/item_thumb.py
+++ b/tagstudio/src/qt/widgets/item_thumb.py
@@ -507,7 +507,11 @@ class ItemThumb(FlowWidget):
             self.lib.remove_tags_from_entry(entry_id, tag_id)
 
         if entry_id in self.driver.selected and self.driver.preview_panel.is_open:
-            self.driver.preview_panel.update_widgets(update_preview=False)
+            # self.driver.preview_panel.update_widgets(update_preview=False)
+            if len(self.driver.selected) == 1:
+                self.driver.preview_panel.fields.update_toggled_tag(tag_id, toggle_value)
+            else:
+                pass
 
     def mouseMoveEvent(self, event):  # noqa: N802
         if event.buttons() is not Qt.MouseButton.LeftButton:

--- a/tagstudio/src/qt/widgets/preview/field_containers.py
+++ b/tagstudio/src/qt/widgets/preview/field_containers.py
@@ -3,14 +3,12 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 import sys
-import time
 import typing
 from collections.abc import Callable
 from datetime import datetime as dt
 from warnings import catch_warnings
 
 import structlog
-from humanfriendly import format_timespan
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import (
@@ -115,19 +113,14 @@ class FieldContainers(QWidget):
         """Update tags and fields from a single Entry source."""
         logger.warning("[FieldContainers] Updating Selection", entry_id=entry_id)
 
-        start_time = time.time()
         self.cached_entries = [self.lib.get_entry_full(entry_id)]
-        end_time = time.time()
-        logger.error(
-            f"[FieldContainers] Time it took to get full entry: "
-            f"{format_timespan(end_time-start_time, max_units=5)}"
-        )
         entry = self.cached_entries[0]
         self.update_granular(entry.tags, entry.fields, update_badges)
 
     def update_granular(
         self, entry_tags: set[Tag], entry_fields: list[BaseField], update_badges: bool = True
     ):
+        """Individually update elements of the item preview."""
         container_len: int = len(entry_fields)
         container_index = 0
         # Write tag container(s)
@@ -153,6 +146,7 @@ class FieldContainers(QWidget):
                     c.setHidden(True)
 
     def update_toggled_tag(self, tag_id: int, toggle_value: bool):
+        """Visually add or remove a tag from the item preview without needing to query the db."""
         entry = self.cached_entries[0]
         tag = self.lib.get_tag(tag_id)
         if not tag:
@@ -284,7 +278,7 @@ class FieldContainers(QWidget):
             tags=tags,
         )
         for entry_id in self.driver.selected:
-            self.lib.add_tags_to_entry(
+            self.lib.add_tags_to_entries(
                 entry_id,
                 tag_ids=tags,
             )

--- a/tagstudio/src/qt/widgets/preview/field_containers.py
+++ b/tagstudio/src/qt/widgets/preview/field_containers.py
@@ -3,12 +3,14 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 import sys
+import time
 import typing
 from collections.abc import Callable
 from datetime import datetime as dt
 from warnings import catch_warnings
 
 import structlog
+from humanfriendly import format_timespan
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import (
@@ -113,14 +115,24 @@ class FieldContainers(QWidget):
         """Update tags and fields from a single Entry source."""
         logger.warning("[FieldContainers] Updating Selection", entry_id=entry_id)
 
+        start_time = time.time()
         self.cached_entries = [self.lib.get_entry_full(entry_id)]
-        entry_ = self.cached_entries[0]
-        container_len: int = len(entry_.fields)
-        container_index = 0
+        end_time = time.time()
+        logger.error(
+            f"[FieldContainers] Time it took to get full entry: "
+            f"{format_timespan(end_time-start_time, max_units=5)}"
+        )
+        entry = self.cached_entries[0]
+        self.update_granular(entry.tags, entry.fields, update_badges)
 
+    def update_granular(
+        self, entry_tags: set[Tag], entry_fields: list[BaseField], update_badges: bool = True
+    ):
+        container_len: int = len(entry_fields)
+        container_index = 0
         # Write tag container(s)
-        if entry_.tags:
-            categories = self.get_tag_categories(entry_.tags)
+        if entry_tags:
+            categories = self.get_tag_categories(entry_tags)
             for cat, tags in sorted(categories.items(), key=lambda kv: (kv[0] is None, kv)):
                 self.write_tag_container(
                     container_index, tags=tags, category_tag=cat, is_mixed=False
@@ -128,10 +140,10 @@ class FieldContainers(QWidget):
                 container_index += 1
                 container_len += 1
         if update_badges:
-            self.emit_badge_signals({t.id for t in entry_.tags})
+            self.emit_badge_signals({t.id for t in entry_tags})
 
         # Write field container(s)
-        for index, field in enumerate(entry_.fields, start=container_index):
+        for index, field in enumerate(entry_fields, start=container_index):
             self.write_container(index, field, is_mixed=False)
 
         # Hide leftover container(s)
@@ -139,6 +151,16 @@ class FieldContainers(QWidget):
             for i, c in enumerate(self.containers):
                 if i > (container_len - 1):
                     c.setHidden(True)
+
+    def update_toggled_tag(self, tag_id: int, toggle_value: bool):
+        entry = self.cached_entries[0]
+        tag = self.lib.get_tag(tag_id)
+        if not tag:
+            return
+        new_tags = (
+            entry.tags.union({tag}) if toggle_value else {t for t in entry.tags if t.id != tag_id}
+        )
+        self.update_granular(entry_tags=new_tags, entry_fields=entry.fields, update_badges=False)
 
     def hide_containers(self):
         """Hide all field and tag containers."""

--- a/tagstudio/src/qt/widgets/tag_box.py
+++ b/tagstudio/src/qt/widgets/tag_box.py
@@ -101,6 +101,6 @@ class TagBoxWidget(FieldWidget):
         )
 
         for entry_id in self.driver.selected:
-            self.driver.lib.remove_tags_from_entry(entry_id, tag_id)
+            self.driver.lib.remove_tags_from_entries(entry_id, tag_id)
 
         self.updated.emit()

--- a/tagstudio/tests/conftest.py
+++ b/tagstudio/tests/conftest.py
@@ -95,7 +95,7 @@ def library(request):
         path=pathlib.Path("foo.txt"),
         fields=lib.default_fields,
     )
-    assert lib.add_tags_to_entry(entry.id, tag.id)
+    assert lib.add_tags_to_entries(entry.id, tag.id)
 
     entry2 = Entry(
         id=2,
@@ -103,7 +103,7 @@ def library(request):
         path=pathlib.Path("one/two/bar.md"),
         fields=lib.default_fields,
     )
-    assert lib.add_tags_to_entry(entry2.id, tag2.id)
+    assert lib.add_tags_to_entries(entry2.id, tag2.id)
 
     assert lib.add_entries([entry, entry2])
     assert len(lib.tags) == 6

--- a/tagstudio/tests/qt/test_field_containers.py
+++ b/tagstudio/tests/qt/test_field_containers.py
@@ -119,7 +119,7 @@ def test_meta_tag_category(qt_driver, library, entry_full):
     panel = PreviewPanel(library, qt_driver)
 
     # Ensure the Favorite tag is on entry_full
-    library.add_tags_to_entry(1, entry_full.id)
+    library.add_tags_to_entries(1, entry_full.id)
 
     # Select the single entry
     qt_driver.toggle_item_selection(entry_full.id, append=False, bridge=False)
@@ -151,7 +151,7 @@ def test_custom_tag_category(qt_driver, library, entry_full):
     )
 
     # Ensure the Favorite tag is on entry_full
-    library.add_tags_to_entry(1, entry_full.id)
+    library.add_tags_to_entries(1, entry_full.id)
 
     # Select the single entry
     qt_driver.toggle_item_selection(entry_full.id, append=False, bridge=False)

--- a/tagstudio/tests/test_library.py
+++ b/tagstudio/tests/test_library.py
@@ -330,8 +330,8 @@ def test_merge_entries(library: Library):
         tag_0 = library.add_tag(Tag(id=1000, name="tag_0"))
         tag_1 = library.add_tag(Tag(id=1001, name="tag_1"))
         tag_2 = library.add_tag(Tag(id=1002, name="tag_2"))
-        library.add_tags_to_entry(ids[0], [tag_0.id, tag_2.id])
-        library.add_tags_to_entry(ids[1], [tag_1.id])
+        library.add_tags_to_entries(ids[0], [tag_0.id, tag_2.id])
+        library.add_tags_to_entries(ids[1], [tag_1.id])
         library.merge_entries(entry_a, entry_b)
         assert library.has_path_entry(Path("b"))
         assert not library.has_path_entry(Path("a"))
@@ -344,11 +344,11 @@ def test_merge_entries(library: Library):
         AssertionError()
 
 
-def test_remove_tag_from_entry(library, entry_full):
+def test_remove_tags_from_entries(library, entry_full):
     removed_tag_id = -1
     for tag in entry_full.tags:
         removed_tag_id = tag.id
-        library.remove_tags_from_entry(entry_full.id, tag.id)
+        library.remove_tags_from_entries(entry_full.id, tag.id)
 
     entry = next(library.get_entries(with_joins=True))
     assert removed_tag_id not in [t.id for t in entry.tags]


### PR DESCRIPTION
### Summary
This PR makes several performance improvements to the way that query methods are executed, how toggled badges update entries with tag changes, and how toggled badges update the preview panel.

The main part of this PR is the restructuring of the `get_entries_full()` method, which now queries the tags separately from the base entry query and recombines them into a final Entry object. I was unable to optimize the preexisting query statement itself, however this recombination method provides a huge performance boost (~10x) for large complex libraries - so much so that the badge optimizations have become almost overshadowed by this change.