### PR TITLE
feat: click tags in tag library to edit

### DIFF
--- a/src/tagstudio/qt/modals/tag_search.py
+++ b/src/tagstudio/qt/modals/tag_search.py
@@ -264,8 +264,7 @@ class TagSearchPanel(PanelWidget):
                 self.scroll_layout.addWidget(new_tw)
 
         # Assign the tag to the widget at the given index.
-        tag_widget = self.scroll_layout.itemAt(index).widget()
-        assert isinstance(tag_widget, TagWidget)
+        assert isinstance(tag_widget := self.scroll_layout.itemAt(index).widget(), TagWidget)
         tag_widget.set_tag(tag)
 
         # Set tag widget viability and potentially return early


### PR DESCRIPTION
### Summary

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

After discussion in https://github.com/TagStudioDev/TagStudio/issues/426, it's been agreed a single left-click of a tag in the tab library should open the edit modal.

There is some discussion of a larger refactor, and while I think there is room for improvement with `TagWidget` and how it's used, this is more of a quick fix adding the functionality as it is currently intended.

I also removed all type errors and warnings in the file, though my techniques for doing so may not be the best. Would be happy to hear suggestions for improvement. These changes are all in the second commit if you'd like to see them (or the functional changes) in isolation.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
