### PR TITLE
fix: Fix searching `A AND A` returning no results

### DIFF
--- a/src/tagstudio/core/library/alchemy/visitors.py
+++ b/src/tagstudio/core/library/alchemy/visitors.py
@@ -146,7 +146,7 @@ class SQLBoolExpressionBuilder(BaseVisitor[ColumnElement[bool]]):
     def __separate_tags(
         self, terms: list[AST], only_single: bool = True
     ) -> tuple[list[int], list[ColumnElement[bool]]]:
-        tag_ids: list[int] = []
+        tag_ids: set[int] = set()
         bool_expressions: list[ColumnElement[bool]] = []
 
         for term in terms:
@@ -154,7 +154,7 @@ class SQLBoolExpressionBuilder(BaseVisitor[ColumnElement[bool]]):
                 match term.type:
                     case ConstraintType.TagID:
                         try:
-                            tag_ids.append(int(term.value))
+                            tag_ids.add(int(term.value))
                         except ValueError:
                             logger.error(
                                 "[SQLBoolExpressionBuilder] Could not cast value to an int Tag ID",
@@ -164,10 +164,10 @@ class SQLBoolExpressionBuilder(BaseVisitor[ColumnElement[bool]]):
                     case ConstraintType.Tag:
                         ids = self.__get_tag_ids(term.value)
                         if not only_single:
-                            tag_ids.extend(ids)
+                            tag_ids.update(ids)
                             continue
                         elif len(ids) == 1:
-                            tag_ids.append(ids[0])
+                            tag_ids.add(ids[0])
                             continue
                     case ConstraintType.FileType:
                         pass
@@ -179,7 +179,7 @@ class SQLBoolExpressionBuilder(BaseVisitor[ColumnElement[bool]]):
                         raise NotImplementedError(f"Unhandled constraint: '{term.type}'")
 
             bool_expressions.append(self.visit(term))
-        return tag_ids, bool_expressions
+        return list(tag_ids), bool_expressions
 
     def __entry_has_all_tags(self, tag_ids: list[int]) -> ColumnElement[bool]:
         """Returns Binary Expression that is true if the Entry has all provided tag ids."""


### PR DESCRIPTION
Fixes searching `<Tag A> AND <Tag A>` returning no results, when it should return the same results as `<Tag A>` ([#951](https://github.com/TagStudioDev/TagStudio/issues/951)).

I'm not very familiar with the backend and haven't done very in-depth testing, so please point out if this causes any unintended side effects.

### Summary
Tweaked the `__separate_tags()` method in `src/tagstudio/core/library/alchemy/visitors.py` to, rather than a list, use a set for collecting the tag IDs of each term of an AST `ANDList` and `ORList` to prevent duplicate tag IDs from being returned.

#### Cause of Bug
The SQL query built from the search `<Tag A> AND <Tag A>` will always fail due to this section:
```
WHERE tag_entries.tag_id IN (1, 1)
GROUP BY tag_entries.entry_id
HAVING count(DISTINCT tag_entries.tag_id) = 2
```
Since it's getting rows where `count(DISTINCT tag_entries.tag_id) = 2`, but it's only searching for rows with a single tag ID, `count(DISTINCT tag_entries.tag_id)` will always equal `1`.

This doesn't apply just to `ANDList`s containing two of the same tag, any `ANDList` containing _at least_ two duplicate tags will cause the query to fail. So a search such as `<Tag A> AND <Tag B> AND <Tag A> AND <Tag A>` would also fail.
However, if the duplicate tag is ambiguous, the SQL query built filters entries in a fundamentally different way that doesn't suffer the same issue, and the search acts as expected.

### Tasks Completed
-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable

