### PR TITLE
fix(test): Fix tests to pass on windows without disrupting other platforms

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,9 +60,7 @@ def temp_dir():
 
     test_dir.mkdir(parents=True, exist_ok=True)
 
-    yield test_dir
-
-    shutil.rmtree(test_dir, ignore_errors=True)
+    return test_dir
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import sys
-import tempfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
@@ -10,6 +9,7 @@ CWD = Path(__file__).parent
 # this needs to be above `src` imports
 sys.path.insert(0, str(CWD.parent))
 
+from tagstudio.core.constants import THUMB_CACHE_NAME, TS_FOLDER_NAME
 from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.models import Entry, Tag
 from tagstudio.qt.ts_qt import QtDriver
@@ -52,28 +52,29 @@ def file_mediatypes_library():
 
 
 @pytest.fixture(scope="session")
-def temp_dir():
-    """Creates a shared library path for tests, and cleans it up after the session."""
-    with tempfile.TemporaryDirectory() as tmp_dir_name:
-        temp_root = Path(tmp_dir_name)
-        yield temp_root
+def library_dir():
+    """Creates a shared library path for tests, that cleans up after the session."""
+    with TemporaryDirectory() as tmp_dir_name:
+        library_path = Path(tmp_dir_name)
+
+        thumbs_path = library_path / TS_FOLDER_NAME / THUMB_CACHE_NAME
+        thumbs_path.mkdir(parents=True, exist_ok=True)
+
+        yield library_path
 
 
 @pytest.fixture
-def library(request, temp_dir: Path):
+def library(request, library_dir: Path):
     # when no param is passed, use the default
-    library_path = str(temp_dir)
+    library_path = library_dir
     if hasattr(request, "param"):
         if isinstance(request.param, TemporaryDirectory):
-            library_path = request.param.name
+            library_path = Path(request.param.name)
         else:
-            library_path = request.param
-
-    thumbs_path = Path(library_path) / ".TagStudio" / "thumbs"
-    thumbs_path.mkdir(parents=True, exist_ok=True)
+            library_path = Path(request.param)
 
     lib = Library()
-    status = lib.open_library(Path(library_path), ":memory:")
+    status = lib.open_library(library_path, ":memory:")
     assert status.success
 
     tag = Tag(
@@ -142,34 +143,32 @@ def entry_full(library: Library):
 
 
 @pytest.fixture
-def qt_driver(qtbot, library):
-    with TemporaryDirectory() as tmp_dir:
+def qt_driver(qtbot, library, library_dir: Path):
+    class Args:
+        settings_file = library_dir / "settings.toml"
+        cache_file = library_dir / "tagstudio.ini"
+        open = library_dir
+        ci = True
 
-        class Args:
-            settings_file = Path(tmp_dir) / "settings.toml"
-            cache_file = Path(tmp_dir) / "tagstudio.ini"
-            open = Path(tmp_dir)
-            ci = True
+    with patch("tagstudio.qt.ts_qt.Consumer"), patch("tagstudio.qt.ts_qt.CustomRunnable"):
+        driver = QtDriver(Args())
 
-        with patch("tagstudio.qt.ts_qt.Consumer"), patch("tagstudio.qt.ts_qt.CustomRunnable"):
-            driver = QtDriver(Args())
+        driver.app = Mock()
+        driver.main_window = Mock()
+        driver.preview_panel = Mock()
+        driver.flow_container = Mock()
+        driver.item_thumbs = []
+        driver.autofill_action = Mock()
 
-            driver.app = Mock()
-            driver.main_window = Mock()
-            driver.preview_panel = Mock()
-            driver.flow_container = Mock()
-            driver.item_thumbs = []
-            driver.autofill_action = Mock()
+        driver.copy_buffer = {"fields": [], "tags": []}
+        driver.copy_fields_action = Mock()
+        driver.paste_fields_action = Mock()
 
-            driver.copy_buffer = {"fields": [], "tags": []}
-            driver.copy_fields_action = Mock()
-            driver.paste_fields_action = Mock()
-
-            driver.lib = library
-            # TODO - downsize this method and use it
-            # driver.start()
-            driver.frame_content = list(library.get_entries())
-            yield driver
+        driver.lib = library
+        # TODO - downsize this method and use it
+        # driver.start()
+        driver.frame_content = list(library.get_entries())
+        yield driver
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def temp_dir():
 @pytest.fixture
 def library(request, temp_dir: Path):
     # when no param is passed, use the default
-    library_path = temp_dir
+    library_path = str(temp_dir)
     if hasattr(request, "param"):
         if isinstance(request.param, TemporaryDirectory):
             library_path = request.param.name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def temp_dir():
 
 
 @pytest.fixture
-def library(request, temp_dir):
+def library(request, temp_dir: Path):
     # when no param is passed, use the default
     library_path = temp_dir
     if hasattr(request, "param"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 import tempfile
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,12 +54,9 @@ def file_mediatypes_library():
 @pytest.fixture(scope="session")
 def temp_dir():
     """Creates a shared library path for tests, and cleans it up after the session."""
-    temp_root = Path(tempfile.gettempdir())
-    test_dir = temp_root / "ts-test-temp"
-
-    test_dir.mkdir(parents=True, exist_ok=True)
-
-    return test_dir
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        temp_root = Path(tmp_dir_name)
+        yield temp_root
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,7 @@ def temp_dir():
     temp_root = Path(tempfile.gettempdir())
     test_dir = temp_root / "ts-test-temp"
 
-    if test_dir.exists():
-        shutil.rmtree(test_dir)
-    test_dir.mkdir(parents=True)
+    test_dir.mkdir(parents=True, exist_ok=True)
 
     yield test_dir
 

--- a/tests/qt/test_file_path_options.py
+++ b/tests/qt/test_file_path_options.py
@@ -107,16 +107,13 @@ def test_file_path_display(
     ],
 )
 def test_title_update(
-    qt_driver: QtDriver, filepath_option: ShowFilepathOption, expected_title, temp_dir
+    qt_driver: QtDriver, filepath_option: ShowFilepathOption, expected_title, temp_dir: Path
 ):
     base_title = qt_driver.base_title
 
-    test_path = temp_dir
-    test_path.mkdir(parents=True, exist_ok=True)
-
     open_status = LibraryStatus(
         success=True,
-        library_path=test_path,
+        library_path=temp_dir,
         message="",
         msg_description="",
     )
@@ -138,7 +135,7 @@ def test_title_update(
     qt_driver.folders_to_tags_action = QAction(menu_bar)
 
     # Trigger the update
-    qt_driver.init_library(test_path, open_status)
+    qt_driver.init_library(temp_dir, open_status)
 
     # Assert the title is updated correctly
-    qt_driver.main_window.setWindowTitle.assert_called_with(expected_title(test_path, base_title))
+    qt_driver.main_window.setWindowTitle.assert_called_with(expected_title(temp_dir, base_title))

--- a/tests/qt/test_file_path_options.py
+++ b/tests/qt/test_file_path_options.py
@@ -107,13 +107,13 @@ def test_file_path_display(
     ],
 )
 def test_title_update(
-    qt_driver: QtDriver, filepath_option: ShowFilepathOption, expected_title, temp_dir: Path
+    qt_driver: QtDriver, filepath_option: ShowFilepathOption, expected_title, library_dir: Path
 ):
     base_title = qt_driver.base_title
 
     open_status = LibraryStatus(
         success=True,
-        library_path=temp_dir,
+        library_path=library_dir,
         message="",
         msg_description="",
     )
@@ -135,7 +135,7 @@ def test_title_update(
     qt_driver.folders_to_tags_action = QAction(menu_bar)
 
     # Trigger the update
-    qt_driver.init_library(temp_dir, open_status)
+    qt_driver.init_library(library_dir, open_status)
 
     # Assert the title is updated correctly
-    qt_driver.main_window.setWindowTitle.assert_called_with(expected_title(temp_dir, base_title))
+    qt_driver.main_window.setWindowTitle.assert_called_with(expected_title(library_dir, base_title))

--- a/tests/qt/test_file_path_options.py
+++ b/tests/qt/test_file_path_options.py
@@ -106,9 +106,14 @@ def test_file_path_display(
         ),
     ],
 )
-def test_title_update(qt_driver: QtDriver, filepath_option: ShowFilepathOption, expected_title):
+def test_title_update(
+    qt_driver: QtDriver, filepath_option: ShowFilepathOption, expected_title, temp_dir
+):
     base_title = qt_driver.base_title
-    test_path = Path("/dev/null")
+
+    test_path = temp_dir
+    test_path.mkdir(parents=True, exist_ok=True)
+
     open_status = LibraryStatus(
         success=True,
         library_path=test_path,

--- a/tests/qt/test_global_settings.py
+++ b/tests/qt/test_global_settings.py
@@ -1,28 +1,26 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from tagstudio.core.global_settings import GlobalSettings, Theme
 
 
-def test_read_settings():
-    with TemporaryDirectory() as tmp_dir:
-        settings_path = Path(tmp_dir) / "settings.toml"
-        with open(settings_path, "a") as settings_file:
-            settings_file.write("""
-                language = "de"
-                open_last_loaded_on_startup = true
-                autoplay = true
-                show_filenames_in_grid = true
-                page_size = 1337
-                show_filepath = 0
-                dark_mode = 2
-            """)
+def test_read_settings(library_dir: Path):
+    settings_path = library_dir / "settings.toml"
+    with open(settings_path, "a") as settings_file:
+        settings_file.write("""
+            language = "de"
+            open_last_loaded_on_startup = true
+            autoplay = true
+            show_filenames_in_grid = true
+            page_size = 1337
+            show_filepath = 0
+            dark_mode = 2
+        """)
 
-        settings = GlobalSettings.read_settings(settings_path)
-        assert settings.language == "de"
-        assert settings.open_last_loaded_on_startup
-        assert settings.autoplay
-        assert settings.show_filenames_in_grid
-        assert settings.page_size == 1337
-        assert settings.show_filepath == 0
-        assert settings.theme == Theme.SYSTEM
+    settings = GlobalSettings.read_settings(settings_path)
+    assert settings.language == "de"
+    assert settings.open_last_loaded_on_startup
+    assert settings.autoplay
+    assert settings.show_filenames_in_grid
+    assert settings.page_size == 1337
+    assert settings.show_filepath == 0
+    assert settings.theme == Theme.SYSTEM

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,10 +1,7 @@
-from os import makedirs
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from PySide6.QtCore import QSettings
 
-from tagstudio.core.constants import TS_FOLDER_NAME
 from tagstudio.core.driver import DriverMixin
 from tagstudio.core.enums import SettingItems
 from tagstudio.core.global_settings import GlobalSettings
@@ -52,22 +49,20 @@ def test_evaluate_path_last_lib_not_exists():
     assert result == LibraryStatus(success=True, library_path=None, message=None)
 
 
-def test_evaluate_path_last_lib_present():
+def test_evaluate_path_last_lib_present(library_dir: Path):
     # Given
-    with TemporaryDirectory() as tmpdir:
-        cache_file = tmpdir + "/test_settings.ini"
-        cache = QSettings(cache_file, QSettings.Format.IniFormat)
-        cache.setValue(SettingItems.LAST_LIBRARY, tmpdir)
-        cache.sync()
+    cache_file = library_dir / "test_settings.ini"
+    cache = QSettings(str(cache_file), QSettings.Format.IniFormat)
+    cache.setValue(SettingItems.LAST_LIBRARY, library_dir)
+    cache.sync()
 
-        settings = GlobalSettings()
-        settings.open_last_loaded_on_startup = True
+    settings = GlobalSettings()
+    settings.open_last_loaded_on_startup = True
 
-        makedirs(Path(tmpdir) / TS_FOLDER_NAME)
-        driver = TestDriver(settings, cache)
+    driver = TestDriver(settings, cache)
 
-        # When
-        result = driver.evaluate_path(None)
+    # When
+    result = driver.evaluate_path(None)
 
-        # Then
-        assert result == LibraryStatus(success=True, library_path=Path(tmpdir))
+    # Then
+    assert result == LibraryStatus(success=True, library_path=library_dir)


### PR DESCRIPTION
### Summary

Replaced `dev/null` path with a universal `temp_dir` function that persists through the test session and cleans itself up afterwards to function identically but runs on windows as well as others? I don't have another platform to test this on so it will need to be tested.

<sub>Sorry, it was bugging me I wanted tests to pass xD<sub>

![image](https://github.com/user-attachments/assets/f22829f9-fc64-49d2-81ca-ce3719074002)

### Tasks Completed

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
