### PR TITLE
feat(resources): provide desktop file

### DIFF
--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -58,6 +58,14 @@ buildPythonApplication {
     syrupy
   ];
 
+  # TODO: Install more icon resolutions when available.
+  preInstall = ''
+    mkdir -p $out/share/applications $out/share/icons/hicolor/512x512/apps
+
+    cp $src/src/tagstudio/resources/tagstudio.desktop $out/share/applications
+    cp $src/src/tagstudio/resources/icon.png $out/share/icons/hicolor/512x512/apps/tagstudio.png
+  '';
+
   makeWrapperArgs =
     [ "--prefix PATH : ${lib.makeBinPath [ ffmpeg-headless ]}" ]
     ++ lib.optional stdenv.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -297,10 +297,13 @@ class QtDriver(DriverMixin, QObject):
             appid = "cyanvoxel.tagstudio.9"
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)  # type: ignore[attr-defined,unused-ignore]
 
-        if sys.platform != "darwin":
+        if platform.system() != "Darwin":
             icon = QIcon()
-            icon.addFile(str(self.rm.get_path("icon")))
+            icon.fromTheme("tagstudio")
             app.setWindowIcon(icon)
+
+            if platform.system() != "Windows":
+                app.setDesktopFileName("tagstudio")
 
         # Initialize the Tag Manager panel
         self.tag_manager_panel = PanelModal(
@@ -328,14 +331,6 @@ class QtDriver(DriverMixin, QObject):
                 self.preview_panel.update_widgets(),
             )
         )
-
-        if platform.system() != "Darwin":
-            icon = QIcon()
-            icon.fromTheme("tagstudio")
-            app.setWindowIcon(icon)
-
-            if platform.system() != "Windows":
-                app.setDesktopFileName("tagstudio")
 
         menu_bar = QMenuBar(self.main_window)
         self.main_window.setMenuBar(menu_bar)

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -13,6 +13,7 @@ import ctypes
 import dataclasses
 import math
 import os
+import platform
 import re
 import sys
 import time
@@ -327,6 +328,14 @@ class QtDriver(DriverMixin, QObject):
                 self.preview_panel.update_widgets(),
             )
         )
+
+        if platform.system() != "Darwin":
+            icon = QIcon()
+            icon.fromTheme("tagstudio")
+            app.setWindowIcon(icon)
+
+            if platform.system() != "Windows":
+                app.setDesktopFileName("tagstudio")
 
         menu_bar = QMenuBar(self.main_window)
         self.main_window.setMenuBar(menu_bar)

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -297,10 +297,12 @@ class QtDriver(DriverMixin, QObject):
             appid = "cyanvoxel.tagstudio.9"
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)  # type: ignore[attr-defined,unused-ignore]
 
+        app.setApplicationName("tagstudio")
+        app.setApplicationDisplayName("TagStudio")
         if platform.system() != "Darwin":
-            icon = QIcon()
-            icon.fromTheme("tagstudio")
-            app.setWindowIcon(icon)
+            fallback_icon = QIcon()
+            fallback_icon.addFile(str(self.rm.get_path("icon")))
+            app.setWindowIcon(QIcon.fromTheme("tagstudio", fallback_icon))
 
             if platform.system() != "Windows":
                 app.setDesktopFileName("tagstudio")

--- a/src/tagstudio/resources/tagstudio.desktop
+++ b/src/tagstudio/resources/tagstudio.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=TagStudio
+GenericName=Tag Management System
+Comment=Tag, find, and organize files
+Icon=tagstudio
+Exec=tagstudio
+Terminal=false
+Categories=AudioVideo;Qt;
+Keywords=files;folders;tags;


### PR DESCRIPTION
### Summary

Provides a desktop file, and exposes it and the relevant icon for the Nix package.

Fixes: #415
Fixes: #422
Fixes: #847

Note that I cannot test pinning functionality as I do not use a desktop environment. Would appreciate help with testing that. Otherwise, I will create a virtual machine.
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86 (NixOS)
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
    -   [x] Nix package building
