### PR TITLE
fix: swap parent and child logic for TAG_CHILDREN_QUERY

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -96,16 +96,15 @@ DB_VERSION_KEY: str = "DB_VERSION"
 DB_VERSION: int = 100
 
 TAG_CHILDREN_QUERY = text("""
--- Note for this entire query that tag_parents.child_id is the parent id and tag_parents.parent_id is the child id due to bad naming
 WITH RECURSIVE ChildTags AS (
-    SELECT :tag_id AS child_id
+    SELECT :tag_id AS tag_id
     UNION
-    SELECT tp.parent_id AS child_id
+    SELECT tp.child_id AS tag_id
 	FROM tag_parents tp
-    INNER JOIN ChildTags c ON tp.child_id = c.child_id
+    INNER JOIN ChildTags c ON tp.parent_id = c.tag_id
 )
 SELECT * FROM ChildTags;
-""")  # noqa: E501
+""")
 
 
 class ReservedNamespaceError(Exception):

--- a/src/tagstudio/core/library/alchemy/visitors.py
+++ b/src/tagstudio/core/library/alchemy/visitors.py
@@ -40,7 +40,7 @@ WITH RECURSIVE ChildTags AS (
     INNER JOIN ChildTags c ON tp.parent_id = c.tag_id
 )
 SELECT tag_id FROM ChildTags;
-""")  # noqa: E501
+""")
 
 
 def get_filetype_equivalency_list(item: str) -> list[str] | set[str]:


### PR DESCRIPTION
### Summary
Fix #1063 by swapping the parent and child ID logic in TAG_CHILDREN_QUERY to match that of TAG_CHILDREN_ID_QUERY which was changed in the TagParent swap in  #998.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
