### PR TITLE
feat: Press enter when adding fields

### DIFF
--- a/src/tagstudio/qt/modals/add_field.py
+++ b/src/tagstudio/qt/modals/add_field.py
@@ -87,6 +87,8 @@ class AddFieldModal(QWidget):
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:  # noqa N802
         if event.key() == QtCore.Qt.Key.Key_Escape:
             self.cancel_button.click()
+        elif event.key() in (QtCore.Qt.Key.Key_Enter, QtCore.Qt.Key.Key_Return):
+            self.save_button.click()
         else:  # Other key presses
             pass
         return super().keyPressEvent(event)


### PR DESCRIPTION
### Summary

As requested in https://github.com/TagStudioDev/TagStudio/issues/463.

I can only test on macOS, where the Return key is sent. I assume on other platforms it would Enter. This covers both, but needs to tested on Linux/Windows. 


<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
