### PR TITLE
fix: catch NotImplementedError for Float16 JPEG-XL files

### DIFF
--- a/src/tagstudio/qt/widgets/preview/preview_thumb.py
+++ b/src/tagstudio/qt/widgets/preview/preview_thumb.py
@@ -213,7 +213,7 @@ class PreviewThumb(QWidget):
                 image = Image.open(str(filepath))
                 stats["width"] = image.width
                 stats["height"] = image.height
-            except (UnidentifiedImageError, FileNotFoundError) as e:
+            except (UnidentifiedImageError, FileNotFoundError, NotImplementedError) as e:
                 logger.error("[PreviewThumb] Could not get image stats", filepath=filepath, error=e)
         elif MediaCategories.is_ext_in_category(
             ext, MediaCategories.IMAGE_VECTOR_TYPES, mime_fallback=True

--- a/src/tagstudio/qt/widgets/thumb_renderer.py
+++ b/src/tagstudio/qt/widgets/thumb_renderer.py
@@ -818,6 +818,7 @@ class ThumbRenderer(QObject):
         except (
             UnidentifiedImageError,
             DecompressionBombError,
+            NotImplementedError,
         ) as e:
             logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
         return im


### PR DESCRIPTION
### Summary
Resolves #848 by catching the `NotImplementedError` raised by attempting to render "Float16" JPEG-XL files, which are not currently supported by the pillow_jxl module.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->