### PR TITLE
feat: cli version argument

### DIFF
--- a/src/tagstudio/main.py
+++ b/src/tagstudio/main.py
@@ -11,6 +11,7 @@ import traceback
 
 import structlog
 
+from tagstudio.core.constants import VERSION, VERSION_BRANCH
 from tagstudio.qt.ts_qt import QtDriver
 
 logger = structlog.get_logger(__name__)
@@ -53,6 +54,13 @@ def main():
         dest="debug",
         action="store_true",
         help="Reveals additional internal data useful for debugging.",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        help="Displays TagStudio version information.",
+        version=f"TagStudio v{VERSION} {VERSION_BRANCH}",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
### Summary

This PR adds version arguments (`-v` and `--version` ) to TagStudio's [main entrypoint](https://github.com/TagStudioDev/TagStudio/blob/3489e159a503d67e1b87e8bcd4fc5be72f944505/src/tagstudio/main.py#L19).
Version information is formatted as follows: `TagStudio v{VERSION} {VERSION_BRANCH}`

Examples:
```
## With TS 9.5.3 on main branch
$ tagstudio --version
TagStudio v9.5.3
```
```
## With TS 9.5.4 on a pre-release branch
$ tagstudio --version
TagStudio v9.5.4 Pre-Release
```

Seeing as this is only a small change, I've opted to open this PR without prior discussion.
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
