### PR TITLE
fix: update entry cache when toggling tags

### DIFF
--- a/src/tagstudio/core/library/alchemy/models.py
+++ b/src/tagstudio/core/library/alchemy/models.py
@@ -163,6 +163,11 @@ class Tag(Base):
     def __hash__(self) -> int:
         return hash(self.id)
 
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, Tag):
+            return False
+        return self.id == value.id
+
     def __lt__(self, other: "Tag") -> bool:
         return self.name < other.name
 

--- a/src/tagstudio/qt/mixed/field_containers.py
+++ b/src/tagstudio/qt/mixed/field_containers.py
@@ -149,10 +149,12 @@ class FieldContainers(QWidget):
         tag = self.lib.get_tag(tag_id)
         if not tag:
             return
-        new_tags = (
-            entry.tags.union({tag}) if toggle_value else {t for t in entry.tags if t.id != tag_id}
-        )
-        self.update_granular(entry_tags=new_tags, entry_fields=entry.fields, update_badges=False)
+        if toggle_value:
+            entry.tags.add(tag)
+        else:
+            entry.tags.discard(tag)
+
+        self.update_granular(entry_tags=entry.tags, entry_fields=entry.fields, update_badges=False)
 
     def hide_containers(self):
         """Hide all field and tag containers."""


### PR DESCRIPTION
### Summary
Saves partial updates to entries in `FieldContainers` cache.
This should fix #1128 

### Tasks Completed
-   Platforms Tested:
    -   [x] Linux x86
-   Tested For:
    -   [x] Basic functionality
