### PR TITLE
Add Nix path to ffmpeg locations on macOS

### DIFF
--- a/src/tagstudio/qt/helpers/vendored/ffmpeg.py
+++ b/src/tagstudio/qt/helpers/vendored/ffmpeg.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import json
+import os
 import platform
 import subprocess
 from shutil import which
@@ -20,7 +21,7 @@ FFMPEG_MACOS_LOCATIONS: list[str] = [
     "",
     "/opt/homebrew/bin/",
     "/usr/local/bin/",
-    f"/etc/profiles/per-user/{user}/bin"
+    f"/etc/profiles/per-user/{user}/bin",
 ]
 
 


### PR DESCRIPTION
### Summary

`ffmpeg` was installed on my system using Nix (package manager, not NixOS) but undetected by TagStudio.
I added the path pointing to where Nix installs these binaries to the list of mac locations.

### Tasks Completed

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
