### PR TITLE
Remove border from video preview top and left

### DIFF
--- a/src/tagstudio/qt/widgets/media_player.py
+++ b/src/tagstudio/qt/widgets/media_player.py
@@ -118,6 +118,7 @@ class MediaPlayer(QGraphicsView):
         self.setStyleSheet("""
             QGraphicsView {
                background: transparent;
+               border: none;
             }
         """)
         self.setAlignment(Qt.AlignmentFlag.AlignCenter)


### PR DESCRIPTION
### Summary

made the border on the video preview none to remove the grey lines on the left and top of the video preview to keep with how it looked before the refactor

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [X] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [X] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
