### PR TITLE
fix: proper error on unterminated quoted string

### DIFF
--- a/src/tagstudio/core/library/alchemy/visitors.py
+++ b/src/tagstudio/core/library/alchemy/visitors.py
@@ -147,7 +147,7 @@ class SQLBoolExpressionBuilder(BaseVisitor[ColumnElement[bool]]):
         # raise exception if Constraint stays unhandled
         raise NotImplementedError("This type of constraint is not implemented yet")
 
-    def visit_property(self, node: Property) -> None:
+    def visit_property(self, node: Property) -> ColumnElement[bool]:
         raise NotImplementedError("This should never be reached!")
 
     def visit_not(self, node: Not) -> ColumnElement[bool]:

--- a/src/tagstudio/core/query_lang/ast.py
+++ b/src/tagstudio/core/query_lang/ast.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 
 
 class ConstraintType(Enum):
@@ -12,7 +12,7 @@ class ConstraintType(Enum):
     Special = 5
 
     @staticmethod
-    def from_string(text: str) -> "ConstraintType":
+    def from_string(text: str) -> Union["ConstraintType", None]:
         return {
             "tag": ConstraintType.Tag,
             "tag_id": ConstraintType.TagID,
@@ -24,7 +24,7 @@ class ConstraintType(Enum):
 
 
 class AST:
-    parent: "AST" = None
+    parent: Union["AST", None] = None
 
     def __str__(self):
         class_name = self.__class__.__name__


### PR DESCRIPTION
### Summary

The tokenizer now returns a ParsingError when encountering an unterminated quoted string (e.g. `"asd`). This way the proper handling for ParsingErrors kicks in.
(Also includes minor refactors to fix warnings in the associated files)

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable
