### PR TITLE
fix: parent tags in tag editor are uneditable

### DIFF
--- a/src/tagstudio/qt/modals/build_tag.py
+++ b/src/tagstudio/qt/modals/build_tag.py
@@ -30,7 +30,7 @@ from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.models import Tag, TagColorGroup
 from tagstudio.core.palette import ColorType, UiColor, get_tag_color, get_ui_color
 from tagstudio.qt.modals.tag_color_selection import TagColorSelection
-from tagstudio.qt.modals.tag_search import TagSearchModal
+from tagstudio.qt.modals.tag_search import TagSearchModal, TagSearchPanel
 from tagstudio.qt.translations import Translations
 from tagstudio.qt.widgets.panel import PanelModal, PanelWidget
 from tagstudio.qt.widgets.tag import (
@@ -385,10 +385,11 @@ class BuildTagPanel(PanelWidget):
         tag_widget = TagWidget(
             tag,
             library=self.lib,
-            has_edit=False,
+            has_edit=True,
             has_remove=True,
         )
         tag_widget.on_remove.connect(lambda t=parent_id: self.remove_parent_tag_callback(t))
+        tag_widget.on_edit.connect(lambda t=tag: TagSearchPanel(library=self.lib).edit_tag(t))
         row.addWidget(tag_widget)
 
         # Add Disambiguation Tag Button


### PR DESCRIPTION
### Summary
Closes #1055 

Enables the Edit context menu item for Parent Tags within the `BuildTagPanel`

**Before**
<img width="324" height="703" alt="Screenshot 2025-08-31 at 13 11 45" src="https://github.com/user-attachments/assets/73196446-5156-41cd-86e6-45c7376316e3" />

**After**
<img width="323" height="697" alt="Screenshot 2025-08-31 at 13 12 23" src="https://github.com/user-attachments/assets/63df5c91-ff4b-46b8-92d6-7be85489d39d" />

### Tasks Completed

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
