### PR TITLE
fix(nix): replace wrapGAppsHook with wrapGAppsHook3

### DIFF
--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -6,7 +6,7 @@
   qt6,
   ripgrep,
   stdenv,
-  wrapGAppsHook,
+  wrapGAppsHook3,
 
   pillow-jxl-plugin,
 
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication {
     # Should be unnecessary once PR is pulled.
     # PR: https://github.com/NixOS/nixpkgs/pull/271037
     # Issue: https://github.com/NixOS/nixpkgs/issues/149812
-    wrapGAppsHook
+    wrapGAppsHook3
   ];
   buildInputs = [
     qt6.qtbase

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -51,7 +51,7 @@ let
       # Should be unnecessary once PR is pulled.
       # PR: https://github.com/NixOS/nixpkgs/pull/271037
       # Issue: https://github.com/NixOS/nixpkgs/issues/149812
-      wrapGAppsHook
+      wrapGAppsHook3
     ];
     buildInputs = with pkgs.qt6; [
       qtbase


### PR DESCRIPTION
### Summary

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

Replaces all occurrences of wrapGAppsHook with wrapGAppsHook3.

wrapGAppsHook has been aliased to wrapGAppsHook3 for a long time (since NixOS/nixpkgs#307077). Recently (NixOS/nixpkgs#456065) this alias was converted to a throw, breaking the build with newer nixpkgs versions.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
