### PR TITLE
fix: always show first frame of video; autoplay will always play

### DIFF
--- a/src/tagstudio/qt/mixed/media_player.py
+++ b/src/tagstudio/qt/mixed/media_player.py
@@ -404,11 +404,11 @@ class MediaPlayer(QGraphicsView):
         if not self.is_paused:
             self.player.stop()
             self.player.setSource(QUrl.fromLocalFile(self.filepath))
-
-            if self.autoplay.isChecked():
-                self.player.play()
         else:
             self.player.setSource(QUrl.fromLocalFile(self.filepath))
+
+        if self.autoplay.isChecked():
+            self.player.play()
 
     def load_toggle_play_icon(self, playing: bool) -> None:
         icon = self.driver.rm.pause_icon if playing else self.driver.rm.play_icon
@@ -453,6 +453,10 @@ class MediaPlayer(QGraphicsView):
             current = self.format_time(self.player.position())
             duration = self.format_time(self.player.duration())
             self.position_label.setText(f"{current} / {duration}")
+
+            # Ensures first frame of non-autoplay videos are loaded
+            if not self.autoplay.isChecked():
+                self.player.pause()
 
     def _update_controls(self, size: QSize) -> None:
         self.scene().setSceneRect(0, 0, size.width(), size.height())


### PR DESCRIPTION
### Summary

Fix #1053 by always showing the first frame of a video in the preview panel when selecting it. Also fixed the related issue of autoplay not always playing automatically depending on the player's pause state.

Closes #1059.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
