### PR TITLE
fix: add loop cutoff to get_tag_categories()

### DIFF
--- a/src/tagstudio/qt/widgets/preview/field_containers.py
+++ b/src/tagstudio/qt/widgets/preview/field_containers.py
@@ -168,9 +168,11 @@ class FieldContainers(QWidget):
         "Character" -> "Johnny Bravo",
         "TV" -> Johnny Bravo"
         """
-        hierarchy_tags = self.lib.get_tag_hierarchy(t.id for t in tags)
+        loop_cutoff = 1024  # Used for stopping the while loop
 
+        hierarchy_tags = self.lib.get_tag_hierarchy(t.id for t in tags)
         categories: dict[Tag | None, set[Tag]] = {None: set()}
+
         for tag in hierarchy_tags.values():
             if tag.is_category:
                 categories[tag] = set()
@@ -178,7 +180,15 @@ class FieldContainers(QWidget):
             tag = hierarchy_tags[tag.id]
             has_category_parent = False
             parent_tags = tag.parent_tags
+
+            loop_counter = 0
             while len(parent_tags) > 0:
+                # NOTE: This is for preventing infinite loops in the event a tag is parented
+                # to itself cyclically.
+                loop_counter += 1
+                if loop_counter >= loop_cutoff:
+                    break
+
                 grandparent_tags: set[Tag] = set()
                 for parent_tag in parent_tags:
                     if parent_tag in categories:
@@ -186,6 +196,7 @@ class FieldContainers(QWidget):
                         has_category_parent = True
                     grandparent_tags.update(parent_tag.parent_tags)
                 parent_tags = grandparent_tags
+
             if tag.is_category:
                 categories[tag].add(tag)
             elif not has_category_parent:


### PR DESCRIPTION
### Summary

This PR addresses (but does not solve the root issue of) #1074 by adding a cutoff to the `get_tag_categories()` method inside the `FieldContainers` class, preventing infinite loops in the event of cyclical tag relationships. Surprisingly this was seemingly not needed in the `get_tag_hierarchy()` method of the `Library` class. 

*No more freezing in the preview panel, tags load as previously done*
<img width="282" height="257" alt="image" src="https://github.com/user-attachments/assets/873059ac-f250-487c-a2ba-fac1a98df198" />


### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
