### PR TITLE
fix: creating new tag now refreshes the menu using the current search…

### DIFF
--- a/src/tagstudio/qt/modals/tag_database.py
+++ b/src/tagstudio/qt/modals/tag_database.py
@@ -51,7 +51,7 @@ class TagDatabasePanel(TagSearchPanel):
                     alias_ids=panel.alias_ids,
                 ),
                 self.modal.hide(),
-                self.update_tags(),
+                self.update_tags(self.search_field.text()),
             )
         )
         self.modal.show()


### PR DESCRIPTION
### Summary

Before when opening the Tag Manager, searching for a tag, and then creating a new tag the search results would be refreshed without taking account for the search text (Meaning the search results would be reset). Now instead it will refresh the search results with the search text.

Closes #932 

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
