### PR TITLE
fix: add tags to selected entries in bulk not individually

### DIFF
--- a/src/tagstudio/qt/widgets/preview/field_containers.py
+++ b/src/tagstudio/qt/widgets/preview/field_containers.py
@@ -285,11 +285,10 @@ class FieldContainers(QWidget):
             selected=self.driver.selected,
             tags=tags,
         )
-        for entry_id in self.driver.selected:
-            self.lib.add_tags_to_entries(
-                entry_id,
-                tag_ids=tags,
-            )
+        self.lib.add_tags_to_entries(
+            self.driver.selected,
+            tag_ids=tags,
+        )
         self.emit_badge_signals(tags, emit_on_absent=False)
 
     def write_container(self, index: int, field: BaseField, is_mixed: bool = False):


### PR DESCRIPTION
### Summary
When adding tags to selected entries we previously added the tag(s) to each entry individually; we now make use of the bulk add method correctly leading to a massive performance increase when adding to a large number of tags (adding a tag to 15k selected entries took ca. 1s for me on a HDD)

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
