### PR TITLE
Fix: Add thumbnail generation for .cbr and .cbz files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "typing_extensions~=4.13",
     "ujson~=5.10",
     "wcmatch==10.*",
+    "rarfile = "^4.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Summary

Closes #1051

This PR adds thumbnail generation for `.cbr` and `.cbz` files. The new logic reads the archive and uses the first internal image as the cover preview, fixing the bug where thumbnails were incorrect or missing.

This change adds the `rarfile` dependency to `pyproject.toml` for `.cbr` support.

### Tasks Completed

- Implemented a new rendering path for comic book archives in `thumb_renderer.py`.
- Added the `rarfile` dependency to support `.cbr` files.

-   Platforms Tested:
    -   [x] Windows x86
    -   [x] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    -   Tested For:
    -   [x] Basic functionality (Verified that `.cbr` and `.cbz` thumbnails now render correctly)
    -   [ ] PyInstaller executable