### PR TITLE
fix(Mirror Entries): repaired Entry mirroring (#1197)

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -1898,20 +1898,33 @@ class Library:
         """Mirror fields among multiple Entry items."""
         fields = {}
         # load all fields
-        existing_fields = {field.type_key for field in entries[0].fields}
         for entry in entries:
             for entry_field in entry.fields:
                 fields[entry_field.type_key] = entry_field
 
-        # assign the field to all entries
+        # assign the fields to all entries
         for entry in entries:
             for field_key, field in fields.items():  # pyright: ignore[reportUnknownVariableType]
+                existing_fields = {entry_field.type_key for entry_field in entry.fields}
                 if field_key not in existing_fields:
                     self.add_field_to_entry(
                         entry_id=entry.id,
                         field_id=field.type_key,
                         value=field.value,
                     )
+
+    def mirror_entry_tags(self, *entries: Entry) -> None:
+        """Mirror tags among multiple Entry items."""
+        tag_ids_set = set()
+        entry_ids = []
+        # load all entries and tags
+        for entry in entries:
+            entry_ids.append(entry.id)
+            for tag in entry.tags:
+                tag_ids_set.add(tag.id)
+        tag_ids = list(tag_ids_set)
+        # assign the tags to all entries
+        self.add_tags_to_entries(entry_ids, tag_ids)
 
     def merge_entries(self, from_entry: Entry, into_entry: Entry) -> bool:
         """Add fields and tags from the first entry to the second, and then delete the first."""

--- a/src/tagstudio/core/library/alchemy/registries/dupe_files_registry.py
+++ b/src/tagstudio/core/library/alchemy/registries/dupe_files_registry.py
@@ -49,18 +49,29 @@ class DupeFilesRegistry:
                         path_relative = file_path.relative_to(library_dir)
                     except ValueError:
                         # The file is not in the library directory
+                        logger.error("File not in library directory", file_path=file_path)
                         continue
 
                     results = self.library.search_library(
                         BrowsingState.from_path(path_relative), 500
                     )
-                    entries = self.library.get_entries(results.ids)
 
                     if not results:
                         # file not in library
+                        logger.error("No Entry matching file", path_relative=path_relative)
                         continue
 
-                    files.append(entries[0])
+                    entry = self.library.get_entry_full(results.ids[0])
+
+                    if not entry:
+                        # file not in library
+                        logger.error(
+                            "Unable to get entry",
+                            entry_id=results.ids[0],
+                            path_relative=path_relative,
+                        )
+                        continue
+                    files.append(entry)
 
                 if not len(files) > 1:
                     # only one file in the group, nothing to do

--- a/src/tagstudio/qt/mixed/mirror_entries_modal.py
+++ b/src/tagstudio/qt/mixed/mirror_entries_modal.py
@@ -95,6 +95,8 @@ class MirrorEntriesModal(QWidget):
         mirrored: list = []
         lib = self.driver.lib
         for i, entries in enumerate(self.tracker.groups):
+            # mirror tags and fields
+            lib.mirror_entry_tags(*entries)
             lib.mirror_entry_fields(*entries)
             sleep(0.005)
             yield i


### PR DESCRIPTION
### Summary

Closes #1197

Tags and fields are now correctly mirrored across Entries when clicking the _Mirror Entries_ button in the _Fix Duplicate Files_ menu 

 - Updated DupeFilesRegistry method refresh_dupe_files() to use library.get_entry_full() in _dupe_files_registry.py_
 _entries previously returned with get_entries() were incomplete and causing errors later down the line_
 - Created mirror_entry_tags() in _library.py_
 - fixed mirror_entry_fields() in _library.py_
 _field mirroring was inconsistent, skipping all fields present on the reference Entry. Now, already present fields are skipped on a per-Entry basis._
 - updated mirror_entries_runnable() to also call lib.mirror_entry_tags() in _mirror_entries_modal.py_

NOTE: this will be difficult to test until #1196 is fixed. See [my thread](https://discord.com/channels/1229183630228848661/1436449668413263953/1436457499204128899) in discord for a quick hack to get around that bug and be able to test the functionality of the changes in this PR.


<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
