### PR TITLE
fix : Empty frame as video preview if auto-play is paused #1053

### DIFF
--- a/src/tagstudio/qt/widgets/media_player.py
+++ b/src/tagstudio/qt/widgets/media_player.py
@@ -455,7 +455,7 @@ class MediaPlayer(QGraphicsView):
             current = self.format_time(self.player.position())
             duration = self.format_time(self.player.duration())
             self.position_label.setText(f"{current} / {duration}")
-            
+
             # The key change: if autoplay is off, pause the player after the media is loaded
             if not self.autoplay.isChecked():
                 self.player.pause()
@@ -493,4 +493,3 @@ class VideoPreview(QGraphicsVideoItem):
     @override
     def boundingRect(self):
         return QRectF(0, 0, self.size().width(), self.size().height())
-    

--- a/src/tagstudio/qt/widgets/media_player.py
+++ b/src/tagstudio/qt/widgets/media_player.py
@@ -101,8 +101,8 @@ class MediaPlayer(QGraphicsView):
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setStyleSheet("""
             QGraphicsView {
-               background: transparent;
-               border: none;
+                background: transparent;
+                border: none;
             }
         """)
         self.setObjectName("mediaPlayer")
@@ -409,6 +409,8 @@ class MediaPlayer(QGraphicsView):
                 self.player.play()
         else:
             self.player.setSource(QUrl.fromLocalFile(self.filepath))
+            if not self.autoplay.isChecked():
+                self.player.pause()
 
     def load_toggle_play_icon(self, playing: bool) -> None:
         icon = self.driver.rm.pause_icon if playing else self.driver.rm.play_icon
@@ -453,6 +455,10 @@ class MediaPlayer(QGraphicsView):
             current = self.format_time(self.player.position())
             duration = self.format_time(self.player.duration())
             self.position_label.setText(f"{current} / {duration}")
+            
+            # The key change: if autoplay is off, pause the player after the media is loaded
+            if not self.autoplay.isChecked():
+                self.player.pause()
 
     def _update_controls(self, size: QSize) -> None:
         self.scene().setSceneRect(0, 0, size.width(), size.height())
@@ -487,3 +493,4 @@ class VideoPreview(QGraphicsVideoItem):
     @override
     def boundingRect(self):
         return QRectF(0, 0, self.size().width(), self.size().height())
+    

--- a/src/tagstudio/qt/widgets/media_player.py
+++ b/src/tagstudio/qt/widgets/media_player.py
@@ -409,8 +409,8 @@ class MediaPlayer(QGraphicsView):
                 self.player.play()
         else:
             self.player.setSource(QUrl.fromLocalFile(self.filepath))
-            if not self.autoplay.isChecked():
-                self.player.pause()
+            if  self.autoplay.isChecked():
+                self.player.play()
 
     def load_toggle_play_icon(self, playing: bool) -> None:
         icon = self.driver.rm.pause_icon if playing else self.driver.rm.play_icon


### PR DESCRIPTION
### Summary
fix :  Empty frame as video preview if auto-play is paused #1053
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
