### PR TITLE
refactor: replace remaining instances of logging with structlog

### DIFF
--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -3,13 +3,14 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 
-import logging
 import mimetypes
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
-logging.basicConfig(format="%(message)s", level=logging.INFO)
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 FILETYPE_EQUIVALENTS = [
     set(["aif", "aiff", "aifc"]),

--- a/src/tagstudio/main.py
+++ b/src/tagstudio/main.py
@@ -7,16 +7,13 @@
 """TagStudio launcher."""
 
 import argparse
-import logging
 import traceback
 
 import structlog
 
 from tagstudio.qt.ts_qt import QtDriver
 
-structlog.configure(
-    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
-)
+logger = structlog.get_logger(__name__)
 
 
 def main():
@@ -67,7 +64,7 @@ def main():
         driver.start()
     except Exception:
         traceback.print_exc()
-        logging.info(f"\nTagStudio Frontend ({ui_name}) Crashed! Press Enter to Continue...")
+        logger.info(f"\nTagStudio Frontend ({ui_name}) Crashed! Press Enter to Continue...")
         input()
 
 

--- a/src/tagstudio/qt/helpers/file_deleter.py
+++ b/src/tagstudio/qt/helpers/file_deleter.py
@@ -3,12 +3,12 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 
-import logging
 from pathlib import Path
 
+import structlog
 from send2trash import send2trash
 
-logging.basicConfig(format="%(message)s", level=logging.INFO)
+logger = structlog.get_logger(__name__)
 
 
 def delete_file(path: str | Path) -> bool:
@@ -19,13 +19,13 @@ def delete_file(path: str | Path) -> bool:
     """
     _path = Path(path)
     try:
-        logging.info(f"[delete_file] Sending to Trash: {_path}")
+        logger.info(f"[delete_file] Sending to Trash: {_path}")
         send2trash(_path)
         return True
     except PermissionError as e:
-        logging.error(f"[delete_file][ERROR] PermissionError: {e}")
+        logger.error(f"[delete_file][ERROR] PermissionError: {e}")
     except FileNotFoundError:
-        logging.error(f"[delete_file][ERROR] File Not Found: {_path}")
+        logger.error(f"[delete_file][ERROR] File Not Found: {_path}")
     except Exception as e:
-        logging.error(e)
+        logger.error(e)
     return False

--- a/src/tagstudio/qt/widgets/landing.py
+++ b/src/tagstudio/qt/widgets/landing.py
@@ -3,11 +3,11 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 
-import logging
 import sys
 import typing
 from pathlib import Path
 
+import structlog
 from PIL import Image, ImageQt
 from PySide6.QtCore import QEasingCurve, QPoint, QPropertyAnimation, Qt
 from PySide6.QtGui import QPixmap
@@ -21,7 +21,7 @@ from tagstudio.qt.widgets.clickable_label import ClickableLabel
 if typing.TYPE_CHECKING:
     from tagstudio.qt.ts_qt import QtDriver
 
-logging.basicConfig(format="%(message)s", level=logging.INFO)
+logger = structlog.get_logger(__name__)
 
 
 class LandingWidget(QWidget):
@@ -153,7 +153,7 @@ class LandingWidget(QWidget):
 
     # def animate_status(self):
     #     # if self.status_label.y() > 50:
-    #     logging.info(f"{self.status_label.pos()}")
+    #     logger.info(f"{self.status_label.pos()}")
     #     self.status_pos_anim.setStartValue(
     #         QPoint(self.status_label.x(), self.status_label.y() + 50)
     #     )


### PR DESCRIPTION
### Summary

This PR replaces the remaining instances of the old logging system (`logging` module) with `stuctlog` to bring them in line with the rest of the program.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
