### PR TITLE
ci: expand pyright ignore rules to vendored and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,12 +84,13 @@ ignore_errors = true
 qt_api = "pyside6"
 
 [tool.pyright]
-ignore = [".venv/**"]
+ignore = ["src/tagstudio/qt/helpers/vendored/pydub/", ".venv/**"]
 include = ["src/tagstudio", "tests"]
 reportAny = false
 reportIgnoreCommentWithoutRule = false
 reportImplicitStringConcatenation = false
 reportMissingTypeArgument = false
+reportMissingTypeStubs = false
 # reportOptionalMemberAccess = false
 reportUnannotatedClassAttribute = false
 reportUnknownArgumentType = false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,13 @@
+# pyright: reportArgumentType=false
+# pyright: reportAttributeAccessIssue=false
+# pyright: reportMissingParameterType=false
+# pyright: reportOptionalMemberAccess=false
+# pyright: reportPrivateUsage=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+# pyright: reportUnusedParameter=false
+
+
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -155,7 +165,7 @@ def qt_driver(qtbot, library, library_dir: Path):
 
         driver.app = Mock()
         driver.main_window = Mock()
-        driver.main_window.preview_panel = Mock()
+        # driver.main_window.preview_panel = Mock()
         driver.main_window.thumb_grid = Mock()
         driver.main_window.thumb_size = 128
         driver.item_thumbs = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,14 +166,14 @@ def qt_driver(qtbot, library, library_dir: Path):
         driver.app = Mock()
         driver.main_window = Mock()
         # driver.main_window.preview_panel = Mock()
-        driver.main_window.thumb_grid = Mock()
+        # driver.main_window.thumb_grid = Mock()
         driver.main_window.thumb_size = 128
         driver.item_thumbs = []
-        driver.main_window.menu_bar.autofill_action = Mock()
+        # driver.main_window.menu_bar.autofill_action = Mock()
 
         driver.copy_buffer = {"fields": [], "tags": []}
-        driver.main_window.menu_bar.copy_fields_action = Mock()
-        driver.main_window.menu_bar.paste_fields_action = Mock()
+        # driver.main_window.menu_bar.copy_fields_action = Mock()
+        # driver.main_window.menu_bar.paste_fields_action = Mock()
 
         driver.lib = library
         # TODO - downsize this method and use it

--- a/tests/macros/test_dupe_entries.py
+++ b/tests/macros/test_dupe_entries.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+
+
 from pathlib import Path
 
 from tagstudio.core.library.alchemy.models import Entry

--- a/tests/macros/test_folders_tags.py
+++ b/tests/macros/test_folders_tags.py
@@ -1,3 +1,8 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+
+
 from tagstudio.qt.modals.folders_to_tags import folders_to_tags
 
 

--- a/tests/macros/test_missing_files.py
+++ b/tests/macros/test_missing_files.py
@@ -16,6 +16,7 @@ def test_refresh_missing_files(library: Library):
     registry = MissingRegistry(library=library)
 
     # touch the file `one/two/bar.md` but in wrong location to simulate a moved file
+    assert library.library_dir
     (library.library_dir / "bar.md").touch()
 
     # no files actually exist, so it should return all entries

--- a/tests/macros/test_refresh_dir.py
+++ b/tests/macros/test_refresh_dir.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/tests/macros/test_sidecar.py
+++ b/tests/macros/test_sidecar.py
@@ -1,37 +1,3 @@
-# import shutil
-# from pathlib import Path
-# from tempfile import TemporaryDirectory
-
-# import pytest
-# from tagstudio.core.enums import MacroID
-# from tagstudio.core.library.alchemy.fields import _FieldID
-
-
-# @pytest.mark.parametrize("library", [TemporaryDirectory()], indirect=True)
-def test_sidecar_macro(qt_driver, library, cwd, entry_full):
-    # TODO: Rework and finalize sidecar loading + macro systems.
+# TODO: REMOVE. THIS. FILE.
+def test_sidecar_macro(qt_driver):  # pyright: ignore
     pass
-    # entry_full.path = Path("newgrounds/foo.txt")
-
-    # fixture = cwd / "fixtures/sidecar_newgrounds.json"
-    # dst = library.library_dir / "newgrounds" / (entry_full.path.name + ".json")
-    # dst.parent.mkdir()
-    # shutil.copy(fixture, dst)
-
-    # qt_driver.frame_content = [entry_full]
-    # qt_driver.run_macro(MacroID.SIDECAR, entry_full.id)
-
-    # entry = library.get_entry_full(entry_full.id)
-    # new_fields = (
-    #     (_FieldID.DESCRIPTION.name, "NG description"),
-    #     (_FieldID.ARTIST.name, "NG artist"),
-    #     (_FieldID.SOURCE.name, "https://ng.com"),
-    # )
-    # found = [(field.type.key, field.value) for field in entry.fields]
-
-    # # `new_fields` should be subset of `found`
-    # for field in new_fields:
-    #     assert field in found, f"Field not found: {field} / {found}"
-
-    # expected_tags = {"ng_tag", "ng_tag2"}
-    # assert {x.name in expected_tags for x in entry.tags}

--- a/tests/qt/test_build_tag_panel.py
+++ b/tests/qt/test_build_tag_panel.py
@@ -1,3 +1,12 @@
+# pyright: reportArgumentType=false
+# pyright: reportAttributeAccessIssue=false
+# pyright: reportMissingParameterType=false
+# pyright: reportOptionalMemberAccess=false
+# pyright: reportPrivateUsage=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+# pyright: reportUnusedParameter=false
+
 from tagstudio.core.library.alchemy.models import Tag
 from tagstudio.qt.modals.build_tag import BuildTagPanel
 from tagstudio.qt.translations import Translations

--- a/tests/qt/test_field_containers.py
+++ b/tests/qt/test_field_containers.py
@@ -1,3 +1,8 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+
+
 from tagstudio.qt.controller.widgets.preview_panel_controller import PreviewPanel
 
 
@@ -102,8 +107,8 @@ def test_add_tag_to_selection_multiple(qt_driver, library):
 
     # Then reload all entries and recheck the presence of tag 1000
     refreshed_entries = library.all_entries(with_joins=True)
-    tag_present_on_some: bool = False
-    tag_absent_on_some: bool = False
+    tag_present_on_some = False
+    tag_absent_on_some = False
 
     for e in refreshed_entries:
         if 1000 in [t.id for t in e.tags]:
@@ -138,6 +143,8 @@ def test_meta_tag_category(qt_driver, library, entry_full):
             case 2:
                 # Make sure the container isn't a duplicate Tags category
                 assert container.title != "<h4>Tags</h4>"
+            case _:
+                pass
 
 
 def test_custom_tag_category(qt_driver, library, entry_full):
@@ -170,3 +177,5 @@ def test_custom_tag_category(qt_driver, library, entry_full):
             case 2:
                 # Make sure the container isn't a plain Tags category
                 assert container.title != "<h4>Tags</h4>"
+            case _:
+                pass

--- a/tests/qt/test_file_path_options.py
+++ b/tests/qt/test_file_path_options.py
@@ -1,3 +1,10 @@
+# pyright: reportAttributeAccessIssue=false
+# pyright: reportMissingParameterType=false
+# pyright: reportPrivateUsage=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+
+
 import os
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/qt/test_flow_widget.py
+++ b/tests/qt/test_flow_widget.py
@@ -1,3 +1,9 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportPrivateUsage=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnusedParameter=false
+
+
 from PySide6.QtCore import QRect
 from PySide6.QtWidgets import QPushButton, QWidget
 

--- a/tests/qt/test_folders_to_tags.py
+++ b/tests/qt/test_folders_to_tags.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+
+
 from tagstudio.qt.modals.folders_to_tags import generate_preview_data
 
 

--- a/tests/qt/test_item_thumb.py
+++ b/tests/qt/test_item_thumb.py
@@ -1,3 +1,9 @@
+# pyright: reportArgumentType=false
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnusedParameter=false
+
+
 import pytest
 
 from tagstudio.core.library.alchemy.enums import ItemType

--- a/tests/qt/test_preview_panel.py
+++ b/tests/qt/test_preview_panel.py
@@ -1,3 +1,8 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnusedParameter=false
+
+
 from tagstudio.qt.controller.widgets.preview_panel_controller import PreviewPanel
 
 

--- a/tests/qt/test_qt_driver.py
+++ b/tests/qt/test_qt_driver.py
@@ -1,3 +1,10 @@
+# pyright: reportArgumentType=false
+# pyright: reportMissingParameterType=false
+# pyright: reportOptionalMemberAccess=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+
+
 from typing import TYPE_CHECKING
 
 from tagstudio.core.library.alchemy.enums import BrowsingState
@@ -6,64 +13,6 @@ from tagstudio.qt.widgets.item_thumb import ItemThumb
 
 if TYPE_CHECKING:
     from tagstudio.qt.ts_qt import QtDriver
-
-# def test_update_thumbs(qt_driver):
-#     qt_driver.frame_content = [
-#         Entry(
-#             folder=qt_driver.lib.folder,
-#             path=Path("/tmp/foo"),
-#             fields=qt_driver.lib.default_fields,
-#         )
-#     ]
-
-#     qt_driver.item_thumbs = []
-#     for _ in range(3):
-#         qt_driver.item_thumbs.append(
-#             ItemThumb(
-#                 mode=ItemType.ENTRY,
-#                 library=qt_driver.lib,
-#                 driver=qt_driver,
-#                 thumb_size=(100, 100),
-#             )
-#         )
-
-#     qt_driver.update_thumbs()
-
-#     for idx, thumb in enumerate(qt_driver.item_thumbs):
-#         # only first item is visible
-#         assert thumb.isVisible() == (idx == 0)
-
-
-# def test_toggle_item_selection_bridge(qt_driver, entry_min):
-#     # mock some props since we're not running `start()`
-#     qt_driver.autofill_action = Mock()
-#     qt_driver.sort_fields_action = Mock()
-
-#     # set the content manually
-#     qt_driver.frame_content = [entry_min] * 3
-
-#     qt_driver.filter.page_size = 3
-#     qt_driver._init_thumb_grid()
-#     assert len(qt_driver.item_thumbs) == 3
-
-#     # select first item
-#     qt_driver.toggle_item_selection(0, append=False, bridge=False)
-#     assert qt_driver.selected == [0]
-
-#     # add second item to selection
-#     qt_driver.toggle_item_selection(1, append=False, bridge=True)
-#     assert qt_driver.selected == [0, 1]
-
-#     # add third item to selection
-#     qt_driver.toggle_item_selection(2, append=False, bridge=True)
-#     assert qt_driver.selected == [0, 1, 2]
-
-#     # select third item only
-#     qt_driver.toggle_item_selection(2, append=False, bridge=False)
-#     assert qt_driver.selected == [2]
-
-#     qt_driver.toggle_item_selection(0, append=False, bridge=True)
-#     assert qt_driver.selected == [0, 1, 2]
 
 
 def test_browsing_state_update(qt_driver: "QtDriver"):

--- a/tests/qt/test_tag_panel.py
+++ b/tests/qt/test_tag_panel.py
@@ -1,3 +1,8 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+
+
 from tagstudio.core.library.alchemy.models import Tag
 from tagstudio.qt.modals.build_tag import BuildTagPanel
 

--- a/tests/qt/test_tag_search_panel.py
+++ b/tests/qt/test_tag_search_panel.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownParameterType=false
+
+
 from tagstudio.qt.modals.tag_search import TagSearchPanel
 
 

--- a/tests/test_json_migration.py
+++ b/tests/test_json_migration.py
@@ -48,5 +48,5 @@ def test_json_migration():
     # List Type
     assert modal.check_ext_type()
     # No Leading Dot
-    for ext in modal.sql_lib.prefs(LibraryPrefs.EXTENSION_LIST):
+    for ext in modal.sql_lib.prefs(LibraryPrefs.EXTENSION_LIST):  # pyright: ignore[reportUnknownVariableType]
         assert ext[0] != "."

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,3 +1,13 @@
+# pyright: reportArgumentType=false
+# pyright: reportAttributeAccessIssue=false
+# pyright: reportMissingParameterType=false
+# pyright: reportOptionalMemberAccess=false
+# pyright: reportPrivateUsage=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false
+# pyright: reportUnusedParameter=false
+
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -139,5 +139,5 @@ def test_parent_tags(search_library: Library, query: str, count: int):
     "invalid_query", ["asd AND", "asd AND AND", "tag:(", "(asd", "asd[]", "asd]", ":", "tag: :"]
 )
 def test_syntax(search_library: Library, invalid_query: str):
-    with pytest.raises(ParsingError) as e_info:  # noqa: F841
+    with pytest.raises(ParsingError) as e_info:  # noqa: F841  # pyright: ignore[reportUnusedVariable]
         search_library.search_library(BrowsingState.from_search_query(invalid_query), page_size=500)


### PR DESCRIPTION
### Summary

This PR sets the Pyright `reportMissingTypeStubs` rule to `false`, ignores the vendored pydub file(s), and ignores specific rules for tests that otherwise can't be reasonably accommodated.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
