### PR TITLE
fix(ffmpeg): remove redundant log statement

### DIFF
--- a/src/tagstudio/qt/modals/ffmpeg_checker.py
+++ b/src/tagstudio/qt/modals/ffmpeg_checker.py
@@ -45,7 +45,6 @@ class FfmpegChecker(QMessageBox):
         if which(FFPROBE_CMD):
             self.ffprobe = True
 
-        logger.info("FFmpeg found: {self.ffmpeg}, FFprobe found: {self.ffprobe}")
         return self.ffmpeg and self.ffprobe
 
     def version(self):


### PR DESCRIPTION
### Summary
A string for a log message was missing the `f` to make it a format string.

### Tasks Completed
-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable
