### PR TITLE
fix: preview thumbnails don't scale as large as they could

### DIFF
--- a/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
+++ b/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
@@ -220,10 +220,12 @@ class PreviewThumbView(QWidget):
             self.__preview_gif.hide()
 
     def __render_thumb(self, filepath: Path) -> None:
+        screen_size = self.screen().size()
+        base_size = (screen_size.width(), screen_size.height())
         self.__thumb_renderer.render(
             time.time(),
             filepath,
-            (512, 512),
+            base_size,
             self.devicePixelRatio(),
             update_on_ratio_change=True,
         )

--- a/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
+++ b/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
@@ -35,6 +35,9 @@ class PreviewThumbView(QWidget):
     __img_button_size: tuple[int, int]
     __image_ratio: float
 
+    __filepath: Path | None
+    __rendered_res: tuple[int, int]
+
     def __init__(self, library: Library, driver: "QtDriver") -> None:
         super().__init__()
 


### PR DESCRIPTION
### Summary
Due to a hardcoded maximum size for preview thumbnails, preview thumbnails don't scale to fit all the space available to the PreviewThumb Component. Since a limit is needed to avoid the performance hit that massive images would incur, I have change the limit to be the screen size since the component shouldn't be bigger than that anyways.

### Tasks Completed
-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable
