### PR TITLE
fix: account for leading slash pattern in wcmatch

### DIFF
--- a/src/tagstudio/core/library/ignore.py
+++ b/src/tagstudio/core/library/ignore.py
@@ -44,7 +44,9 @@ def ignore_to_glob(ignore_patterns: list[str]) -> list[str]:
         ignore_patterns (list[str]): The .gitignore-like patterns to convert.
     """
     glob_patterns: list[str] = deepcopy(ignore_patterns)
+    glob_patterns_remove: list[str] = []
     additional_patterns: list[str] = []
+    root_patterns: list[str] = []
 
     # Mimic implicit .gitignore syntax behavior for the SQLite GLOB function.
     for pattern in glob_patterns:
@@ -66,6 +68,16 @@ def ignore_to_glob(ignore_patterns: list[str]) -> list[str]:
             gp = gp.removeprefix("**/").removeprefix("*/")
             additional_patterns.append(exclusion_char + gp)
 
+        elif gp.startswith("/"):
+            # Matches "/file" case for .gitignore behavior where it should only match
+            # a file or folder int the root directory, and nowhere else.
+            glob_patterns_remove.append(gp)
+            gp = gp.lstrip("/")
+            root_patterns.append(exclusion_char + gp)
+
+    for gp in glob_patterns_remove:
+        glob_patterns.remove(gp)
+
     glob_patterns = glob_patterns + additional_patterns
 
     # Add "/**" suffix to suffix-less patterns to match implicit .gitignore behavior.
@@ -75,6 +87,7 @@ def ignore_to_glob(ignore_patterns: list[str]) -> list[str]:
 
         glob_patterns.append(pattern.removesuffix("/*").removesuffix("/") + "/**")
 
+    glob_patterns = glob_patterns + root_patterns
     glob_patterns = list(set(glob_patterns))
 
     logger.info("[Ignore]", glob_patterns=glob_patterns)


### PR DESCRIPTION
### Summary
This fixes #1089 by accounting for ignore pattern cases where there's a leading slash present and using `wcmatch`, which in gitignore should only match with files and folders in the root directory. Previously this was not accounted for in the `wcmatch` glob conversion, and would also separately raise a `ValueError` exception with a pattern with a leading slash was passed to it.

When testing, make sure the internal tools (wcmatch) flag is forced if you have ripgrep on your system. Otherwise this fix is designed to match ripgrep's pattern matching behavior.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
