### PR TITLE
feat: add ability to invert selection

### DIFF
--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -473,6 +473,21 @@ class QtDriver(DriverMixin, QObject):
         self.select_all_action.setEnabled(False)
         edit_menu.addAction(self.select_all_action)
 
+        self.select_inverse_action = QAction(Translations["select.inverse"], menu_bar)
+        self.select_inverse_action.triggered.connect(self.select_inverse_action_callback)
+        self.select_inverse_action.setShortcut(
+            QtCore.QKeyCombination(
+                QtCore.Qt.KeyboardModifier(
+                    QtCore.Qt.KeyboardModifier.ControlModifier
+                    ^ QtCore.Qt.KeyboardModifier.ShiftModifier
+                ),
+                QtCore.Qt.Key.Key_I,
+            )
+        )
+        self.select_inverse_action.setToolTip("Ctrl+Shift+I")
+        self.select_inverse_action.setEnabled(False)
+        edit_menu.addAction(self.select_inverse_action)
+
         self.clear_select_action = QAction(Translations["select.clear"], menu_bar)
         self.clear_select_action.triggered.connect(self.clear_select_action_callback)
         self.clear_select_action.setShortcut(QtCore.Qt.Key.Key_Escape)
@@ -950,6 +965,26 @@ class QtDriver(DriverMixin, QObject):
             if item.mode and item.item_id not in self.selected and not item.isHidden():
                 self.selected.append(item.item_id)
                 item.thumb_button.set_selected(True)
+
+        self.set_macro_menu_viability()
+        self.set_clipboard_menu_viability()
+        self.set_select_actions_visibility()
+
+        self.preview_panel.update_widgets(update_preview=False)
+
+    def select_inverse_action_callback(self):
+        """Invert the selection of all visible items."""
+        new_selected = []
+
+        for item in self.item_thumbs:
+            if item.mode and not item.isHidden():
+                if item.item_id in self.selected:
+                    item.thumb_button.set_selected(False)
+                else:
+                    item.thumb_button.set_selected(True)
+                    new_selected.append(item.item_id)
+
+        self.selected = new_selected
 
         self.set_macro_menu_viability()
         self.set_clipboard_menu_viability()
@@ -1479,8 +1514,10 @@ class QtDriver(DriverMixin, QObject):
 
         if self.frame_content:
             self.select_all_action.setEnabled(True)
+            self.select_inverse_action.setEnabled(True)
         else:
             self.select_all_action.setEnabled(False)
+            self.select_inverse_action.setEnabled(False)
 
         if self.selected:
             self.add_tag_to_selected_action.setEnabled(True)

--- a/src/tagstudio/resources/translations/en.json
+++ b/src/tagstudio/resources/translations/en.json
@@ -229,7 +229,7 @@
     "select.add_tag_to_selected": "Add Tag to Selected",
     "select.all": "Select All",
     "select.clear": "Clear Selection",
-    "select.inverse": "Select Inverse",
+    "select.inverse": "Invert Selection",
     "settings.clear_thumb_cache.title": "Clear Thumbnail Cache",
     "settings.filepath.label": "Filepath Visibility",
     "settings.filepath.option.full": "Show Full Paths",

--- a/src/tagstudio/resources/translations/en.json
+++ b/src/tagstudio/resources/translations/en.json
@@ -229,6 +229,7 @@
     "select.add_tag_to_selected": "Add Tag to Selected",
     "select.all": "Select All",
     "select.clear": "Clear Selection",
+    "select.inverse": "Select Inverse",
     "settings.clear_thumb_cache.title": "Clear Thumbnail Cache",
     "settings.filepath.label": "Filepath Visibility",
     "settings.filepath.option.full": "Show Full Paths",


### PR DESCRIPTION
### Summary

Add the ability to select unselected thumbnails while unselecting selected thumbnails.. thus inverting your selection. I found that when I'm trying to go through a lot of tags sometimes it's more of a Boolean operation where I select a bunch to tag with one thing but want to select all the opposite ones to tag them with the other tag. I used what was considered a fairly common hotkey for invert selection (at least it's the one that comes up when you google "hotkey to select inverse")

Sorry I didn't open an issue first, It seemed small enough of a thing I didn't mind to throw it together as I didn't see any mention of anything similar in any issues or on the roadmap and I wont be offended if it's rejected but it certainly would be helpful to have :)

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [x] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [x] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
