### PR TITLE
fix(nix/package): account for GTK platform

### DIFF
--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -28,6 +28,7 @@
   syrupy,
   ujson,
   vtf2img,
+  wrapGAppsHook,
 
   withJXLSupport ? false,
 }:
@@ -45,6 +46,11 @@ buildPythonApplication {
   nativeBuildInputs = [
     pythonRelaxDepsHook
     qt6.wrapQtAppsHook
+
+    # INFO: Should be unnecessary once PR is pulled.
+    # PR: https://github.com/NixOS/nixpkgs/pull/271037
+    # Issue: https://github.com/NixOS/nixpkgs/issues/149812
+    wrapGAppsHook
   ];
   buildInputs = [
     qt6.qtbase


### PR DESCRIPTION
### Summary
Impacts users using GTK-related Qt platform plugins, must wrap application.
See https://github.com/NixOS/nixpkgs/issues/149812 for details.
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86 (NixOS)
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    -   [x] Nix package building
    <!-- If other important criteria was tested for, please add it here -->
