### PR TITLE
fix(flake): remove pinned input, only consume in Nix shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,27 +36,10 @@
         "type": "github"
       }
     },
-    "nixpkgs-qt6": {
-      "locked": {
-        "lastModified": 1734856068,
-        "narHash": "sha256-Q+CB1ajsJg4Z9HGHTBAGY1q18KpnnkmF/eCTLUY6FQ0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "93ff48c9be84a76319dac293733df09bbbe3f25c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "93ff48c9be84a76319dac293733df09bbbe3f25c",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-qt6": "nixpkgs-qt6",
         "systems": "systems"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,6 @@
 
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    nixpkgs-qt6.url = "github:NixOS/nixpkgs/93ff48c9be84a76319dac293733df09bbbe3f25c";
-
     systems.url = "github:nix-systems/default";
   };
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,12 +1,13 @@
-{
-  inputs,
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, pkgs, ... }:
 
 let
-  qt6Pkgs = import inputs.nixpkgs-qt6 { inherit (pkgs) system; };
+  # INFO: PySide6 from PIP is compiled for 6.8.0 of Qt, must pin to match version.
+  # Long term this can be solved with an alternative like uv2nix for the devshell.
+  qt6Pkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable-qt6-pinned";
+    url = "https://github.com/NixOS/nixpkgs/archive/93ff48c9be84a76319dac293733df09bbbe3f25c.tar.gz";
+    sha256 = "038m7932v4z0zn2lk7k7mbqbank30q84r1viyhchw9pcm3aq3q23";
+  }) { inherit (pkgs) system; };
 
   pythonLibraryPath = lib.makeLibraryPath (
     (with pkgs; [


### PR DESCRIPTION
### Summary
Resolves problem of duplicated nixpkgs input as noted in https://github.com/TagStudioDev/TagStudio/issues/847#issuecomment-2727624004, will now only be consumed by the Nix shell.

Long term, an alternative like uv2nix could be used in the shell to remove any kind of pinning. That is out of scope for now, especially when there is no lock file being used in the repo yet.
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86 (NixOS)
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
