### PR TITLE
Type fixes to folders_to_tags.py, collage_icon.py and item_thumb.py

### DIFF
--- a/src/tagstudio/qt/widgets/collage_icon.py
+++ b/src/tagstudio/qt/widgets/collage_icon.py
@@ -29,14 +29,16 @@ class CollageIconRenderer(QObject):
 
     def render(
         self,
-        entry_id,
+        entry_id: int,
         size: tuple[int, int],
-        data_tint_mode,
-        data_only_mode,
-        keep_aspect,
+        data_tint_mode: bool,
+        data_only_mode: bool,
+        keep_aspect: bool,
     ):
         entry = self.lib.get_entry(entry_id)
-        filepath = self.lib.library_dir / entry.path
+        lib_dir = self.lib.library_dir
+        assert lib_dir is not None and entry is not None
+        filepath = lib_dir / entry.path
         color: str = ""
 
         try:
@@ -57,7 +59,7 @@ class CollageIconRenderer(QObject):
                 ext: str = filepath.suffix.lower()
                 if MediaCategories.is_ext_in_category(ext, MediaCategories.IMAGE_TYPES):
                     try:
-                        with Image.open(str(self.lib.library_dir / entry.path)) as pic:
+                        with Image.open(filepath) as pic:
                             if keep_aspect:
                                 pic.thumbnail(size)
                             else:

--- a/src/tagstudio/qt/widgets/item_thumb.py
+++ b/src/tagstudio/qt/widgets/item_thumb.py
@@ -8,13 +8,13 @@ import typing
 from enum import Enum
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 from warnings import catch_warnings
 
 import structlog
 from PIL import Image, ImageQt
 from PySide6.QtCore import QEvent, QMimeData, QSize, Qt, QUrl
-from PySide6.QtGui import QAction, QDrag, QEnterEvent, QPixmap
+from PySide6.QtGui import QAction, QDrag, QEnterEvent, QMouseEvent, QPixmap
 from PySide6.QtWidgets import (
     QBoxLayout,
     QCheckBox,
@@ -403,7 +403,7 @@ class ItemThumb(FlowWidget):
                 self.ext_badge.setHidden(True)
                 self.count_badge.setHidden(True)
 
-    def set_filename_text(self, filename: Path | None):
+    def set_filename_text(self, filename: Path):
         self.set_item_path(filename)
         self.file_label.setText(str(filename.name))
 
@@ -437,22 +437,21 @@ class ItemThumb(FlowWidget):
             size (QSize): The new thumbnail size to set.
         """
         if timestamp > ItemThumb.update_cutoff:
-            self.thumb_size = size.toTuple()  # type: ignore
+            self.thumb_size = size.width(), size.height()
             self.thumb_button.setIconSize(size)
             self.thumb_button.setMinimumSize(size)
             self.thumb_button.setMaximumSize(size)
 
-    def update_clickable(self, clickable: typing.Callable):
+    def update_clickable(self, clickable: typing.Callable[[], None]):
         """Updates attributes of a thumbnail element."""
-        if clickable:
-            with catch_warnings(record=True):
-                self.thumb_button.clicked.disconnect()
-            self.thumb_button.clicked.connect(clickable)
+        with catch_warnings(record=True):
+            self.thumb_button.clicked.disconnect()
+        self.thumb_button.clicked.connect(clickable)
 
     def set_item_id(self, item_id: int):
         self.item_id = item_id
 
-    def set_item_path(self, path: Path | str | None):
+    def set_item_path(self, path: Path | str):
         """Set the absolute filepath for the item. Used for locating on disk."""
         self.opener.set_filepath(path)
 
@@ -474,11 +473,13 @@ class ItemThumb(FlowWidget):
                 is_hidden = not (show or self.badge_active[badge_type])
                 badge.setHidden(is_hidden)
 
-    def enterEvent(self, event: QEnterEvent) -> None:  # noqa: N802
+    @override
+    def enterEvent(self, event: QEnterEvent) -> None:
         self.show_check_badges(show=True)
         return super().enterEvent(event)
 
-    def leaveEvent(self, event: QEvent) -> None:  # noqa: N802
+    @override
+    def leaveEvent(self, event: QEvent) -> None:
         self.show_check_badges(show=False)
         return super().leaveEvent(event)
 
@@ -490,6 +491,7 @@ class ItemThumb(FlowWidget):
         toggle_value = self.badges[badge_type].isChecked()
         self.badge_active[badge_type] = toggle_value
         badge_values: dict[BadgeType, bool] = {badge_type: toggle_value}
+        assert self.item_id is not None
         self.driver.update_badges(badge_values, self.item_id)
 
     def toggle_item_tag(
@@ -506,7 +508,8 @@ class ItemThumb(FlowWidget):
             else:
                 pass
 
-    def mouseMoveEvent(self, event):  # noqa: N802
+    @override
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
         if event.buttons() is not Qt.MouseButton.LeftButton:
             return
 
@@ -521,6 +524,7 @@ class ItemThumb(FlowWidget):
             if not entry:
                 continue
 
+            assert self.lib.library_dir is not None
             url = QUrl.fromLocalFile(Path(self.lib.library_dir) / entry.path)
             paths.append(url)
 


### PR DESCRIPTION
### Summary
few type annotation fixes
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
