### PR TITLE
perf: optimize refresh_dir by prefetching all paths

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import time
 import unicodedata
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from os import makedirs
@@ -867,6 +867,10 @@ class Library:
         """Check if item with given path is in library already."""
         with Session(self.engine) as session:
             return session.query(exists().where(Entry.path == path)).scalar()
+
+    def all_paths(self) -> Sequence[Path]:
+        with Session(self.engine) as session:
+            return session.scalars(select(Entry.path)).fetchall()
 
     def get_paths(self, glob: str | None = None, limit: int = -1) -> list[str]:
         path_strings: list[str] = []


### PR DESCRIPTION
### Summary
Instead of fetching each entry path one by one prefetch all of them into a set for fast checks.
Refresh time on a library with 400_000 entries went from `160s` to `13s`.

### Tasks Completed
-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [X] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [X] Basic functionality
    -   [ ] PyInstaller executable
