### PR TITLE
fix: use srctools instead of vtf2img to render vtf files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,20 +16,20 @@ dependencies = [
     "mutagen~=1.47",
     "numpy~=2.2",
     "opencv_python~=4.11",
-    "Pillow~=11.2",
     "pillow-heif~=0.22",
     "pillow-jxl-plugin~=1.3",
+    "Pillow~=11.2",
     "pydantic~=2.10",
     "pydub~=0.25",
     "PySide6==6.8.0.*",
     "rawpy~=0.24",
     "Send2Trash~=1.8",
     "SQLAlchemy~=2.0",
+    "srctools~=2.6",
     "structlog~=25.3",
     "toml~=0.10",
     "typing_extensions~=4.13",
     "ujson~=5.10",
-    "vtf2img~=0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Summary
This PR replaces the [vtf2img](https://github.com/julienc91/vtf2img) library dependency with [srctools](https://github.com/TeamSpen210/srctools) in order to render [VTF](https://srctools.readthedocs.io/en/stable/modules/vtf.html) files.

Fixes #980.

vtf2img:
<img width="1315" height="760" alt="Image" src="https://github.com/user-attachments/assets/565001ed-8342-4c8c-98b5-0578cacde6f7" />

srctools:
<img width="1764" height="855" alt="Image" src="https://github.com/user-attachments/assets/fbfd2606-39f0-4f45-b855-a4d637e984b5" />

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
