### PR TITLE
fix: use first file as epub thumbnail instead of the last.

### DIFF
--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -885,6 +885,7 @@ class ThumbRenderer(QObject):
                         ):
                             image_data = zip_file.read(file_name)
                             im = Image.open(BytesIO(image_data))
+                            break
         except Exception as e:
             logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
 


### PR DESCRIPTION
### Summary

If an ePub contains no ComicInfo.xml the first image should be used as the fallback thumbnail.
Currently, the last image will be used due to a missing `break` after the first image is loaded.

Fixes https://github.com/TagStudioDev/TagStudio/issues/1051 (at least for zip based ePubs)

#### Before
<img width="1299" height="752" alt="before" src="https://github.com/user-attachments/assets/21aa7284-7548-4448-93f7-008ee50dcc7c" />

#### After
<img width="1303" height="747" alt="after" src="https://github.com/user-attachments/assets/f837ed59-eca1-4568-8c63-6023b36bcbe3" />

#### Files used for testing

* [NoComicInfo.cbz.zip](https://github.com/user-attachments/files/22198469/NoComicInfo.cbz.zip)
* [NoPages.cbz.zip](https://github.com/user-attachments/files/22198471/NoPages.cbz.zip)

Again renamed because of GitHub upload limitiations.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
