### PR TITLE
fix(nix/package): override PySide6 if later version is being used

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725024810,
-        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741173522,
-        "narHash": "sha256-k7VSqvv0r1r53nUI/IfPHCppkUAddeXn843YlAC5DR0=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d69ab0d71b22fa1ce3dbeff666e6deb4917db049",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,31 @@
             in
             rec {
               default = tagstudio;
-              tagstudio = pkgs.callPackage ./nix/package { inherit pillow-jxl-plugin vtf2img; };
+              tagstudio = pkgs.callPackage ./nix/package {
+                # HACK: Remove when PySide6 is bumped to 6.9.x.
+                # Sourced from https://github.com/NixOS/nixpkgs/commit/2f9c1ad5e19a6154d541f878774a9aacc27381b7.
+                pyside6 =
+                  if lib.versionAtLeast python3Packages.pyside6.version "6.9.0" then
+                    (python3Packages.pyside6.override {
+                      shiboken6 = python3Packages.shiboken6.overrideAttrs {
+                        version = "6.8.0.2";
+
+                        src = pkgs.fetchurl {
+                          url = "mirror://qt/official_releases/QtForPython/shiboken6/PySide6-6.8.0.2-src/pyside-setup-everywhere-src-6.8.0.tar.xz";
+                          hash = "sha256-Ghohmo8yfjQNJYJ1+tOp8mG48EvFcEF0fnPdatJStOE=";
+                        };
+
+                        sourceRoot = "pyside-setup-everywhere-src-6.8.0/sources/shiboken6";
+
+                        patches = [ ./nix/package/shiboken6-fix-include-qt-headers.patch ];
+                      };
+                    }).overrideAttrs
+                      { sourceRoot = "pyside-setup-everywhere-src-6.8.0/sources/pyside6"; }
+                  else
+                    python3Packages.pyside6;
+
+                inherit pillow-jxl-plugin vtf2img;
+              };
               tagstudio-jxl = tagstudio.override { withJXLSupport = true; };
 
               inherit pillow-jxl-plugin pyexiv2 vtf2img;

--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -8,6 +8,7 @@
   wrapGAppsHook,
 
   pillow-jxl-plugin,
+  pyside6,
   vtf2img,
 
   withJXLSupport ? false,

--- a/nix/package/shiboken6-fix-include-qt-headers.patch
+++ b/nix/package/shiboken6-fix-include-qt-headers.patch
@@ -1,0 +1,81 @@
+Sourced from https://github.com/NixOS/nixpkgs/blob/5ba0f1ea90b0afa2abc23a43edb63af51d932e6d/pkgs/development/python-modules/shiboken6/fix-include-qt-headers.patch.
+--- a/ApiExtractor/clangparser/compilersupport.cpp
++++ b/ApiExtractor/clangparser/compilersupport.cpp
+@@ -16,6 +16,7 @@
+ #include <QtCore/QStandardPaths>
+ #include <QtCore/QStringList>
+ #include <QtCore/QVersionNumber>
++#include <QtCore/QRegularExpression>
+
+ #include <clang-c/Index.h>
+
+@@ -341,6 +342,13 @@ QByteArrayList emulatedCompilerOptions()
+ {
+     QByteArrayList result;
+     HeaderPaths headerPaths;
++
++    bool isNixDebug = qgetenv("NIX_DEBUG").toInt() > 0;
++    // examples:
++    // /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-qtsensors-6.4.2-dev/include
++    // /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-qtbase-6.4.2-dev/include
++    QRegularExpression qtHeaderRegex(uR"(/[0-9a-z]{32}-qt[a-z0-9]+-)"_s);
++
+     switch (compiler()) {
+     case Compiler::Msvc:
+         result.append(QByteArrayLiteral("-fms-compatibility-version=19.26.28806"));
+@@ -352,9 +360,30 @@ QByteArrayList emulatedCompilerOptions()
+             appendClangBuiltinIncludes(&headerPaths);
+         break;
+     case Compiler::Clang:
+-        headerPaths.append(gppInternalIncludePaths(compilerFromCMake(u"clang++"_s)));
++    // fix: error: cannot jump from switch statement to this case label: case Compiler::Gpp
++    // note: jump bypasses variable initialization: const HeaderPaths clangPaths =
++    {
++        //headerPaths.append(gppInternalIncludePaths(compilerFromCMake(u"clang++"_s)));
++        // fix: qt.shiboken: x is specified in typesystem, but not defined. This could potentially lead to compilation errors.
++        // PySide requires that Qt headers are not -isystem
++        // https://bugreports.qt.io/browse/PYSIDE-787
++        const HeaderPaths clangPaths = gppInternalIncludePaths(compilerFromCMake(u"clang++"_qs));
++        for (const HeaderPath &h : clangPaths) {
++            auto match = qtHeaderRegex.match(QString::fromUtf8(h.path));
++            if (!match.hasMatch()) {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found non-qt header: " << h.path;
++                // add using -isystem
++                headerPaths.append(h);
++            } else {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found qt header: " << h.path;
++                headerPaths.append({h.path, HeaderType::Standard});
++            }
++        }
+         result.append(noStandardIncludeOption());
+         break;
++    }
+     case Compiler::Gpp:
+         if (needsClangBuiltinIncludes())
+             appendClangBuiltinIncludes(&headerPaths);
+@@ -363,8 +392,20 @@ QByteArrayList emulatedCompilerOptions()
+         // <type_traits> etc (g++ 11.3).
+         const HeaderPaths gppPaths = gppInternalIncludePaths(compilerFromCMake(u"g++"_qs));
+         for (const HeaderPath &h : gppPaths) {
+-            if (h.path.contains("c++") || h.path.contains("sysroot"))
++            // fix: qt.shiboken: x is specified in typesystem, but not defined. This could potentially lead to compilation errors.
++            // PySide requires that Qt headers are not -isystem
++            // https://bugreports.qt.io/browse/PYSIDE-787
++            auto match = qtHeaderRegex.match(QString::fromUtf8(h.path));
++            if (!match.hasMatch()) {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found non-qt header: " << h.path;
++                // add using -isystem
+                 headerPaths.append(h);
++            } else {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found qt header: " << h.path;
++                headerPaths.append({h.path, HeaderType::Standard});
++            }
+         }
+         break;
+     }
+--
+2.39.0


### PR DESCRIPTION
### Summary

Temporary solution for #915, long term should involve a proper upgrade on PySide6. This only applies the override if a later version of PySide6 is found. Again, this should only be temporary, my poor machine took a beating compiling this; does give some motivation for exploring Cachix further, however.

As far as I have been able to tell, Qt does not need any override treatment.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
