### PR TITLE
fix: use absolute path for file opener

### DIFF
--- a/src/tagstudio/qt/mixed/item_thumb.py
+++ b/src/tagstudio/qt/mixed/item_thumb.py
@@ -439,7 +439,8 @@ class ItemThumb(FlowWidget):
 
     def set_item(self, entry: "Entry"):
         self.set_item_id(entry.id)
-        self.set_item_path(entry.path)
+        path = unwrap(self.lib.library_dir) / entry.path
+        self.set_item_path(path)
 
     def set_item_id(self, item_id: int):
         self.item_id = item_id


### PR DESCRIPTION
### Summary
Relative path was being used when updating thumbnails. This prevented "show in file explorer" and 'move to trash" from working.
Fixes #1133 

### Tasks Completed
-   Platforms Tested:
    -   [x] Windows x86
    -   [x] Linux x86
-   Tested For:
    -   [x] Basic functionality