### PR TITLE
fix: hide mnemonics on macOS

### DIFF
--- a/src/tagstudio/qt/translations.py
+++ b/src/tagstudio/qt/translations.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from pathlib import Path
+from platform import system
 from typing import Any
 
 import structlog
@@ -28,6 +29,11 @@ class Translator:
     def change_language(self, lang: str):
         self._lang = lang
         self._strings = self.__get_translation_dict(lang)
+        if system() == "Darwin":
+            for k, v in self._strings.items():
+                self._strings[k] = (
+                    v.replace("&&", "<ESC_AMP>").replace("&", "", 1).replace("<ESC_AMP>", "&&")
+                )
 
     def __format(self, text: str, **kwargs) -> str:
         try:


### PR DESCRIPTION
### Summary

This PR aims to hide non-functional keyboard mnemonics on macOS as the system does not support them. It aims to do this by filtering out mnemonic indicators from translation files while keeping escaped ampersands intact.

This change will also hide any non-menu mnemonics on macOS that may be added in #843 (menu mnemonics are already hidden by the system's native menubar).

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
