### PR TITLE
feat: add settings to disable automatic thumbnail generation for sound

### DIFF
--- a/src/tagstudio/core/global_settings.py
+++ b/src/tagstudio/core/global_settings.py
@@ -44,6 +44,7 @@ class Theme(Enum):
 class GlobalSettings(BaseModel):
     language: str = Field(default="en")
     open_last_loaded_on_startup: bool = Field(default=True)
+    generate_thumbs: bool = Field(default=False)
     autoplay: bool = Field(default=True)
     loop: bool = Field(default=True)
     show_filenames_in_grid: bool = Field(default=True)

--- a/src/tagstudio/qt/modals/settings_panel.py
+++ b/src/tagstudio/qt/modals/settings_panel.py
@@ -135,6 +135,10 @@ class SettingsPanel(PanelWidget):
             Translations["settings.open_library_on_start"], self.open_last_lib_checkbox
         )
 
+        self.generate_thumbs = QCheckBox()
+        self.generate_thumbs.setChecked(self.driver.settings.generate_thumbs)
+        form_layout.addRow(Translations["settings.generate_thumbs"], self.generate_thumbs)
+
         # Autoplay
         self.autoplay_checkbox = QCheckBox()
         self.autoplay_checkbox.setChecked(self.driver.settings.autoplay)
@@ -232,6 +236,7 @@ class SettingsPanel(PanelWidget):
         return {
             "language": self.__get_language(),
             "open_last_loaded_on_startup": self.open_last_lib_checkbox.isChecked(),
+            "generate_thumbs": self.generate_thumbs.isChecked(),
             "autoplay": self.autoplay_checkbox.isChecked(),
             "show_filenames_in_grid": self.show_filenames_checkbox.isChecked(),
             "page_size": int(self.page_size_line_edit.text()),
@@ -249,6 +254,7 @@ class SettingsPanel(PanelWidget):
         driver.settings.language = settings["language"]
         driver.settings.open_last_loaded_on_startup = settings["open_last_loaded_on_startup"]
         driver.settings.autoplay = settings["autoplay"]
+        driver.settings.generate_thumbs = settings["generate_thumbs"]
         driver.settings.show_filenames_in_grid = settings["show_filenames_in_grid"]
         driver.settings.page_size = settings["page_size"]
         driver.settings.show_filepath = settings["show_filepath"]

--- a/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
+++ b/src/tagstudio/qt/view/widgets/preview/preview_thumb_view.py
@@ -98,7 +98,7 @@ class PreviewThumbView(QWidget):
         self.__media_player_page = QWidget()
         self.__stacked_page_setup(self.__media_player_page, self.__media_player)
 
-        self.__thumb_renderer = ThumbRenderer(library)
+        self.__thumb_renderer = ThumbRenderer(library, driver)
         self.__thumb_renderer.updated.connect(self.__thumb_renderer_updated_callback)
         self.__thumb_renderer.updated_ratio.connect(self.__thumb_renderer_updated_ratio_callback)
 

--- a/src/tagstudio/qt/widgets/item_thumb.py
+++ b/src/tagstudio/qt/widgets/item_thumb.py
@@ -201,7 +201,7 @@ class ItemThumb(FlowWidget):
         self.thumb_layout.addWidget(self.bottom_container)
 
         self.thumb_button = ThumbButton(self.thumb_container, thumb_size)
-        self.renderer = ThumbRenderer(self.lib)
+        self.renderer = ThumbRenderer(self.lib, self.driver)
         self.renderer.updated.connect(
             lambda timestamp, image, size, filename: (
                 self.update_thumb(image, timestamp),

--- a/src/tagstudio/resources/translations/en.json
+++ b/src/tagstudio/resources/translations/en.json
@@ -243,6 +243,7 @@
     "settings.language": "Language",
     "settings.library": "Library Settings",
     "settings.open_library_on_start": "Open Library on Start",
+    "settings.generate_thumbs": "Thumbnail Generation",
     "settings.page_size": "Page Size",
     "settings.restart_required": "Please restart TagStudio for changes to take effect.",
     "settings.show_filenames_in_grid": "Show Filenames in Grid",


### PR DESCRIPTION
### Summary
#930 is a blocker for me because I mainly use it for sound at the moment.

Haven't wrote python for a while and isn't really familiar with the current convention for python so let me know if anything need fixing.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed
<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->