### PR TITLE
fix(pyproject): allow Python 3.13 to function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
       perSystem =
         { pkgs, ... }:
         let
-          python3 = pkgs.python312;
+          python3 = pkgs.python313;
         in
         {
           packages =

--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -86,6 +86,7 @@ python3Packages.buildPythonApplication {
   dependencies =
     with python3Packages;
     [
+      audioop-lts
       chardet
       ffmpeg-python
       humanfriendly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,9 @@ description = "A User-Focused Photo & File Management System."
 version = "9.5.3"
 license = "GPL-3.0-only"
 readme = "README.md"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.12,<3.14"
 dependencies = [
+    "audioop-lts; python_version >= '3.13'",
     "chardet~=5.2",
     "ffmpeg-python~=0.2",
     "humanfriendly==10.*",


### PR DESCRIPTION
### Summary

Python 3.13 doesn't seem to have any trouble from running TagStudio, apart from `audioop` being removed/deprecated. While we do not support outside package managers at the moment, more and more systems will be moving to it as the system interpreter, and simply allowing this doesn't cause any harm.

`pydub` is what currently depends on the removed `audioop` module. For now, added in `audioop-lts` (only when on a version at or above 3.13) while a long-term solution is figured out.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
