### PR TITLE
fix(library): get_tag_by_name

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -858,7 +858,7 @@ class Library:
     def search_library(
         self,
         search: BrowsingState,
-        page_size: int,
+        page_size: int | None,
     ) -> SearchResult:
         """Filter library by search query.
 
@@ -903,7 +903,8 @@ class Library:
                     sort_on = func.lower(Entry.path)
 
             statement = statement.order_by(asc(sort_on) if search.ascending else desc(sort_on))
-            statement = statement.limit(page_size).offset(search.page_index * page_size)
+            if page_size is not None:
+                statement = statement.limit(page_size).offset(search.page_index * page_size)
 
             logger.info(
                 "searching library",
@@ -1425,12 +1426,14 @@ class Library:
             )
             tag = session.scalar(tags_query.where(Tag.id == tag_id))
 
-            session.expunge(tag)
-            for parent in tag.parent_tags:
-                session.expunge(parent)
+            if tag is not None:
+                session.expunge(tag)
 
-            for alias in tag.aliases:
-                session.expunge(alias)
+                for parent in tag.parent_tags:
+                    session.expunge(parent)
+
+                for alias in tag.aliases:
+                    session.expunge(alias)
 
         return tag
 
@@ -1438,10 +1441,23 @@ class Library:
         with Session(self.engine) as session:
             statement = (
                 select(Tag)
+                .options(selectinload(Tag.parent_tags), selectinload(Tag.aliases))
                 .outerjoin(TagAlias)
                 .where(or_(Tag.name == tag_name, TagAlias.name == tag_name))
             )
-            return session.scalar(statement)
+
+            tag = session.scalar(statement)
+
+            if tag is not None:
+                session.expunge(tag)
+
+                for parent in tag.parent_tags:
+                    session.expunge(parent)
+
+                for alias in tag.aliases:
+                    session.expunge(alias)
+
+        return tag
 
     def get_alias(self, tag_id: int, alias_id: int) -> TagAlias | None:
         with Session(self.engine) as session:


### PR DESCRIPTION
### Summary
The `get_tag_by_name` method was broken. I also fixed a warning in `get_tag` and extended `search_library` to support searching without a page size (just internally; i.e. no UI changes).

(This is kind of just a mix of stuff I came across. Since this isn't a lot changes I figured splitting into multiple PRs would be unnecessary work)

### Tasks Completed

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable
