### PR TITLE
fix(search): pass current `BrowsingState` to `from_tag_id()`

### DIFF
--- a/src/tagstudio/core/library/alchemy/enums.py
+++ b/src/tagstudio/core/library/alchemy/enums.py
@@ -97,7 +97,24 @@ class BrowsingState:
         return cls(query=search_query)
 
     @classmethod
-    def from_tag_id(cls, tag_id: int | str) -> "BrowsingState":
+    def from_tag_id(
+        cls, tag_id: int | str, state: "BrowsingState | None" = None
+    ) -> "BrowsingState":
+        """Create and return a BrowsingState object given a tag ID.
+
+        Args:
+            tag_id(int): The tag ID to search for.
+            browsing_state(BrowsingState|None): An optional BrowsingState object to use
+                existing options from, such as sorting options.
+
+        """
+        logger.warning(state)
+        if state:
+            return (
+                cls(query=f"tag_id:{str(tag_id)}")
+                .with_sorting_direction(state.ascending)
+                .with_sorting_mode(state.sorting_mode)
+            )
         return cls(query=f"tag_id:{str(tag_id)}")
 
     @classmethod

--- a/src/tagstudio/core/library/alchemy/enums.py
+++ b/src/tagstudio/core/library/alchemy/enums.py
@@ -104,7 +104,7 @@ class BrowsingState:
 
         Args:
             tag_id(int): The tag ID to search for.
-            browsing_state(BrowsingState|None): An optional BrowsingState object to use
+            state(BrowsingState|None): An optional BrowsingState object to use
                 existing options from, such as sorting options.
 
         """

--- a/src/tagstudio/qt/controller/components/tag_box_controller.py
+++ b/src/tagstudio/qt/controller/components/tag_box_controller.py
@@ -38,14 +38,18 @@ class TagBoxWidget(TagBoxWidgetView):
             case TagClickActionOption.OPEN_EDIT:
                 self._on_edit(tag)
             case TagClickActionOption.SET_SEARCH:
-                self.__driver.update_browsing_state(BrowsingState.from_tag_id(tag.id))
+                self.__driver.update_browsing_state(
+                    BrowsingState.from_tag_id(tag.id, self.__driver.browsing_history.current)
+                )
             case TagClickActionOption.ADD_TO_SEARCH:
                 # NOTE: modifying the ast and then setting that would be nicer
                 #       than this string manipulation, but also much more complex,
                 #       due to needing to implement a visitor that turns an AST to a string
                 #       So if that exists when you read this, change the following accordingly.
                 current = self.__driver.browsing_history.current
-                suffix = BrowsingState.from_tag_id(tag.id).query
+                suffix = BrowsingState.from_tag_id(
+                    tag.id, self.__driver.browsing_history.current
+                ).query
                 assert suffix is not None
                 self.__driver.update_browsing_state(
                     current.with_search_query(
@@ -90,4 +94,6 @@ class TagBoxWidget(TagBoxWidgetView):
     @override
     def _on_search(self, tag: Tag) -> None:  # type: ignore[misc]
         self.__driver.main_window.search_field.setText(f"tag_id:{tag.id}")
-        self.__driver.update_browsing_state(BrowsingState.from_tag_id(tag.id))
+        self.__driver.update_browsing_state(
+            BrowsingState.from_tag_id(tag.id, self.__driver.browsing_history.current)
+        )

--- a/src/tagstudio/qt/modals/tag_search.py
+++ b/src/tagstudio/qt/modals/tag_search.py
@@ -316,7 +316,9 @@ class TagSearchPanel(PanelWidget):
             tag_widget.search_for_tag_action.triggered.connect(
                 lambda checked=False, tag_id=tag.id, driver=self.driver: (
                     driver.main_window.search_field.setText(f"tag_id:{tag_id}"),
-                    driver.update_browsing_state(BrowsingState.from_tag_id(tag_id)),
+                    driver.update_browsing_state(
+                        BrowsingState.from_tag_id(tag_id, driver.browsing_history.current)
+                    ),
                 )
             )
             tag_widget.search_for_tag_action.setEnabled(True)


### PR DESCRIPTION
### Summary

This PR fixes `BrowsingState` objects created via the `from_tag_id()` not respecting the current sorting options by allowing the method to receive an optional `BrowsingState` object to use the current sorting information from and passing the current `BrowsingState` in all instances of this method call. Fixes #1031.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
