### PR TITLE
feat: add minimalist "__main__.py" to 'tagstudio' module

### DIFF
--- a/src/tagstudio/__main__.py
+++ b/src/tagstudio/__main__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# Copyright (C) 2024 Travis Abendshien (CyanVoxel).
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
+import sys
+
+from tagstudio.main import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Summary

Adding a minimalist `__main__.py` to `tagstudio` module to explicitly define the entry point, and so that TagStudio can be run directly from `python -m tagstudio`.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
