### PR TITLE
fix: reorder renderer types to fix early false positives

### DIFF
--- a/src/tagstudio/qt/widgets/thumb_renderer.py
+++ b/src/tagstudio/qt/widgets/thumb_renderer.py
@@ -1524,8 +1524,23 @@ class ThumbRenderer(QObject):
         if _filepath and _filepath.is_file():
             try:
                 ext: str = _filepath.suffix.lower() if _filepath.suffix else _filepath.stem.lower()
-                # Images =======================================================
+                # Ebooks =======================================================
                 if MediaCategories.is_ext_in_category(
+                    ext, MediaCategories.EBOOK_TYPES, mime_fallback=True
+                ):
+                    image = self._epub_cover(_filepath)
+                # Krita ========================================================
+                elif MediaCategories.is_ext_in_category(
+                    ext, MediaCategories.KRITA_TYPES, mime_fallback=True
+                ):
+                    image = self._krita_thumb(_filepath)
+                # VTF ==========================================================
+                elif MediaCategories.is_ext_in_category(
+                    ext, MediaCategories.SOURCE_ENGINE_TYPES, mime_fallback=True
+                ):
+                    image = self._vtf_thumb(_filepath)
+                # Images =======================================================
+                elif MediaCategories.is_ext_in_category(
                     ext, MediaCategories.IMAGE_TYPES, mime_fallback=True
                 ):
                     # Raw Images -----------------------------------------------
@@ -1552,11 +1567,6 @@ class ThumbRenderer(QObject):
                 # PowerPoint Slideshow
                 elif ext in {".pptx"}:
                     image = self._powerpoint_thumb(_filepath)
-                # Krita ========================================================
-                elif MediaCategories.is_ext_in_category(
-                    ext, MediaCategories.KRITA_TYPES, mime_fallback=True
-                ):
-                    image = self._krita_thumb(_filepath)
                 # OpenDocument/OpenOffice ======================================
                 elif MediaCategories.is_ext_in_category(
                     ext, MediaCategories.OPEN_DOCUMENT_TYPES, mime_fallback=True
@@ -1590,11 +1600,6 @@ class ThumbRenderer(QObject):
                         savable_media_type = False
                         if image is not None:
                             image = self._apply_overlay_color(image, UiColor.GREEN)
-                # Ebooks =======================================================
-                elif MediaCategories.is_ext_in_category(
-                    ext, MediaCategories.EBOOK_TYPES, mime_fallback=True
-                ):
-                    image = self._epub_cover(_filepath)
                 # Blender ======================================================
                 elif MediaCategories.is_ext_in_category(
                     ext, MediaCategories.BLENDER_TYPES, mime_fallback=True
@@ -1605,11 +1610,6 @@ class ThumbRenderer(QObject):
                     ext, MediaCategories.PDF_TYPES, mime_fallback=True
                 ):
                     image = self._pdf_thumb(_filepath, adj_size)
-                # VTF ==========================================================
-                elif MediaCategories.is_ext_in_category(
-                    ext, MediaCategories.SOURCE_ENGINE_TYPES, mime_fallback=True
-                ):
-                    image = self._vtf_thumb(_filepath)
                 # No Rendered Thumbnail ========================================
                 if not image:
                     raise NoRendererError


### PR DESCRIPTION
### Summary

This fixes #1091, which was caused by MIME types on the tested Linux systems to assume that `.vtf` files have the "Image" MIME type and therefore were sent to the standard image renderer rather than the bespoke VTF renderer. I've chosen to reorder the ""switch"" statement to put pseudo image types before the standard image types in order to retain the functionality of the MIME fallback while also prioritizing these specific formats.

While I did not run any specific performance measurement tests, I don't believe this will make an impact since each of these checks should be O(1) since they're just set membership checks - I'd love a second opinion on this though.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
