### PR TITLE
feat: render `.clip` thumbnails.

### DIFF
--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -33,6 +33,7 @@ class MediaType(str, Enum):
     AUDIO_MIDI = "audio_midi"
     AUDIO = "audio"
     BLENDER = "blender"
+    CLIP_STUDIO_PAINT = "clip_studio_paint"
     CODE = "code"
     DATABASE = "database"
     DISK_IMAGE = "disk_image"
@@ -175,6 +176,7 @@ class MediaCategories:
         ".blend31",
         ".blend32",
     }
+    _CLIP_STUDIO_PAINT_SET: set[str] = {".clip"}
     _CODE_SET: set[str] = {
         ".bat",
         ".cfg",
@@ -451,6 +453,12 @@ class MediaCategories:
         extensions=_BLENDER_SET,
         is_iana=False,
         name="blender",
+    )
+    CLIP_STUDIO_PAINT_TYPES = MediaCategory(
+        media_type=MediaType.CLIP_STUDIO_PAINT,
+        extensions=_CLIP_STUDIO_PAINT_SET,
+        is_iana=False,
+        name="clip studio paint",
     )
     CODE_TYPES = MediaCategory(
         media_type=MediaType.CODE,

--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -7,6 +7,7 @@ import contextlib
 import hashlib
 import math
 import os
+import sqlite3
 import tarfile
 import xml.etree.ElementTree as ET
 import zipfile
@@ -1378,6 +1379,34 @@ class ThumbRenderer(QObject):
             logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
         return im
 
+    @staticmethod
+    def _clip_thumb(filepath: Path) -> Image.Image | None:
+        """Extract the thumbnail from the SQLite database embedded in a .clip file.
+
+        Args:
+            filepath (Path): The path of the .clip file.
+
+        Returns:
+            Image: The embedded thumbnail, if extractable.
+        """
+        im: Image.Image | None = None
+        try:
+            with open(filepath, "rb") as f:
+                blob = f.read()
+                sqlite_index = blob.find(b"SQLite format 3")
+                if sqlite_index == -1:
+                    return im
+
+            with sqlite3.connect(":memory:") as conn:
+                conn.deserialize(blob[sqlite_index:])
+                thumbnail = conn.execute("SELECT ImageData FROM CanvasPreview").fetchone()
+                if thumbnail:
+                    im = Image.open(BytesIO(thumbnail[0]))
+        except Exception as e:
+            logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
+
+        return im
+
     def render(
         self,
         timestamp: float,
@@ -1628,6 +1657,11 @@ class ThumbRenderer(QObject):
                     ext, MediaCategories.KRITA_TYPES, mime_fallback=True
                 ):
                     image = self._krita_thumb(_filepath)
+                # Clip Studio Paint ============================================
+                elif MediaCategories.is_ext_in_category(
+                    ext, MediaCategories.CLIP_STUDIO_PAINT_TYPES
+                ):
+                    image = self._clip_thumb(_filepath)
                 # VTF ==========================================================
                 elif MediaCategories.is_ext_in_category(
                     ext, MediaCategories.SOURCE_ENGINE_TYPES, mime_fallback=True


### PR DESCRIPTION
### Summary

Add support for rendering `.clip` thumbnails.
Fixes https://github.com/TagStudioDev/TagStudio/issues/1146

`.clip` project files embedd an SQLite database at the end of the file which contains the thumbnail in the `CanvasPreview` table.

#### Before
<img width="1320" height="768" alt="before" src="https://github.com/user-attachments/assets/5107686f-b47d-41c3-94d1-49bc3f633bd7" />

#### After
<img width="1316" height="764" alt="after" src="https://github.com/user-attachments/assets/ece869f8-741b-4a44-a510-f89f601cec64" />

#### Sources for the file format
* [clip-studio-paint-layers-extractor](https://github.com/FlagCatStudio/clip-studio-paint-layers-extractor)
* The test file opened in a text editor

#### File used for testing
[Drawing by Surendra Rajawat hosted on Clip Studio Paint's website](https://vd.clipstudio.net/clipcontent/sample/surendra.zip)

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
