### PR TITLE
ui: recent libraries list improvements

### DIFF
--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -1857,8 +1857,18 @@ class QtDriver(DriverMixin, QObject):
         open_status: LibraryStatus | None = None
         try:
             open_status = self.lib.open_library(path)
+        except ValueError as e:
+            logger.warning(e)
+            open_status = LibraryStatus(
+                success=False,
+                library_path=path,
+                message=Translations["menu.file.missing_library.title"],
+                msg_description=Translations.format(
+                    "menu.file.missing_library.message", library=library_dir_display
+                ),
+            )
         except Exception as e:
-            logger.exception(e)
+            logger.error(e)
             open_status = LibraryStatus(
                 success=False, library_path=path, message=type(e).__name__, msg_description=str(e)
             )

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -1728,7 +1728,7 @@ class QtDriver(DriverMixin, QObject):
 
     def update_libs_list(self, path: Path | str):
         """Add library to list in SettingItems.LIBS_LIST."""
-        item_limit: int = 5
+        item_limit: int = 10
         path = Path(path)
 
         self.settings.beginGroup(SettingItems.LIBS_LIST)

--- a/src/tagstudio/resources/translations/en.json
+++ b/src/tagstudio/resources/translations/en.json
@@ -197,6 +197,8 @@
     "menu.edit": "Edit",
     "menu.file.clear_recent_libraries": "Clear Recent",
     "menu.file.close_library": "&Close Library",
+    "menu.file.missing_library.message": "The location of the library \"{library}\" cannot be found.",
+    "menu.file.missing_library.title": "Missing Library",
     "menu.file.new_library": "New Library",
     "menu.file.open_create_library": "&Open/Create Library",
     "menu.file.open_library": "Open Library",


### PR DESCRIPTION
### Summary

This PR makes a couple tweaks to the Recent Libraries menu item:
1. Add a more specific error message when trying to open a library location that no longer exists *(while keeping in mind that the full library path may not always be shown anymore, and in the future library files may not be in the same location as the folders they use)*
2. Increase the recent library list limit from 5 to 10

![image](https://github.com/user-attachments/assets/7d76a903-7824-48a3-8d17-b7fcb273ee17)

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
