### PR TITLE
fix: use UNION instead of UNION ALL

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -96,7 +96,7 @@ TAG_CHILDREN_QUERY = text("""
 -- Note for this entire query that tag_parents.child_id is the parent id and tag_parents.parent_id is the child id due to bad naming
 WITH RECURSIVE ChildTags AS (
     SELECT :tag_id AS child_id
-    UNION ALL
+    UNION
     SELECT tp.parent_id AS child_id
 	FROM tag_parents tp
     INNER JOIN ChildTags c ON tp.child_id = c.child_id

--- a/src/tagstudio/core/library/alchemy/visitors.py
+++ b/src/tagstudio/core/library/alchemy/visitors.py
@@ -36,7 +36,7 @@ TAG_CHILDREN_ID_QUERY = text("""
 -- Note for this entire query that tag_parents.child_id is the parent id and tag_parents.parent_id is the child id due to bad naming
 WITH RECURSIVE ChildTags AS (
     SELECT :tag_id AS child_id
-    UNION ALL
+    UNION
     SELECT tp.parent_id AS child_id
 	FROM tag_parents tp
     INNER JOIN ChildTags c ON tp.child_id = c.child_id


### PR DESCRIPTION
### Summary

Replaces instances of `UNION ALL` with `UNION` to prevent infinite recursive loops in SQL statements. This also aligns with the intended behavior of these statements where the returned results should be unique (at least in library.py). Fixes #875. 

From the [SQLite docs](https://www.sqlite.org/lang_with.html):
> If a UNION operator connects the initial-select with the recursive-select, then only add rows to the queue if no identical row has been previously added to the queue. Repeated rows are discarded before being added to the queue even if the repeated rows have already been extracted from the queue by the recursion step. If the operator is UNION ALL, then all rows generated by both the initial-select and the recursive-select are always added to the queue even if they are repeats. When determining if a row is repeated, NULL values compare equal to one another and not equal to any other value. 

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
