### PR TITLE
feat: render `.mdp` thumbnails.

### DIFF
--- a/docs/library/index.md
+++ b/docs/library/index.md
@@ -86,20 +86,21 @@ Audio thumbnails will default to embedded cover art (if any) andfallback to gene
 
 Preview support for office documents or well-known project file formats varies by the format and whether or not embedded thumbnails are available to be read from. OpenDocument-based files are typically supported.
 
-| Filetype                      | Extensions            | Preview Type                                                               |
-| ----------------------------- | --------------------- | -------------------------------------------------------------------------- |
-| Blender                       | `.blend`, `.blend<#>` | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
-| Keynote (Apple iWork)         | `.key`                | Embedded thumbnail                                                         |
-| Krita[^3]                     | `.kra`, `.krz`        | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
-| MuseScore                     | `.mscz`               | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
-| Numbers (Apple iWork)         | `.numbers`            | Embedded thumbnail                                                         |
-| OpenDocument Presentation     | `.odp`, `.fodp`       | Embedded thumbnail                                                         |
-| OpenDocument Spreadsheet      | `.ods`, `.fods`       | Embedded thumbnail                                                         |
-| OpenDocument Text             | `.odt`, `.fodt`       | Embedded thumbnail                                                         |
-| Pages (Apple iWork)           | `.pages`              | Embedded thumbnail                                                         |
-| PDF                           | `.pdf`                | First page render                                                          |
-| Photoshop                     | `.psd`                | Flattened image render                                                     |
-| PowerPoint (Microsoft Office) | `.pptx`, `.ppt`       | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
+| Filetype                             | Extensions            | Preview Type                                                               |
+| ------------------------------------ | --------------------- | -------------------------------------------------------------------------- |
+| Blender                              | `.blend`, `.blend<#>` | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
+| Keynote (Apple iWork)                | `.key`                | Embedded thumbnail                                                         |
+| Krita[^3]                            | `.kra`, `.krz`        | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
+| Mdipack (FireAlpaca, Medibang Paint) | `.mdp`                | Embedded thumbnail                                                         |
+| MuseScore                            | `.mscz`               | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
+| Numbers (Apple iWork)                | `.numbers`            | Embedded thumbnail                                                         |
+| OpenDocument Presentation            | `.odp`, `.fodp`       | Embedded thumbnail                                                         |
+| OpenDocument Spreadsheet             | `.ods`, `.fods`       | Embedded thumbnail                                                         |
+| OpenDocument Text                    | `.odt`, `.fodt`       | Embedded thumbnail                                                         |
+| Pages (Apple iWork)                  | `.pages`              | Embedded thumbnail                                                         |
+| PDF                                  | `.pdf`                | First page render                                                          |
+| Photoshop                            | `.psd`                | Flattened image render                                                     |
+| PowerPoint (Microsoft Office)        | `.pptx`, `.ppt`       | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
 
 ### :material-book: eBooks
 

--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -46,6 +46,7 @@ class MediaType(str, Enum):
     INSTALLER = "installer"
     IWORK = "iwork"
     MATERIAL = "material"
+    MDIPACK = "mdipack"
     MODEL = "model"
     OPEN_DOCUMENT = "open_document"
     PACKAGE = "package"
@@ -335,6 +336,7 @@ class MediaCategories:
     _INSTALLER_SET: set[str] = {".appx", ".msi", ".msix"}
     _IWORK_SET: set[str] = {".key", ".pages", ".numbers"}
     _MATERIAL_SET: set[str] = {".mtl"}
+    _MDIPACK_SET: set[str] = {".mdp"}
     _MODEL_SET: set[str] = {".3ds", ".fbx", ".obj", ".stl"}
     _OPEN_DOCUMENT_SET: set[str] = {
         ".fodg",
@@ -536,6 +538,12 @@ class MediaCategories:
         is_iana=False,
         name="material",
     )
+    MDIPACK_TYPES = MediaCategory(
+        media_type=MediaType.MDIPACK,
+        extensions=_MDIPACK_SET,
+        is_iana=False,
+        name="mdipack",
+    )
     MODEL_TYPES = MediaCategory(
         media_type=MediaType.MODEL,
         extensions=_MODEL_SET,
@@ -640,6 +648,7 @@ class MediaCategories:
         INSTALLER_TYPES,
         IWORK_TYPES,
         MATERIAL_TYPES,
+        MDIPACK_TYPES,
         MODEL_TYPES,
         OPEN_DOCUMENT_TYPES,
         PACKAGE_TYPES,

--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -7,9 +7,11 @@ import contextlib
 import hashlib
 import math
 import os
+import struct
 import tarfile
 import xml.etree.ElementTree as ET
 import zipfile
+import zlib
 from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
@@ -1378,6 +1380,48 @@ class ThumbRenderer(QObject):
             logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
         return im
 
+    @staticmethod
+    def _mdp_thumb(filepath: Path) -> Image.Image | None:
+        """Extract the thumbnail from a .mdp file.
+
+        Args:
+            filepath (Path): The path of the .mdp file.
+
+        Returns:
+            Image: The embedded thumbnail.
+        """
+        im: Image.Image | None = None
+        try:
+            with open(filepath, "rb") as f:
+                magic = struct.unpack("<7sx", f.read(8))[0]
+                if magic != b"mdipack":
+                    return im
+
+                bin_header = struct.unpack("<LLL", f.read(12))
+                xml_header = ET.fromstring(f.read(bin_header[1]))
+                mdibin_count = len(xml_header.findall("./*Layer")) + 1
+                for _ in range(mdibin_count):
+                    pac_header = struct.unpack("<3sxLLLL48s64s", f.read(132))
+                    if not pac_header[6].startswith(b"thumb"):
+                        f.seek(pac_header[3], os.SEEK_CUR)
+                        continue
+
+                    thumb_element = unwrap(xml_header.find("Thumb"))
+                    dimensions = (
+                        int(unwrap(thumb_element.get("width"))),
+                        int(unwrap(thumb_element.get("height"))),
+                    )
+                    thumb_blob = f.read(pac_header[3])
+                    if pac_header[2] == 1:
+                        thumb_blob = zlib.decompress(thumb_blob, bufsize=pac_header[4])
+
+                    im = Image.frombytes("RGBA", dimensions, thumb_blob, "raw", "BGRA")
+                    break
+        except Exception as e:
+            logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
+
+        return im
+
     def render(
         self,
         timestamp: float,
@@ -1704,6 +1748,9 @@ class ThumbRenderer(QObject):
                     ext, MediaCategories.PDF_TYPES, mime_fallback=True
                 ):
                     image = self._pdf_thumb(_filepath, adj_size)
+                # MDIPACK ======================================================
+                elif MediaCategories.is_ext_in_category(ext, MediaCategories.MDIPACK_TYPES):
+                    image = self._mdp_thumb(_filepath)
                 # No Rendered Thumbnail ========================================
                 if not image:
                     raise NoRendererError


### PR DESCRIPTION
### Summary
Add support for rendering `.mdp` thumbnails.
Fixes https://github.com/TagStudioDev/TagStudio/issues/1145

#### File layout
Mostly translated from the repo linked below.

The first 20 bytes are a binary header called `TMDIPack`.
```c
struct TMDIPack {
    char header[8]; // "mdipack "
    unsigned long version; // always 0
    unsigned long mdiSize; // size of the XML header
    unsigned long version; // size of the actual project data
}
```

After the binary header comes an XML header called `MDI`.
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<Mdiapp width="1600" height="1200" dpi="350" checkerBG="true" bgColorR="255" bgColorG="255" bgColorB="255">
    <CreateTime time="1758967935" timeString="2025-09-27T12:12:15" />
    <UpdateTime time="1758967935" timeString="2025-09-27T12:12:15" rev="1" />
    <Thumb width="256" height="192" bin="thumb" />
    <Snaps />
    <Guides />
    <ICCProfiles enabled="false" cmykView="false" blackPoint="true" renderingIntent="perceptual" />
    <Layers active="1">
        <Layer ofsx="0" ofsy="0" width="1600" height="1200" mode="normal" alpha="255" visible="true" protectAlpha="false" locked="false" clipping="false" masking="false" maskingType="0" group="-1" id="0" draft="false" parentId="-1" name="Ebene1" binType="2" bin="layer0img" type="32bpp" />
        <Layer ofsx="0" ofsy="0" width="1600" height="1200" mode="normal" alpha="255" visible="true" protectAlpha="false" locked="false" clipping="false" masking="false" maskingType="0" group="-1" id="1" draft="false" parentId="-1" name="Ebene2" binType="2" bin="layer1img" type="32bpp" />
    </Layers>
    <appInfo name="MediBang Paint Pro" rev="92" bitType="64" />
</Mdiapp>
```

The relevant bits are the `Thumb` element and its attributes as well as the amount of `Layer` elements.

After the XML comes the `MDIBIN` which holds the embedded thumbnail as well as the actual project data.
The `MDIBIN` contains with a 132-byte `TPackerHeader` followed by a blob of data whose length is specified in the header.
This repeats for each layer as well as the thumbnail.

The `TPackerHeader` looks like this
```c
struct TPackerHeader {
    char identifier[4]; // 'PAC '

    unsigned long chunkSIze; // Size of the TPackerHeader and layer / thumbnail data
    unsigned long streamType; // 0 for uncompressed, 1 for zlib
    unsigned long streamSize; // Size of the layer / thumbnail data
    unsigned long outSize; // Size after decompression

    unsigned char reserved[48]; // Buffer, all 0
    unsigned char archiveName[64]; // Name of the layer, padded. The one of the thumbnail is called "thumb", otherwise it's the layer's "bin" attribute from the xml header.
}
```

The thumbnail is stored as a continious blob of BGRA image data whose dimensions are specified in the attributes of the `Thumb` element in the XML header.

I _think_ the thumbnail is always the first block in the `MDIBIN`, but I couldn't find anything explicitly saying so.

While the thumbnail is in BGRA, it doesn't seem to store any transparency data. It always shows up with a solid white background, even in Windows explorer.
<img width="294" height="295" alt="explorer" src="https://github.com/user-attachments/assets/734a3cf5-8975-4372-bdcc-48931696872d" />

I also wanted to document the format in the code, but I always ended up with a docstring several times the size of the actual implementation, so I left it out.

#### Before
<img width="1315" height="768" alt="before" src="https://github.com/user-attachments/assets/819b470b-e23d-4ca2-af37-7911a5c28803" />

#### After
<img width="1319" height="768" alt="after" src="https://github.com/user-attachments/assets/1cd1da87-cf85-4a53-967c-40c99f9fa2bf" />

#### Sources for the file format
I Got most of the info from [this repo](https://github.com/rsuzaki/mdp_format/wiki). It gets one thig wrong, namely the color mode of the thumbnail. It claims its in ARGB, when it's actually in BGRA. I found that out via [this GIMP plugin for `.mdp` files](https://github.com/weeb-poly/gimp-file-mdp-plugin/blob/main/src/file-mdp-thumb-load.c#L73)

#### File used for testing
[layers-color-transparency.zip](https://github.com/user-attachments/files/22581913/layers-color-transparency.zip)
Zipped because of GitHub upload limitations,

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
