### PR TITLE
feat: datetime fields settings integration

### DIFF
--- a/src/tagstudio/core/global_settings.py
+++ b/src/tagstudio/core/global_settings.py
@@ -2,6 +2,7 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 import platform
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import override
@@ -49,6 +50,7 @@ class GlobalSettings(BaseModel):
     page_size: int = Field(default=100)
     show_filepath: ShowFilepathOption = Field(default=ShowFilepathOption.DEFAULT)
     theme: Theme = Field(default=Theme.SYSTEM)
+
     date_format: str = Field(default="%x")
     hour_format: bool = Field(default=True)
     zero_padding: bool = Field(default=True)
@@ -72,3 +74,21 @@ class GlobalSettings(BaseModel):
 
         with open(path, "w") as f:
             toml.dump(dict(self), f, encoder=TomlEnumEncoder())
+
+    def format_datetime(self, dt: datetime) -> str:
+        date_format = self.date_format
+        is_24h = self.hour_format
+        hour_format = "%H:%M:%S" if is_24h else "%I:%M:%S %p"
+        zero_padding = self.zero_padding
+        zero_padding_symbol = ""
+
+        if not zero_padding:
+            zero_padding_symbol = "#" if platform.system() == "Windows" else "-"
+            date_format = date_format.replace("%d", f"%{zero_padding_symbol}d").replace(
+                "%m", f"%{zero_padding_symbol}m"
+            )
+            hour_format = hour_format.replace("%H", f"%{zero_padding_symbol}H").replace(
+                "%I", f"%{zero_padding_symbol}I"
+            )
+
+        return datetime.strftime(dt, f"{date_format}, {hour_format}")

--- a/src/tagstudio/qt/widgets/preview/field_containers.py
+++ b/src/tagstudio/qt/widgets/preview/field_containers.py
@@ -392,8 +392,9 @@ class FieldContainers(QWidget):
                 container.set_inline(False)
                 try:
                     title = f"{field.type.name} (Date)"
-                    # TODO: Localize this and/or add preferences.
-                    text = dt.strptime(field.value or "", "%Y-%m-%d %H:%M:%S").strftime("%D - %r")
+                    text = self.driver.settings.format_datetime(
+                        dt.strptime(field.value or "", "%Y-%m-%d %H:%M:%S")
+                    )
                 except ValueError:
                     title = f"{field.type.name} (Date) (Unknown Format)"
                     text = str(field.value)


### PR DESCRIPTION
### Summary
- move datetime formatting according to the current settings to the global settings class
- integration date format settings with datetime field formatting

### Tasks Completed
-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable
