### PR TITLE
fix: toggle play only with left mouse button click

### DIFF
--- a/src/tagstudio/qt/mixed/media_player.py
+++ b/src/tagstudio/qt/mixed/media_player.py
@@ -312,7 +312,10 @@ class MediaPlayer(QGraphicsView):
     def mousePressEvent(self, event: QMouseEvent) -> None:
         # Pause media if background is clicked, with buffer around controls
         buffer: int = 6
-        if event.y() < (self.height() - self.controls.height() - buffer):
+        if (
+            event.y() < (self.height() - self.controls.height() - buffer)
+            and event.button() == Qt.MouseButton.LeftButton
+        ):
             self.toggle_play()
         return super().mousePressEvent(event)
 


### PR DESCRIPTION
### Summary
This change ensures the user clicked with the left mouse button before togging the media player. With no checks, it will also pause on right click. 

Fixes issue: https://github.com/TagStudioDev/TagStudio/issues/1151
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
