### PR TITLE
feat: add model thumbnail rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "typing_extensions>=3.10.0.0,<4.11.0",
     "ujson>=5.8.0,<5.9.0",
     "vtf2img==0.1.0",
+    "open3d==0.19.0"
 ]
 
 [project.optional-dependencies]

--- a/src/tagstudio/qt/helpers/model_thumbnailer.py
+++ b/src/tagstudio/qt/helpers/model_thumbnailer.py
@@ -1,0 +1,147 @@
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from queue import Empty, Queue
+
+import numpy as np
+import structlog
+from open3d.io import read_triangle_model  # type: ignore
+from open3d.visualization.rendering import (  # type: ignore
+    MaterialRecord,
+    OffscreenRenderer,
+    TriangleMeshModel,
+)
+from PIL import Image
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class QueueRequest:
+    filename: Path
+    size: tuple[int, int]
+    model: TriangleMeshModel
+
+
+@dataclass
+class QueueResponse:
+    filename: Path
+    size: tuple[int, int]
+    image: np.array
+
+
+QUEUE_TIMEOUT = 0.1
+DEFAULT_SIZE = (256, 256)
+
+
+# A thread safe class to handle multiple rendering calls to the Open3D library
+class Open3DRenderer:
+    def __init__(self):
+        self._stop_event = threading.Event()
+        self._render_request_queue = Queue()
+        self._image_response_queue = Queue()
+        self.UP = [0, 1, 0]
+        self.FOV = 60
+        self.DISTANCE_SCALE = 1.0
+        self.BG_COLOR = (0.5, 0.5, 0.5, 1.0)
+        self.renderer = None
+
+        # Primarily for .STL files
+        self.default_mat = MaterialRecord()
+        self.default_mat.base_color = [1.0, 0.5, 0.0, 1.0]
+        self.default_mat.shader = "defaultLit"
+
+        self._render_thread = threading.Thread(target=self._render_loop, daemon=True)
+        self._render_thread.start()
+
+    # ! I do not know why .mtl's are getting passed here so I just kick them out for now
+    def render(self, filename: Path, size: tuple[int, int]) -> Image.Image:
+        if filename.suffix == ".mtl":
+            return None
+        return self._render(filename, size)
+
+    def _render(self, filename: Path, size: tuple[int, int]) -> Image.Image:
+        model = read_triangle_model(filename)
+        request = QueueRequest(filename, size, model)
+        self._render_request_queue.put(request)
+
+        response: QueueResponse | None = None
+        while response is None:
+            # Fetch only the correct response
+            try:
+                response: QueueResponse = self._image_response_queue.get(timeout=QUEUE_TIMEOUT)
+                if response.filename != filename:
+                    self._image_response_queue.put(response)
+                    response = None
+            except Empty:
+                continue
+
+        return Image.fromarray(response.image)
+
+    def _update_camera(self, renderer: OffscreenRenderer, model: TriangleMeshModel):
+        combined_bounding_box = None
+        # Iterate through all meshes to compute the combined bounding box
+        for mesh_model in model.meshes:
+            mesh = mesh_model.mesh
+            bounding_box = mesh.get_axis_aligned_bounding_box()
+
+            if combined_bounding_box is None:
+                combined_bounding_box = bounding_box
+            else:
+                combined_bounding_box = combined_bounding_box + bounding_box
+
+        # Get the center of the combined bounding box
+        center = combined_bounding_box.get_center()
+
+        # Calculate the diagonal size of the bounding box
+        diagonal = combined_bounding_box.get_extent()
+        distance = np.linalg.norm(diagonal) * self.DISTANCE_SCALE
+        eye = center + np.array([1, 1, 1]) * distance / np.linalg.norm([1, 1, 1])
+
+        # Vertical offset helps center object in render better
+        vertical_offset = 0.4
+        eye[1] += vertical_offset
+        renderer.setup_camera(self.FOV, center, eye, self.UP)
+
+    def _render_loop(self):
+        old_size = DEFAULT_SIZE
+        while not self._stop_event.set():
+            try:
+                request: QueueRequest = self._render_request_queue.get(timeout=QUEUE_TIMEOUT)
+            except Empty:
+                continue
+
+            if self.renderer is not None and request.size != old_size:
+                logger.info(f"Releasing renderer for resize from {old_size} to {request.size}")
+                del self.renderer
+                self.renderer = None
+
+            if self.renderer is None:
+                logger.info(f"RESIZING from {old_size} to {request.size}")
+                self.renderer = OffscreenRenderer(request.size[0], request.size[1])
+                old_size = request.size
+                # Signal that the renderer is ready for use
+            #   self.renderer_ready_event.set()
+
+            # # Wait until renderer is ready for the first use
+            # self.renderer_ready_event.wait()
+
+            # Setup Scene
+            self.renderer.scene.clear_geometry()
+            self.renderer.scene.add_model("model", request.model)
+
+            # If stl paint the model
+            if request.filename.suffix == ".stl":
+                self.renderer.scene.update_material(self.default_mat)
+
+            self.renderer.scene.set_background(self.BG_COLOR)
+
+            # Update the camera position
+            self._update_camera(self.renderer, request.model)
+
+            # Render the image
+            image = self.renderer.render_to_image()
+            image_np = np.asarray(image)
+
+            response = QueueResponse(request.filename, request.size, image_np)
+            self._image_response_queue.put(response)


### PR DESCRIPTION
### Summary

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

This pull request adds 3D model thumbnail support for .obj, .gltf, .stl, .glb, and .fbx formats, using Open3D 0.19.0 for rendering. It supports textures and can color texture-less models. In the future, I plan to add a setting for users to choose their default model color.

This supersedes https://github.com/TagStudioDev/TagStudio/pull/693

This closes https://github.com/TagStudioDev/TagStudio/issues/351

#### Remaining Issue
The remaining issue with the pull request is that Open3D's OffscreenRenderer requires a dedicated thread, and it crashes if no thread adopts the renderer. I'm unsure how to integrate this with QThreads, so as a workaround, I set daemon=True for the rendering thread to prevent the software from hanging on exit. While this stops the hanging issue, it feels like a hacky solution.


### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [X] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
