### PR TITLE
fix: add option to use old Windows 'start' command

### DIFF
--- a/src/tagstudio/core/global_settings.py
+++ b/src/tagstudio/core/global_settings.py
@@ -60,6 +60,7 @@ class GlobalSettings(BaseModel):
     tag_click_action: TagClickActionOption = Field(default=TagClickActionOption.DEFAULT)
     theme: Theme = Field(default=Theme.SYSTEM)
     splash: Splash = Field(default=Splash.DEFAULT)
+    windows_start_command: bool = Field(default=False)
 
     date_format: str = Field(default="%x")
     hour_format: bool = Field(default=True)

--- a/src/tagstudio/qt/controller/widgets/preview/preview_thumb_controller.py
+++ b/src/tagstudio/qt/controller/widgets/preview/preview_thumb_controller.py
@@ -144,7 +144,9 @@ class PreviewThumb(PreviewThumbView):
             return self.__get_image_stats(filepath)
 
     def _open_file_action_callback(self):
-        open_file(self.__current_file)
+        open_file(
+            self.__current_file, windows_start_command=self.__driver.settings.windows_start_command
+        )
 
     def _open_explorer_action_callback(self):
         open_file(self.__current_file, file_manager=True)
@@ -154,4 +156,6 @@ class PreviewThumb(PreviewThumbView):
             self.__driver.delete_files_callback(self.__current_file)
 
     def _button_wrapper_callback(self):
-        open_file(self.__current_file)
+        open_file(
+            self.__current_file, windows_start_command=self.__driver.settings.windows_start_command
+        )


### PR DESCRIPTION
### Summary

Fixes #1036 by adding a new `windows_start_command` option in the `settings.toml` file which toggles the pre-#667 file opener behavior on Windows. This is a niche option so I decided to not include it in the GUI and only make it available when editing the file itself.

In order to test the full functionality of this PR, the option must be set to `true`. 

I tested this on Windows 10 with "Photos" version 2025.11070.8001.0 by opening .jpg files with and without the option. Without it, I get the following message about 50% of the time with some times having the zoom locked and other times having no apparent issue at all.

<img width="994" height="186" alt="image" src="https://github.com/user-attachments/assets/cbef3f49-cd50-436d-88bf-ef576262eacc" />

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
