### PR TITLE
ui: tweak media player style and behavior

### DIFF
--- a/src/tagstudio/qt/helpers/qslider_wrapper.py
+++ b/src/tagstudio/qt/helpers/qslider_wrapper.py
@@ -4,9 +4,9 @@
 
 from typing import override
 
+import structlog
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QSlider, QStyle, QStyleOptionSlider
-import structlog
 
 logger = structlog.get_logger(__name__)
 

--- a/src/tagstudio/qt/helpers/qslider_wrapper.py
+++ b/src/tagstudio/qt/helpers/qslider_wrapper.py
@@ -6,6 +6,9 @@ from typing import override
 
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QSlider, QStyle, QStyleOptionSlider
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 
 class QClickSlider(QSlider):
@@ -35,9 +38,14 @@ class QClickSlider(QSlider):
         was_slider_clicked = handle_rect.contains(int(ev.position().x()), int(ev.position().y()))
 
         if not was_slider_clicked:
+            self.setSliderDown(True)
             self.setValue(
                 QStyle.sliderValueFromPosition(self.minimum(), self.maximum(), ev.x(), self.width())
             )
-            self.mouse_pressed = True
 
         super().mousePressEvent(ev)
+
+    @override
+    def mouseReleaseEvent(self, ev: QMouseEvent) -> None:
+        self.setSliderDown(False)
+        return super().mouseReleaseEvent(ev)

--- a/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
+++ b/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
@@ -95,8 +95,6 @@ class PreviewThumbView(QWidget):
             self.__media_player_video_changed_callback
         )
 
-        self.__mp_max_size = QSize(*self.__img_button_size)
-
         self.__media_player_page = QWidget()
         self.__stacked_page_setup(self.__media_player_page, self.__media_player)
 
@@ -131,7 +129,6 @@ class PreviewThumbView(QWidget):
         self, _timestamp: float, img: QPixmap, _size: QSize, _path: Path
     ) -> None:
         self.__button_wrapper.setIcon(img)
-        self.__mp_max_size = img.size()
 
     def __thumb_renderer_updated_ratio_callback(self, ratio: float) -> None:
         self.__image_ratio = ratio
@@ -174,25 +171,8 @@ class PreviewThumbView(QWidget):
         self.__preview_gif.setMaximumSize(adj_size)
         self.__preview_gif.setMinimumSize(adj_size)
 
-        if not self.__media_player.player.hasVideo():
-            # ensure we do not exceed the thumbnail size
-            mp_width = (
-                adj_size.width()
-                if adj_size.width() < self.__mp_max_size.width()
-                else self.__mp_max_size.width()
-            )
-            mp_height = (
-                adj_size.height()
-                if adj_size.height() < self.__mp_max_size.height()
-                else self.__mp_max_size.height()
-            )
-            mp_size = QSize(mp_width, mp_height)
-            self.__media_player.setMinimumSize(mp_size)
-            self.__media_player.setMaximumSize(mp_size)
-        else:
-            # have video, so just resize as normal
-            self.__media_player.setMaximumSize(adj_size)
-            self.__media_player.setMinimumSize(adj_size)
+        self.__media_player.setMaximumSize(adj_size)
+        self.__media_player.setMinimumSize(adj_size)
 
         proxy_style = RoundedPixmapStyle(radius=8)
         self.__preview_gif.setStyle(proxy_style)

--- a/src/tagstudio/qt/widgets/media_player.py
+++ b/src/tagstudio/qt/widgets/media_player.py
@@ -15,6 +15,7 @@ from PySide6.QtGui import (
     QBitmap,
     QBrush,
     QColor,
+    QLinearGradient,
     QMouseEvent,
     QPainter,
     QPen,
@@ -120,7 +121,7 @@ class MediaPlayer(QGraphicsView):
             0,
             0,
             self.size().width(),
-            self.size().height(),
+            12,
             QPen(QColor(0, 0, 0, 0)),
             QBrush(QColor(0, 0, 0, 0)),
         )
@@ -284,12 +285,15 @@ class MediaPlayer(QGraphicsView):
         Args:
             opacity(int): The opacity value, from 0-255.
         """
-        self.tint.setBrush(QBrush(QColor(0, 0, 0, opacity)))
+        gradient = QLinearGradient(0, 0, 0, self.height())
+        gradient.setColorAt(0.8, QColor(0, 0, 0, 0))
+        gradient.setColorAt(1, QColor(0, 0, 0, opacity))
+        self.tint.setBrush(QBrush(gradient))
 
     @override
     def underMouse(self) -> bool:  # noqa: N802
-        self.animation.setStartValue(self.tint.brush().color().alpha())
-        self.animation.setEndValue(150)
+        self.animation.setStartValue(0)
+        self.animation.setEndValue(160)
         self.animation.setDuration(125)
         self.animation.start()
         self.timeline_slider.show()
@@ -301,7 +305,7 @@ class MediaPlayer(QGraphicsView):
 
     @override
     def releaseMouse(self) -> None:  # noqa: N802
-        self.animation.setStartValue(self.tint.brush().color().alpha())
+        self.animation.setStartValue(160)
         self.animation.setEndValue(0)
         self.animation.setDuration(125)
         self.animation.start()

--- a/src/tagstudio/qt/widgets/media_player.py
+++ b/src/tagstudio/qt/widgets/media_player.py
@@ -67,6 +67,9 @@ class MediaPlayer(QGraphicsView):
             QSlider::add-page:horizontal {
                 background: #65000000;
                 border-radius: 3px;
+                border-style: solid;
+                border-width: 1px;
+                border-color: #65444444;
             }
 
             QSlider::sub-page:horizontal {

--- a/src/tagstudio/qt/widgets/media_player.py
+++ b/src/tagstudio/qt/widgets/media_player.py
@@ -433,6 +433,10 @@ class MediaPlayer(QGraphicsView):
         self.mute_unmute.load(icon)
 
     def slider_value_changed(self, value: int) -> None:
+        if self.timeline_slider.isSliderDown():
+            self.player.setPosition(value)
+            self.player.setPlaybackRate(0.0001)
+
         current = self.format_time(value)
         duration = self.format_time(self.player.duration())
         self.position_label.setText(f"{current} / {duration}")
@@ -440,6 +444,7 @@ class MediaPlayer(QGraphicsView):
     def slider_released(self) -> None:
         was_playing = self.player.isPlaying()
         self.player.setPosition(self.timeline_slider.value())
+        self.player.setPlaybackRate(1)  # Restore from slider_value_changed()
 
         # Setting position causes the player to start playing again.
         # We should reset back to initial state.


### PR DESCRIPTION
### Summary

This PR makes a few design and QoL tweaks to the media player:
- Simplified layout and style
- Black hover overlay replaced with gradient behind controls
- Added deadzone around player controls where clicking won't pause/unpause
- Added more generous margins between controls
- Fixed clicking to jump far into unbuffered media
- Misc code cleanup

Known (preexisting) issue: Clicking to jump to a presumably unbuffered section of media does now allow for continuous dragging until clicked again.

Before:
<img width="288" height="217" alt="image" src="https://github.com/user-attachments/assets/f4487e40-5e01-4c73-8105-c912f6e63bf1" />

After:
<img width="292" height="213" alt="image" src="https://github.com/user-attachments/assets/3f9e5c19-2e3b-442b-8030-9ca888cb4d5c" />

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
