### PR TITLE
fix: process ignore patterns for wcmatch in unlinked registry

### DIFF
--- a/src/tagstudio/core/library/alchemy/registries/unlinked_registry.py
+++ b/src/tagstudio/core/library/alchemy/registries/unlinked_registry.py
@@ -7,7 +7,7 @@ from wcmatch import pathlib
 
 from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.models import Entry
-from tagstudio.core.library.ignore import PATH_GLOB_FLAGS, Ignore
+from tagstudio.core.library.ignore import PATH_GLOB_FLAGS, Ignore, ignore_to_glob
 from tagstudio.core.utils.types import unwrap
 
 logger = structlog.get_logger()
@@ -47,7 +47,8 @@ class UnlinkedRegistry:
         library_dir = unwrap(self.lib.library_dir)
         matches: list[Path] = []
 
-        ignore_patterns = Ignore.get_patterns(library_dir)
+        # NOTE: ignore_to_glob() is needed for wcmatch, not ripgrep.
+        ignore_patterns = ignore_to_glob(Ignore.get_patterns(library_dir))
         for path in pathlib.Path(str(library_dir)).glob(
             f"***/{match_entry.path.name}",
             flags=PATH_GLOB_FLAGS,


### PR DESCRIPTION
### Summary

Fixes #1123 by correctly processing the ignore patterns into glob patterns for use with `wcmatch`.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
