### PR TITLE
feat: add tests for translations

### DIFF
--- a/tagstudio/tests/conftest.py
+++ b/tagstudio/tests/conftest.py
@@ -1,11 +1,11 @@
-import pathlib
 import sys
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
 import pytest
 
-CWD = pathlib.Path(__file__).parent
+CWD = Path(__file__).parent
 # this needs to be above `src` imports
 sys.path.insert(0, str(CWD.parent))
 
@@ -23,24 +23,24 @@ def cwd():
 def file_mediatypes_library():
     lib = Library()
 
-    status = lib.open_library(pathlib.Path(""), ":memory:")
+    status = lib.open_library(Path(""), ":memory:")
     assert status.success
 
     entry1 = Entry(
         folder=lib.folder,
-        path=pathlib.Path("foo.png"),
+        path=Path("foo.png"),
         fields=lib.default_fields,
     )
 
     entry2 = Entry(
         folder=lib.folder,
-        path=pathlib.Path("bar.png"),
+        path=Path("bar.png"),
         fields=lib.default_fields,
     )
 
     entry3 = Entry(
         folder=lib.folder,
-        path=pathlib.Path("baz.apng"),
+        path=Path("baz.apng"),
         fields=lib.default_fields,
     )
 
@@ -61,7 +61,7 @@ def library(request):
             library_path = request.param
 
     lib = Library()
-    status = lib.open_library(pathlib.Path(library_path), ":memory:")
+    status = lib.open_library(Path(library_path), ":memory:")
     assert status.success
 
     tag = Tag(
@@ -92,7 +92,7 @@ def library(request):
     entry = Entry(
         id=1,
         folder=lib.folder,
-        path=pathlib.Path("foo.txt"),
+        path=Path("foo.txt"),
         fields=lib.default_fields,
     )
     assert lib.add_tags_to_entries(entry.id, tag.id)
@@ -100,7 +100,7 @@ def library(request):
     entry2 = Entry(
         id=2,
         folder=lib.folder,
-        path=pathlib.Path("one/two/bar.md"),
+        path=Path("one/two/bar.md"),
         fields=lib.default_fields,
     )
     assert lib.add_tags_to_entries(entry2.id, tag2.id)
@@ -114,7 +114,7 @@ def library(request):
 @pytest.fixture
 def search_library() -> Library:
     lib = Library()
-    lib.open_library(pathlib.Path(CWD / "fixtures" / "search_library"))
+    lib.open_library(Path(CWD / "fixtures" / "search_library"))
     return lib
 
 
@@ -133,8 +133,8 @@ def qt_driver(qtbot, library):
     with TemporaryDirectory() as tmp_dir:
 
         class Args:
-            config_file = pathlib.Path(tmp_dir) / "tagstudio.ini"
-            open = pathlib.Path(tmp_dir)
+            config_file = Path(tmp_dir) / "tagstudio.ini"
+            open = Path(tmp_dir)
             ci = True
 
         with patch("src.qt.ts_qt.Consumer"), patch("src.qt.ts_qt.CustomRunnable"):

--- a/tagstudio/tests/macros/test_dupe_entries.py
+++ b/tagstudio/tests/macros/test_dupe_entries.py
@@ -1,22 +1,22 @@
-import pathlib
+from pathlib import Path
 
 from src.core.library import Entry
 from src.core.utils.dupe_files import DupeRegistry
 
-CWD = pathlib.Path(__file__).parent
+CWD = Path(__file__).parent
 
 
 def test_refresh_dupe_files(library):
     library.library_dir = "/tmp/"
     entry = Entry(
         folder=library.folder,
-        path=pathlib.Path("bar/foo.txt"),
+        path=Path("bar/foo.txt"),
         fields=library.default_fields,
     )
 
     entry2 = Entry(
         folder=library.folder,
-        path=pathlib.Path("foo/foo.txt"),
+        path=Path("foo/foo.txt"),
         fields=library.default_fields,
     )
 
@@ -30,7 +30,7 @@ def test_refresh_dupe_files(library):
     assert len(registry.groups) == 1
     paths = [entry.path for entry in registry.groups[0]]
     assert paths == [
-        pathlib.Path("bar/foo.txt"),
-        pathlib.Path("foo.txt"),
-        pathlib.Path("foo/foo.txt"),
+        Path("bar/foo.txt"),
+        Path("foo.txt"),
+        Path("foo/foo.txt"),
     ]

--- a/tagstudio/tests/macros/test_missing_files.py
+++ b/tagstudio/tests/macros/test_missing_files.py
@@ -1,4 +1,4 @@
-import pathlib
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -6,7 +6,7 @@ from src.core.library import Library
 from src.core.library.alchemy.enums import FilterState
 from src.core.utils.missing_files import MissingRegistry
 
-CWD = pathlib.Path(__file__).parent
+CWD = Path(__file__).parent
 
 
 # NOTE: Does this test actually work?
@@ -28,4 +28,4 @@ def test_refresh_missing_files(library: Library):
 
     # `bar.md` should be relinked to new correct path
     results = library.search_library(FilterState.from_path("bar.md"))
-    assert results[0].path == pathlib.Path("bar.md")
+    assert results[0].path == Path("bar.md")

--- a/tagstudio/tests/macros/test_refresh_dir.py
+++ b/tagstudio/tests/macros/test_refresh_dir.py
@@ -1,11 +1,11 @@
-import pathlib
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
 from src.core.enums import LibraryPrefs
 from src.core.utils.refresh_dir import RefreshDirTracker
 
-CWD = pathlib.Path(__file__).parent
+CWD = Path(__file__).parent
 
 
 @pytest.mark.parametrize("exclude_mode", [True, False])
@@ -22,4 +22,4 @@ def test_refresh_new_files(library, exclude_mode):
     assert len(list(registry.refresh_dir(library.library_dir))) == 1
 
     # Then
-    assert registry.files_not_in_library == [pathlib.Path("FOO.MD")]
+    assert registry.files_not_in_library == [Path("FOO.MD")]

--- a/tagstudio/tests/test_json_migration.py
+++ b/tagstudio/tests/test_json_migration.py
@@ -2,13 +2,13 @@
 # Licensed under the GPL-3.0 License.
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
-import pathlib
+from pathlib import Path
 from time import time
 
 from src.core.enums import LibraryPrefs
 from src.qt.widgets.migration_modal import JsonMigrationModal
 
-CWD = pathlib.Path(__file__)
+CWD = Path(__file__)
 
 
 def test_json_migration():

--- a/tagstudio/tests/test_translations.py
+++ b/tagstudio/tests/test_translations.py
@@ -17,15 +17,6 @@ def find_format_keys(format_string: str) -> set[str]:
     return set([field[1] for field in formatter.parse(format_string) if field[1] is not None])
 
 
-def foreach_translation(callback):
-    with open(TRANSLATION_DIR / "en.json", encoding="utf-8") as f:
-        default_translation = json.loads(f.read())
-    for translation_path in TRANSLATION_DIR.glob("*.json"):
-        with open(translation_path, encoding="utf-8") as f:
-            translation = json.load(f)
-        callback(default_translation, translation, translation_path)
-
-
 @pytest.mark.parametrize(["translation_filename"], [(fn,) for fn in get_translation_filenames()])
 def test_validate_format_keys(translation_filename: str):
     with open(TRANSLATION_DIR / "en.json", encoding="utf-8") as f:

--- a/tagstudio/tests/test_translations.py
+++ b/tagstudio/tests/test_translations.py
@@ -39,10 +39,10 @@ def test_validate_format_keys(translation_filename: str):
         translation_keys = find_format_keys(translation[key])
         assert default_keys.issuperset(
             translation_keys
-        ), f"Translation {translation_filename} for key {key} is using an invalid format key"
+        ), f"Translation {translation_filename} for key {key} is using an invalid format key ({translation_keys.difference(default_keys)})"  # noqa: E501
         assert translation_keys.issuperset(
             default_keys
-        ), f"Translation {translation_filename} for key {key} is missing format keys"
+        ), f"Translation {translation_filename} for key {key} is missing format keys ({default_keys.difference(translation_keys)})"  # noqa: E501
 
 
 @pytest.mark.parametrize(["translation_filename"], [(fn,) for fn in get_translation_filenames()])

--- a/tagstudio/tests/test_translations.py
+++ b/tagstudio/tests/test_translations.py
@@ -45,13 +45,15 @@ def test_validate_format_keys(translation_filename: str):
         ), f"Translation {translation_filename} for key {key} is missing format keys"
 
 
-def test_translation_completeness():
-    def check_completeness(default_translation: dict, translation: dict, translation_path: Path):
-        assert set(default_translation.keys()).issubset(
-            translation.keys()
-        ), f"Translation {translation_path.name} is missing keys"
-        assert set(default_translation.keys()).issuperset(
-            translation.keys()
-        ), f"Translation {translation_path.name} has unnecessary keys"
-
-    foreach_translation(check_completeness)
+@pytest.mark.parametrize(["translation_filename"], [(fn,) for fn in get_translation_filenames()])
+def test_translation_completeness(translation_filename: str):
+    with open(TRANSLATION_DIR / "en.json", encoding="utf-8") as f:
+        default_translation = json.loads(f.read())
+    with open(TRANSLATION_DIR / translation_filename, encoding="utf-8") as f:
+        translation = json.load(f)
+    assert set(default_translation.keys()).issubset(
+        translation.keys()
+    ), f"Translation {translation_filename} is missing keys"
+    assert set(default_translation.keys()).issuperset(
+        translation.keys()
+    ), f"Translation {translation_filename} has unnecessary keys"

--- a/tagstudio/tests/test_translations.py
+++ b/tagstudio/tests/test_translations.py
@@ -13,8 +13,8 @@ def load_translation(filename: str) -> dict[str, str]:
         return json.load(f)
 
 
-def get_translation_filenames() -> list[str]:
-    return [a.name for a in TRANSLATION_DIR.glob("*.json")]
+def get_translation_filenames() -> list[tuple[str]]:
+    return [(a.name,) for a in TRANSLATION_DIR.glob("*.json")]
 
 
 def find_format_keys(format_string: str) -> set[str]:
@@ -22,7 +22,7 @@ def find_format_keys(format_string: str) -> set[str]:
     return set([field[1] for field in formatter.parse(format_string) if field[1] is not None])
 
 
-@pytest.mark.parametrize(["translation_filename"], [(fn,) for fn in get_translation_filenames()])
+@pytest.mark.parametrize(["translation_filename"], get_translation_filenames())
 def test_validate_format_keys(translation_filename: str):
     default_translation = load_translation("en.json")
     translation = load_translation(translation_filename)
@@ -39,13 +39,17 @@ def test_validate_format_keys(translation_filename: str):
         ), f"Translation {translation_filename} for key {key} is missing format keys ({default_keys.difference(translation_keys)})"  # noqa: E501
 
 
-@pytest.mark.parametrize(["translation_filename"], [(fn,) for fn in get_translation_filenames()])
+@pytest.mark.parametrize(["translation_filename"], get_translation_filenames())
 def test_translation_completeness(translation_filename: str):
     default_translation = load_translation("en.json")
     translation = load_translation(translation_filename)
-    assert set(default_translation.keys()).issubset(
+    assert set(
+        default_translation.keys()
+    ).issubset(
         translation.keys()
-    ), f"Translation {translation_filename} is missing keys"
-    assert set(default_translation.keys()).issuperset(
+    ), f"Translation {translation_filename} is missing keys ({set(default_translation.keys()).difference(translation.keys())})"  # noqa: E501
+    assert set(
+        default_translation.keys()
+    ).issuperset(
         translation.keys()
-    ), f"Translation {translation_filename} has unnecessary keys"
+    ), f"Translation {translation_filename} has unnecessary keys ({set(translation.keys()).difference(default_translation.keys())})"  # noqa: E501

--- a/tagstudio/tests/test_translations.py
+++ b/tagstudio/tests/test_translations.py
@@ -8,6 +8,11 @@ CWD = Path(__file__).parent
 TRANSLATION_DIR = CWD / ".." / "resources" / "translations"
 
 
+def load_translation(filename: str) -> dict[str, str]:
+    with open(TRANSLATION_DIR / filename, encoding="utf-8") as f:
+        return json.load(f)
+
+
 def get_translation_filenames() -> list[str]:
     return [a.name for a in TRANSLATION_DIR.glob("*.json")]
 
@@ -19,10 +24,8 @@ def find_format_keys(format_string: str) -> set[str]:
 
 @pytest.mark.parametrize(["translation_filename"], [(fn,) for fn in get_translation_filenames()])
 def test_validate_format_keys(translation_filename: str):
-    with open(TRANSLATION_DIR / "en.json", encoding="utf-8") as f:
-        default_translation = json.loads(f.read())
-    with open(TRANSLATION_DIR / translation_filename, encoding="utf-8") as f:
-        translation = json.load(f)
+    default_translation = load_translation("en.json")
+    translation = load_translation(translation_filename)
     for key in default_translation:
         if key not in translation:
             continue
@@ -38,10 +41,8 @@ def test_validate_format_keys(translation_filename: str):
 
 @pytest.mark.parametrize(["translation_filename"], [(fn,) for fn in get_translation_filenames()])
 def test_translation_completeness(translation_filename: str):
-    with open(TRANSLATION_DIR / "en.json", encoding="utf-8") as f:
-        default_translation = json.loads(f.read())
-    with open(TRANSLATION_DIR / translation_filename, encoding="utf-8") as f:
-        translation = json.load(f)
+    default_translation = load_translation("en.json")
+    translation = load_translation(translation_filename)
     assert set(default_translation.keys()).issubset(
         translation.keys()
     ), f"Translation {translation_filename} is missing keys"

--- a/tagstudio/tests/test_translations.py
+++ b/tagstudio/tests/test_translations.py
@@ -23,7 +23,7 @@ def find_format_keys(format_string: str) -> set[str]:
 
 
 @pytest.mark.parametrize(["translation_filename"], get_translation_filenames())
-def test_validate_format_keys(translation_filename: str):
+def test_format_key_validity(translation_filename: str):
     default_translation = load_translation("en.json")
     translation = load_translation(translation_filename)
     for key in default_translation:
@@ -40,14 +40,9 @@ def test_validate_format_keys(translation_filename: str):
 
 
 @pytest.mark.parametrize(["translation_filename"], get_translation_filenames())
-def test_translation_completeness(translation_filename: str):
+def test_for_unnecessary_translations(translation_filename: str):
     default_translation = load_translation("en.json")
     translation = load_translation(translation_filename)
-    assert set(
-        default_translation.keys()
-    ).issubset(
-        translation.keys()
-    ), f"Translation {translation_filename} is missing keys ({set(default_translation.keys()).difference(translation.keys())})"  # noqa: E501
     assert set(
         default_translation.keys()
     ).issuperset(

--- a/tagstudio/tests/test_translations.py
+++ b/tagstudio/tests/test_translations.py
@@ -1,0 +1,50 @@
+import string
+from pathlib import Path
+
+import ujson as json
+
+CWD = Path(__file__).parent
+TRANSLATION_DIR = CWD / ".." / "resources" / "translations"
+
+
+def find_format_keys(format_string: str) -> set[str]:
+    formatter = string.Formatter()
+    return set([field[1] for field in formatter.parse(format_string) if field[1] is not None])
+
+
+def foreach_translation(callback):
+    with open(TRANSLATION_DIR / "en.json", encoding="utf-8") as f:
+        default_translation = json.loads(f.read())
+    for translation_path in TRANSLATION_DIR.glob("*.json"):
+        with open(translation_path, encoding="utf-8") as f:
+            translation = json.load(f)
+        callback(default_translation, translation, translation_path)
+
+
+def test_validate_format_keys():
+    def validate_format_keys(default_translation: dict, translation: dict, translation_path: Path):
+        for key in default_translation:
+            if key not in translation:
+                continue
+            default_keys = find_format_keys(default_translation[key])
+            translation_keys = find_format_keys(translation[key])
+            assert default_keys.issuperset(
+                translation_keys
+            ), f"Translation {translation_path.name} for key {key} is using an invalid format key"
+            assert translation_keys.issuperset(
+                default_keys
+            ), f"Translation {translation_path.name} for key {key} is missing format keys"
+
+    foreach_translation(validate_format_keys)
+
+
+def test_translation_completeness():
+    def check_completeness(default_translation: dict, translation: dict, translation_path: Path):
+        assert set(default_translation.keys()).issubset(
+            translation.keys()
+        ), f"Translation {translation_path.name} is missing keys"
+        assert set(default_translation.keys()).issuperset(
+            translation.keys()
+        ), f"Translation {translation_path.name} has unnecessary keys"
+
+    foreach_translation(check_completeness)


### PR DESCRIPTION
### Summary
Test for the following problems:
- translation keys that are present in en.json not being present in other translations
- translation keys that are present other translations not being present in en.json
- translations using format keys that aren't used by the equivalent in en.json
-  translations not using format keys that *are* used by the equivalent in en.json

(Note that these tests currently fail and that that is intentional as the translations are incorrect at the moment)

### Tasks Completed

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
