### PR TITLE
Feat: Add TRUE and FALSE as search terms

### DIFF
--- a/src/tagstudio/core/library/alchemy/visitors.py
+++ b/src/tagstudio/core/library/alchemy/visitors.py
@@ -6,7 +6,7 @@ import re
 from typing import TYPE_CHECKING, override
 
 import structlog
-from sqlalchemy import ColumnElement, and_, distinct, func, or_, select
+from sqlalchemy import ColumnElement, and_, distinct, false, func, or_, select, true
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.operators import ilike_op
 
@@ -18,6 +18,7 @@ from tagstudio.core.query_lang.ast import (
     AST,
     ANDList,
     BaseVisitor,
+    Boolean,
     Constraint,
     ConstraintType,
     Not,
@@ -115,6 +116,12 @@ class SQLBoolExpressionBuilder(BaseVisitor[ColumnElement[bool]]):
     @override
     def visit_property(self, node: Property) -> ColumnElement[bool]:  # type: ignore
         raise NotImplementedError("This should never be reached!")
+
+    def visit_boolean(self, node: Boolean) -> ColumnElement[bool]:
+        if node.value:
+            return true()
+        else:
+            return false()
 
     @override
     def visit_not(self, node: Not) -> ColumnElement[bool]:  # type: ignore

--- a/src/tagstudio/core/query_lang/ast.py
+++ b/src/tagstudio/core/query_lang/ast.py
@@ -94,6 +94,12 @@ class Not(AST):
         super().__init__()
         self.child = child
 
+class Boolean(AST):
+    value: bool
+
+    def __init__(self, value: bool) -> None:
+        super().__init__()
+        self.value = value
 
 T = TypeVar("T")
 
@@ -110,6 +116,8 @@ class BaseVisitor(ABC, Generic[T]):
             return self.visit_property(node)
         elif isinstance(node, Not):
             return self.visit_not(node)
+        elif isinstance(node, Boolean):
+            return self.visit_boolean(node)
         raise Exception(f"Unknown Node Type of {node}")  # pragma: nocover
 
     @abstractmethod
@@ -130,4 +138,8 @@ class BaseVisitor(ABC, Generic[T]):
 
     @abstractmethod
     def visit_not(self, node: Not) -> T:
+        raise NotImplementedError()  # pragma: nocover
+
+    @abstractmethod
+    def visit_boolean(self, node: Boolean) -> T:
         raise NotImplementedError()  # pragma: nocover

--- a/src/tagstudio/core/query_lang/parser.py
+++ b/src/tagstudio/core/query_lang/parser.py
@@ -6,6 +6,7 @@
 from tagstudio.core.query_lang.ast import (
     AST,
     ANDList,
+    Boolean,
     Constraint,
     ConstraintType,
     Not,
@@ -81,6 +82,12 @@ class Parser:
             if isinstance(term, Not):  # instead of Not(Not(child)) return child
                 return term.child
             return Not(term)
+        if self.__is_next_true():
+            self.__eat(TokenType.ULITERAL)
+            return Boolean(value = True)
+        if self.__is_next_false():
+            self.__eat(TokenType.ULITERAL)
+            return Boolean(value = False)
         if self.next_token.type == TokenType.RBRACKETO:
             self.__eat(TokenType.RBRACKETO)
             out = self.__or_list()
@@ -91,6 +98,18 @@ class Parser:
 
     def __is_next_not(self) -> bool:
         return self.next_token.type == TokenType.ULITERAL and self.next_token.value.upper() == "NOT"  # pyright: ignore
+
+    def __is_next_true(self) -> bool:
+        return (
+            self.next_token.type == TokenType.ULITERAL
+            and self.next_token.value.upper() == "TRUE"  # pyright: ignore
+        )
+
+    def __is_next_false(self) -> bool:
+        return (
+            self.next_token.type == TokenType.ULITERAL
+            and self.next_token.value.upper() == "TRUE"  # pyright: ignore
+        )
 
     def __constraint(self) -> Constraint:
         if self.next_token.type == TokenType.CONSTRAINTTYPE:


### PR DESCRIPTION
### Summary

This was to meet this feature request: https://github.com/TagStudioDev/TagStudio/issues/1142
To allow for TRUE and FALSE as keywords in the search bar.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [X] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [X] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
