### PR TITLE
fix: update SQL_FILENAME to import from new constant

### DIFF
--- a/src/tagstudio/qt/widgets/migration_modal.py
+++ b/src/tagstudio/qt/widgets/migration_modal.py
@@ -31,6 +31,7 @@ from tagstudio.core.constants import (
 )
 from tagstudio.core.enums import LibraryPrefs
 from tagstudio.core.library.alchemy import default_color_groups
+from tagstudio.core.library.alchemy.constants import SQL_FILENAME
 from tagstudio.core.library.alchemy.joins import TagParent
 from tagstudio.core.library.alchemy.library import Library as SqliteLibrary
 from tagstudio.core.library.alchemy.models import Entry, TagAlias
@@ -492,7 +493,7 @@ class JsonMigrationModal(QObject):
 
     def finish_migration(self):
         """Finish the migration upon user approval."""
-        final_name = self.json_lib.library_dir / TS_FOLDER_NAME / SqliteLibrary.SQL_FILENAME
+        final_name = self.json_lib.library_dir / TS_FOLDER_NAME / SQL_FILENAME
         if self.temp_path.exists():
             self.temp_path.rename(final_name)
 


### PR DESCRIPTION
### Summary

This fixes an issue where the Migration Modal would throw an error when attempting to finish due to an internal constant not being refactored properly and still using the old invalid Library class attribute. Pyright caught this, but mypy did not (see #1061).

<img width="713" height="683" alt="image" src="https://github.com/user-attachments/assets/358758dd-f52e-4ce0-a4ce-4cbcdacd01b5" />


### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
