### PR TITLE
fix: call ripgrep with explicit utf-8 encoding.

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -40,6 +40,7 @@ jobs:
             libxcb-xinerama0 \
             libxkbcommon-x11-0 \
             libyaml-dev \
+            ripgrep \
             x11-utils
 
       - name: Execute pytest

--- a/src/tagstudio/core/library/refresh.py
+++ b/src/tagstudio/core/library/refresh.py
@@ -105,8 +105,8 @@ class RefreshTracker:
                 ),
                 cwd=library_dir,
                 capture_output=True,
-                text=True,
                 shell=True,
+                encoding="UTF-8",
             )
             compiled_ignore_path.unlink()
 

--- a/tests/macros/test_refresh_dir.py
+++ b/tests/macros/test_refresh_dir.py
@@ -2,6 +2,7 @@
 # Licensed under the GPL-3.0 License.
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
+import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -29,3 +30,25 @@ def test_refresh_new_files(library: Library, exclude_mode: bool):
     # Test if the single file was added
     list(registry.refresh_dir(library_dir, force_internal_tools=True))
     assert registry.files_not_in_library == [Path("FOO.MD")]
+
+
+@pytest.mark.parametrize("library", [TemporaryDirectory()], indirect=True)
+def test_refresh_multi_byte_filenames_ripgrep(library: Library):
+    assert shutil.which("rg") is not None
+
+    library_dir = unwrap(library.library_dir)
+    # Given
+    registry = RefreshTracker(library=library)
+    library.included_files.clear()
+    (library_dir / ".TagStudio").mkdir()
+    (library_dir / "こんにちは.txt").touch()
+    (library_dir / "em–dash.txt").touch()
+    (library_dir / "apostrophe’.txt").touch()
+    (library_dir / "umlaute äöü.txt").touch()
+
+    # Test if all files were added with their correct names and without exceptions
+    list(registry.refresh_dir(library_dir))
+    assert Path("こんにちは.txt") in registry.files_not_in_library
+    assert Path("em–dash.txt") in registry.files_not_in_library
+    assert Path("apostrophe’.txt") in registry.files_not_in_library
+    assert Path("umlaute äöü.txt") in registry.files_not_in_library


### PR DESCRIPTION
### Summary

Call ripgrep with explicit `UTF-8` encoding to prevent issues with multi-byte characters.

When calling `subprocess.Popen`, (which is where `silent_subprocess::silent_run` eventually ends up) with `text=True`[ without specifying the encoding](https://github.com/python/cpython/blob/3.12/Lib/subprocess.py#L876-L877), python will use the encoding returned by `locale::getencoding`.

On Linux this returns `UTF-8` while on Windows it will return `cp1252` which causes issues with multi-byte characters like em dashes or Japanese characters.
<img width="278" height="191" alt="linux" src="https://github.com/user-attachments/assets/6f281cdd-a0ae-4b60-9b8c-4cfd813bfa93" />
<img width="377" height="175" alt="win" src="https://github.com/user-attachments/assets/f0909271-e0b1-4732-adb1-9eb2820388e5" />

Fixes https://github.com/TagStudioDev/TagStudio/issues/1195.

#### Before
<img width="1311" height="766" alt="before" src="https://github.com/user-attachments/assets/017d9ad2-2cfd-4ae2-9a08-66421f27602a" />

I've omitted `こんにちは.txt` from the screenshot since it hangs the program with the error reported in https://github.com/TagStudioDev/TagStudio/issues/1195

#### After
<img width="1315" height="765" alt="after" src="https://github.com/user-attachments/assets/737ae84b-def1-4cc0-aa2d-75fef3d11653" />

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
