### PR TITLE
fix: remove unescaped ampersand from "about.description"

### DIFF
--- a/src/tagstudio/resources/translations/de.json
+++ b/src/tagstudio/resources/translations/de.json
@@ -1,6 +1,6 @@
 {
     "about.config_path": "Konfigurations-Pfad",
-    "about.description": "TagStudio ist eine Anwendung zum organisieren von Fotos & Dateien mit einem zugrunde liegendem Tag-basierten System, welches sich darauf konzentriert, dem Nutzer Freiraum und Flexibilität zu bieten. Keine proprietären Programme oder Formate, kein Meer an Hilfsdateien und keine komplette Umwälzung deiner Dateisystemstruktur.",
+    "about.description": "TagStudio ist eine Anwendung zum organisieren von Fotos und Dateien mit einem zugrunde liegendem Tag-basierten System, welches sich darauf konzentriert, dem Nutzer Freiraum und Flexibilität zu bieten. Keine proprietären Programme oder Formate, kein Meer an Hilfsdateien und keine komplette Umwälzung deiner Dateisystemstruktur.",
     "about.documentation": "Dokumentation",
     "about.license": "Lizenz",
     "about.title": "Über TagStudio",

--- a/src/tagstudio/resources/translations/en.json
+++ b/src/tagstudio/resources/translations/en.json
@@ -1,6 +1,6 @@
 {
     "about.config_path": "Config Path",
-    "about.description": "TagStudio is a photo & file organization application with an underlying tag-based system that focuses on giving freedom and flexibility to the user. No proprietary programs or formats, no sea of sidecar files, and no complete upheaval of your filesystem structure.",
+    "about.description": "TagStudio is a photo and file organization application with an underlying tag-based system that focuses on giving freedom and flexibility to the user. No proprietary programs or formats, no sea of sidecar files, and no complete upheaval of your filesystem structure.",
     "about.documentation": "Documentation",
     "about.license": "License",
     "about.module.found": "Found",


### PR DESCRIPTION
### Summary
Remove an unescaped ampersand from the "about.description" translation key which caused the text to render incorrectly. This could have been addressed by escaping the ampersand (e.g. "&&") but I've opted to replace it with the word "and" instead.

Before:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/03d40169-6545-4f78-9b0f-cb82b57067c8" />
After:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/82381b5d-4b45-4c64-8332-37429d9f6721" />


### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
