### PR TITLE
feat(ui): show stems for extension-less files

### DIFF
--- a/src/tagstudio/qt/widgets/item_thumb.py
+++ b/src/tagstudio/qt/widgets/item_thumb.py
@@ -205,11 +205,11 @@ class ItemThumb(FlowWidget):
         self.thumb_button = ThumbButton(self.thumb_container, thumb_size)
         self.renderer = ThumbRenderer(self.lib)
         self.renderer.updated.connect(
-            lambda timestamp, image, size, filename, ext: (
+            lambda timestamp, image, size, filename: (
                 self.update_thumb(timestamp, image=image),
                 self.update_size(timestamp, size=size),
                 self.set_filename_text(filename),
-                self.set_extension(ext),  # type: ignore
+                self.set_extension(filename),  # type: ignore
             )
         )
         self.thumb_button.setFlat(True)
@@ -365,13 +365,13 @@ class ItemThumb(FlowWidget):
             self.item_type_badge.setHidden(False)
         self.mode = mode
 
-    def set_extension(self, ext: str) -> None:
+    def set_extension(self, filename: Path) -> None:
+        ext = filename.suffix
         if ext and ext.startswith(".") is False:
             ext = "." + ext
         media_types: set[MediaType] = MediaCategories.get_types(ext)
         if (
-            ext
-            and not MediaCategories.is_ext_in_category(ext, MediaCategories.IMAGE_TYPES)
+            not MediaCategories.is_ext_in_category(ext, MediaCategories.IMAGE_TYPES)
             or MediaCategories.is_ext_in_category(ext, MediaCategories.IMAGE_RAW_TYPES)
             or MediaCategories.is_ext_in_category(ext, MediaCategories.IMAGE_VECTOR_TYPES)
             or MediaCategories.is_ext_in_category(ext, MediaCategories.ADOBE_PHOTOSHOP_TYPES)
@@ -386,7 +386,7 @@ class ItemThumb(FlowWidget):
             ]
         ):
             self.ext_badge.setHidden(False)
-            self.ext_badge.setText(ext.upper()[1:])
+            self.ext_badge.setText(ext.upper()[1:] or filename.stem.upper())
             if MediaType.VIDEO in media_types or MediaType.AUDIO in media_types:
                 self.count_badge.setHidden(False)
         else:

--- a/src/tagstudio/qt/widgets/preview/file_attributes.py
+++ b/src/tagstudio/qt/widgets/preview/file_attributes.py
@@ -130,8 +130,9 @@ class FileAttributes(QWidget):
             self.date_created_label.setHidden(True)
             self.date_modified_label.setHidden(True)
 
-    def update_stats(self, filepath: Path | None = None, ext: str = ".", stats: dict = None):
+    def update_stats(self, filepath: Path | None = None, stats: dict | None = None):
         """Render the panel widgets with the newest data from the Library."""
+        ext = filepath.suffix.lower()
         if not stats:
             stats = {}
 
@@ -186,8 +187,7 @@ class FileAttributes(QWidget):
             height_px_text = stats.get("height", "")
             duration_text = stats.get("duration", "")
             font_family = stats.get("font_family", "")
-            if ext:
-                ext_display = ext.upper()[1:]
+            ext_display = ext.upper()[1:] or filepath.stem.upper()
             if filepath:
                 try:
                     file_size = format_size(filepath.stat().st_size)

--- a/src/tagstudio/qt/widgets/preview/preview_thumb.py
+++ b/src/tagstudio/qt/widgets/preview/preview_thumb.py
@@ -242,17 +242,18 @@ class PreviewThumb(QWidget):
             self.devicePixelRatio(),
             update_on_ratio_change=True,
         )
-        return self._update_image(filepath, ext)
+        return self._update_image(filepath)
 
-    def _update_image(self, filepath: Path, ext: str) -> dict:
+    def _update_image(self, filepath: Path) -> dict:
         """Update the static image preview from a filepath."""
         stats: dict = {}
+        ext = filepath.suffix.lower()
         self.switch_preview("image")
 
         image: Image.Image | None = None
 
         if MediaCategories.is_ext_in_category(
-            ext, MediaCategories.IMAGE_RAW_TYPES, mime_fallback=True
+            filepath.suffix.lower(), MediaCategories.IMAGE_RAW_TYPES, mime_fallback=True
         ):
             try:
                 with rawpy.imread(str(filepath)) as raw:
@@ -380,8 +381,9 @@ class PreviewThumb(QWidget):
         stats["duration"] = self.media_player.player.duration() * 1000
         return stats
 
-    def update_preview(self, filepath: Path, ext: str) -> dict:
+    def update_preview(self, filepath: Path) -> dict:
         """Render a single file preview."""
+        ext = filepath.suffix.lower()
         stats: dict = {}
 
         # Video
@@ -394,7 +396,7 @@ class PreviewThumb(QWidget):
         elif MediaCategories.is_ext_in_category(
             ext, MediaCategories.AUDIO_TYPES, mime_fallback=True
         ):
-            self._update_image(filepath, ext)
+            self._update_image(filepath)
             stats = self._update_media(filepath, MediaType.AUDIO)
             self.thumb_renderer.render(
                 time.time(),
@@ -413,7 +415,7 @@ class PreviewThumb(QWidget):
         # Other Types (Including Images)
         else:
             # TODO: Get thumb renderer to return this stuff to pass on
-            stats = self._update_image(filepath, ext)
+            stats = self._update_image(filepath)
 
             self.thumb_renderer.render(
                 time.time(),

--- a/src/tagstudio/qt/widgets/preview_panel.py
+++ b/src/tagstudio/qt/widgets/preview_panel.py
@@ -145,11 +145,10 @@ class PreviewPanel(QWidget):
                 entry: Entry = self.lib.get_entry(self.driver.selected[0])
                 entry_id = self.driver.selected[0]
                 filepath: Path = self.lib.library_dir / entry.path
-                ext: str = filepath.suffix.lower()
 
                 if update_preview:
-                    stats: dict = self.thumb.update_preview(filepath, ext)
-                    self.file_attrs.update_stats(filepath, ext, stats)
+                    stats: dict = self.thumb.update_preview(filepath)
+                    self.file_attrs.update_stats(filepath, stats)
                 self.file_attrs.update_date_label(filepath)
                 self.fields.update_from_entry(entry_id)
                 self.update_add_tag_button(entry_id)

--- a/src/tagstudio/qt/widgets/thumb_renderer.py
+++ b/src/tagstudio/qt/widgets/thumb_renderer.py
@@ -88,7 +88,7 @@ class ThumbRenderer(QObject):
 
     rm: ResourceManager = ResourceManager()
     cache: CacheManager = CacheManager()
-    updated = Signal(float, QPixmap, QSize, Path, str)
+    updated = Signal(float, QPixmap, QSize, Path)
     updated_ratio = Signal(float)
 
     cached_img_res: int = 256  # TODO: Pull this from config
@@ -1299,7 +1299,6 @@ class ThumbRenderer(QObject):
                     math.ceil(image.size[1] / pixel_ratio),
                 ),
                 filepath,
-                filepath.suffix.lower(),
             )
         else:
             self.updated.emit(
@@ -1307,7 +1306,6 @@ class ThumbRenderer(QObject):
                 QPixmap(),
                 QSize(*base_size),
                 filepath,
-                filepath.suffix.lower(),
             )
 
     def _render(


### PR DESCRIPTION
### Summary

This PR displays file stems in place of extensions for extension-less filenames inside item thumbnails and the preview panel. The prior behavior was to show no label if there was no extension, which made browsing these extension-less files difficult. 
<img width="557" alt="image" src="https://github.com/user-attachments/assets/11578ad8-22ed-4e88-b81e-93ff5c364c03" />
<img width="283" alt="image" src="https://github.com/user-attachments/assets/09193dcc-2bf3-468b-a594-d92c33434f42" />
*Note: Yes, this example shows several filetypes that should normally be excluded from TagStudio libraries. That is not related to this PR.*

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
