### PR TITLE
fix: add parent tags to `folders_to_tags` macro and start tagging at root folder

### DIFF
--- a/src/tagstudio/qt/modals/folders_to_tags.py
+++ b/src/tagstudio/qt/modals/folders_to_tags.py
@@ -44,14 +44,14 @@ class BranchData:
 
 def add_folders_to_tree(library: Library, tree: BranchData, items: tuple[str, ...]) -> BranchData:
     branch = tree
+    parent_tag = None
     for folder in items:
         if folder not in branch.dirs:
-            # TODO: Reimplement parent tags
-            new_tag = Tag(name=folder)
+            new_tag = Tag(name=folder, parent_tags=({parent_tag} if parent_tag else None))
             library.add_tag(new_tag)
             branch.dirs[folder] = BranchData(tag=new_tag)
-            branch.tag = new_tag
         branch = branch.dirs[folder]
+        parent_tag = branch.tag
     return branch
 
 
@@ -71,7 +71,7 @@ def folders_to_tags(library: Library):
         add_tag_to_tree(reversed_tag)
 
     for entry in library.get_entries():
-        folders = entry.path.parts[1:-1]
+        folders = entry.path.parts[0:-1]
         if not folders:
             continue
 
@@ -124,7 +124,7 @@ def generate_preview_data(library: Library) -> BranchData:
         add_tag_to_tree(reversed_tag)
 
     for entry in library.get_entries():
-        folders = entry.path.parts[1:-1]
+        folders = entry.path.parts[0:-1]
         if not folders:
             continue
 

--- a/tests/qt/__snapshots__/test_folders_to_tags.ambr
+++ b/tests/qt/__snapshots__/test_folders_to_tags.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_generate_preview_data
-  BranchData(dirs={'two': BranchData(dirs={}, files=['bar.md'], tag=<Tag ID: None Name: two>)}, files=[], tag=None)
+  BranchData(dirs={'one': BranchData(dirs={'two': BranchData(dirs={}, files=['bar.md'], tag=<Tag ID: None Name: two>)}, files=[], tag=<Tag ID: None Name: one>)}, files=[], tag=None)
 # ---


### PR DESCRIPTION
### Summary

2 main things are changed for the `folders_to_tags` macro.
1. Tagging starts with folders in the root of the TagStudio directory (i.e. on the same level as .TagStudio). 
2. Parent tags are assigned.

Tested on my library of \~850 images, nested up to 3 layers of folders deep.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
