### PR TITLE
fix: folders with names of unlinked entries are linked

### DIFF
--- a/src/tagstudio/core/utils/missing_files.py
+++ b/src/tagstudio/core/utils/missing_files.py
@@ -41,6 +41,7 @@ class MissingRegistry:
 
         Works if files were just moved to different subfolders and don't have duplicate names.
         """
+
         assert self.library.library_dir
         matches: list[Path] = []
 
@@ -50,6 +51,8 @@ class MissingRegistry:
             flags=PATH_GLOB_FLAGS,
             exclude=ignore_patterns,
         ):
+            if path.is_dir():
+                continue
             if path.name == match_entry.path.name:
                 new_path = Path(path).relative_to(self.library.library_dir)
                 matches.append(new_path)

--- a/src/tagstudio/core/utils/missing_files.py
+++ b/src/tagstudio/core/utils/missing_files.py
@@ -41,7 +41,6 @@ class MissingRegistry:
 
         Works if files were just moved to different subfolders and don't have duplicate names.
         """
-
         assert self.library.library_dir
         matches: list[Path] = []
 

--- a/src/tagstudio/qt/controller/widgets/preview/preview_thumb_controller.py
+++ b/src/tagstudio/qt/controller/widgets/preview/preview_thumb_controller.py
@@ -39,7 +39,9 @@ class PreviewThumb(PreviewThumbView):
         stats = FileAttributeData()
         ext = filepath.suffix.lower()
 
-        if MediaCategories.IMAGE_RAW_TYPES.contains(ext, mime_fallback=True):
+        if filepath.is_dir():
+            pass
+        elif MediaCategories.IMAGE_RAW_TYPES.contains(ext, mime_fallback=True):
             try:
                 with rawpy.imread(str(filepath)) as raw:
                     rgb = raw.postprocess()

--- a/src/tagstudio/qt/helpers/file_deleter.py
+++ b/src/tagstudio/qt/helpers/file_deleter.py
@@ -21,6 +21,8 @@ def delete_file(path: str | Path) -> bool:
     """
     _path = Path(path)
     try:
+        if _path.is_dir():
+            return False
         logger.info(f"[delete_file] Sending to Trash: {_path}")
         send2trash(_path)
         return True

--- a/src/tagstudio/qt/helpers/file_opener.py
+++ b/src/tagstudio/qt/helpers/file_opener.py
@@ -109,7 +109,8 @@ class FileOpenerHelper:
 
     def open_file(self):
         """Open the file in the default application."""
-        open_file(self.filepath)
+        if Path(self.filepath).is_file():
+            open_file(self.filepath)
 
     def open_explorer(self):
         """Open the file in the default file explorer."""

--- a/src/tagstudio/qt/helpers/file_opener.py
+++ b/src/tagstudio/qt/helpers/file_opener.py
@@ -113,7 +113,8 @@ class FileOpenerHelper:
 
     def open_explorer(self):
         """Open the file in the default file explorer."""
-        open_file(self.filepath, file_manager=True)
+        if Path(self.filepath).is_file():
+            open_file(self.filepath, file_manager=True)
 
 
 class FileOpenerLabel(QLabel):

--- a/src/tagstudio/qt/widgets/preview/file_attributes.py
+++ b/src/tagstudio/qt/widgets/preview/file_attributes.py
@@ -193,7 +193,7 @@ class FileAttributes(QWidget):
 
             # Attempt to populate the stat variables
             ext_display = ext.upper()[1:] or filepath.stem.upper()
-            if filepath:
+            if filepath and filepath.is_file():
                 try:
                     file_size = format_size(filepath.stat().st_size)
 

--- a/src/tagstudio/qt/widgets/thumb_renderer.py
+++ b/src/tagstudio/qt/widgets/thumb_renderer.py
@@ -1454,7 +1454,7 @@ class ThumbRenderer(QObject):
                 if not image:
                     image = (
                         render_unlinked((adj_size, adj_size), pixel_ratio)
-                        if not filepath.exists()
+                        if not filepath.exists() or filepath.is_dir()
                         else render_default((adj_size, adj_size), pixel_ratio)
                     )
                     render_mask_and_edge = False
@@ -1498,7 +1498,7 @@ class ThumbRenderer(QObject):
             if not image:
                 image = (
                     render_unlinked((512, 512), 2)
-                    if not filepath.exists()
+                    if not filepath.exists() or filepath.is_dir()
                     else render_default((512, 512), 2)
                 )
                 render_mask_and_edge = False

--- a/src/tagstudio/qt/widgets/thumb_renderer.py
+++ b/src/tagstudio/qt/widgets/thumb_renderer.py
@@ -1560,7 +1560,7 @@ class ThumbRenderer(QObject):
         _filepath: Path = Path(filepath)
         savable_media_type: bool = True
 
-        if _filepath:
+        if _filepath and _filepath.is_file():
             try:
                 ext: str = _filepath.suffix.lower() if _filepath.suffix else _filepath.stem.lower()
                 # Images =======================================================


### PR DESCRIPTION
### Summary

Fixes #989 

When a unlinked entry has a folder with the same name:
- It can’t be deleted.
- It can’t be opened or revealed
- The thumbnail will show as unlinked
- File stats are hidden.
- Considered as unlinked in the Fix Unlinked Entries menu (which was the behaviour even before this PR)

Let me know if there is any changes you would like me to make :)

### Tasks Completed
-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [x] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
