### PR TITLE
fix(ui): hide empty ProgressWidget cancel button

### DIFF
--- a/src/tagstudio/qt/widgets/progress.py
+++ b/src/tagstudio/qt/widgets/progress.py
@@ -29,7 +29,7 @@ class ProgressWidget(QWidget):
         self.pb = QProgressDialog(
             labelText=label_text,
             minimum=minimum,
-            cancelButtonText=cancel_button_text or "",
+            cancelButtonText=cancel_button_text,  # pyright: ignore[reportArgumentType]
             maximum=maximum,
         )
         self.root.addWidget(self.pb)


### PR DESCRIPTION
### Summary
Correctly passes `None` value to the QProgressDialog class's `cancelButtonText` parameter, which it uses to hide its "cancel" button instead of showing an empty one. Pyside's type hints for this method appear to incorrectly omit this functionality. This fixes empty cancel buttons from appearing on any `ProgressWidget` instances.

Fixes #1004

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
