### PR TITLE
fix: revert mnemonic removal logic

### DIFF
--- a/src/tagstudio/qt/mnemonics.py
+++ b/src/tagstudio/qt/mnemonics.py
@@ -8,21 +8,7 @@ from PySide6.QtWidgets import QMenu
 
 def remove_mnemonic_marker(label: str) -> str:
     """Remove existing accelerator markers (&) from a label."""
-    result = ""
-    skip = False
-    for i, ch in enumerate(label):
-        if skip:
-            skip = False
-            continue
-        if ch == "&":
-            # escaped ampersand "&&"
-            if i + 1 < len(label) and label[i + 1] == "&":
-                result += "&"
-                skip = True
-            # otherwise skip this '&'
-            continue
-        result += ch
-    return result
+    return label.replace("&&", "<ESC_AMP>").replace("&", "", 1).replace("<ESC_AMP>", "&&")
 
 
 # Additional weight for first character in string


### PR DESCRIPTION
### Summary
Fixes #1100 by reverting the mnemonic removal logic to the previous method that was used for macOS-specific code.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
