### PR TITLE
feat: add windows runner for pytest 

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -68,25 +68,9 @@ jobs:
         run: |
           choco install ripgrep
 
-      - &pytest
-        name: Execute pytest
+      - name: Execute pytest
         run: |
           pytest
-
-  pytest-macos:
-    name: Run pytest (macOS)
-    runs-on: macos-15
-
-    steps:
-      - *checkout
-      - *setup-python
-      - *install-dependencies
-
-      - name: Install system dependencies
-        run: |
-          brew install ripgrep
-
-      - *pytest
 
   coverage:
     name: Check coverage


### PR DESCRIPTION
### Summary

As discussed on discord, run pytest on Windows and macOS.

I haven't added `ripgrep` to the list of installed Linux packages, since that will be handled by https://github.com/TagStudioDev/TagStudio/pull/1199.

I've omitted the coverage check from the new jobs since the result is the same across all jobs.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
