### PR TITLE
feat(thumbnail grid): arrow key navigation & selection history 

### DIFF
--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -429,7 +429,7 @@ class QtDriver(DriverMixin, QObject):
         self.main_window.menu_bar.select_inverse_action.triggered.connect(
             self.select_inverse_action_callback
         )
-        
+
         self.main_window.menu_bar.undo_selection_action.triggered.connect(
             self.undo_selection_action_callback
         )

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -429,6 +429,14 @@ class QtDriver(DriverMixin, QObject):
         self.main_window.menu_bar.select_inverse_action.triggered.connect(
             self.select_inverse_action_callback
         )
+        
+        self.main_window.menu_bar.undo_selection_action.triggered.connect(
+            self.undo_selection_action_callback
+        )
+
+        self.main_window.menu_bar.redo_selection_action.triggered.connect(
+            self.redo_selection_action_callback
+        )
 
         self.main_window.menu_bar.clear_select_action.triggered.connect(
             self.clear_select_action_callback
@@ -851,6 +859,20 @@ class QtDriver(DriverMixin, QObject):
         selected = self.selected
         self.main_window.thumb_layout.add_tags(selected, tag_ids)
         self.lib.add_tags_to_entries(selected, tag_ids)
+
+    def undo_selection_action_callback(self):
+        """Undo most recent selection change."""
+        self.main_window.thumb_layout.undo_selection()
+        self.set_clipboard_menu_viability()
+        self.set_select_actions_visibility()
+        self.main_window.preview_panel.set_selection(self.selected, update_preview=True)
+
+    def redo_selection_action_callback(self):
+        """Redo most recent selection undo."""
+        self.main_window.thumb_layout.redo_selection()
+        self.set_clipboard_menu_viability()
+        self.set_select_actions_visibility()
+        self.main_window.preview_panel.set_selection(self.selected, update_preview=True)
 
     def delete_files_callback(self, origin_path: str | Path, origin_id: int | None = None):
         """Callback to send on or more files to the system trash.

--- a/src/tagstudio/qt/views/main_window.py
+++ b/src/tagstudio/qt/views/main_window.py
@@ -11,7 +11,7 @@ import structlog
 from PIL import Image, ImageQt
 from PySide6 import QtCore
 from PySide6.QtCore import QMetaObject, QSize, QStringListModel, Qt
-from PySide6.QtGui import QAction, QPixmap, QKeyEvent
+from PySide6.QtGui import QAction, QKeyEvent, QPixmap
 from PySide6.QtWidgets import (
     QComboBox,
     QCompleter,
@@ -218,9 +218,7 @@ class MainMenuBar(QMenuBar):
         self.edit_menu.addAction(self.select_inverse_action)
 
         # Undo Selection
-        self.undo_selection_action = QAction(
-            Translations["select.undo"], self
-        )
+        self.undo_selection_action = QAction(Translations["select.undo"], self)
         self.undo_selection_action.setShortcut(
             QtCore.QKeyCombination(
                 QtCore.Qt.Key.Key_R,
@@ -230,9 +228,7 @@ class MainMenuBar(QMenuBar):
         self.edit_menu.addAction(self.undo_selection_action)
 
         # Redo Selection
-        self.redo_selection_action = QAction(
-            Translations["select.redo"], self
-        )
+        self.redo_selection_action = QAction(Translations["select.redo"], self)
         self.redo_selection_action.setShortcut(
             QtCore.QKeyCombination(
                 QtCore.Qt.KeyboardModifier(QtCore.Qt.KeyboardModifier.ShiftModifier),
@@ -717,8 +713,8 @@ class MainWindow(QMainWindow):
 
     # endregion
 
-    #keyboard navigation of thumb_layout
-    def eventFilter(self, watched, event):
+    @typing.override
+    def eventFilter(self, watched, event) -> bool:
         if isinstance(event, QKeyEvent):
             key = event.key()
             # KEY RELEASED
@@ -746,7 +742,6 @@ class MainWindow(QMainWindow):
                     self.preview_panel.set_selection(selected, update_preview=True)
                     return True
         return super().eventFilter(watched, event)
-    
 
     def toggle_landing_page(self, enabled: bool):
         if enabled:

--- a/src/tagstudio/qt/views/main_window.py
+++ b/src/tagstudio/qt/views/main_window.py
@@ -716,31 +716,34 @@ class MainWindow(QMainWindow):
     @typing.override
     def eventFilter(self, watched, event) -> bool:
         if isinstance(event, QKeyEvent):
-            key = event.key()
-            # KEY RELEASED
+            # Key released
             if event.type() == event.Type.KeyRelease:
-                if key == QtCore.Qt.Key.Key_Shift:
-                    self.thumb_layout.handle_shift_key_event(is_shift_key_pressed=False)
-            # KEY PRESSED
+                match event.key():
+                    case QtCore.Qt.Key.Key_Shift:
+                        self.thumb_layout.handle_shift_key_event(is_shift_key_pressed=False)
+
+            # Key pressed
             else:
-                if key == QtCore.Qt.Key.Key_Shift:
-                    self.thumb_layout.handle_shift_key_event(is_shift_key_pressed=True)
-                elif key == QtCore.Qt.Key.Key_Right:
-                    selected = self.thumb_layout.select_next()
-                    self.preview_panel.set_selection(selected, update_preview=True)
-                    return True
-                elif key == QtCore.Qt.Key.Key_Left:
-                    selected = self.thumb_layout.select_prev()
-                    self.preview_panel.set_selection(selected, update_preview=True)
-                    return True
-                elif key == QtCore.Qt.Key.Key_Up:
-                    selected = self.thumb_layout.select_up()
-                    self.preview_panel.set_selection(selected, update_preview=True)
-                    return True
-                elif key == QtCore.Qt.Key.Key_Down:
-                    selected = self.thumb_layout.select_down()
-                    self.preview_panel.set_selection(selected, update_preview=True)
-                    return True
+                match event.key():
+                    case QtCore.Qt.Key.Key_Shift:
+                        self.thumb_layout.handle_shift_key_event(is_shift_key_pressed=True)
+                    case QtCore.Qt.Key.Key_Right:
+                        selected = self.thumb_layout.select_next()
+                        self.preview_panel.set_selection(selected, update_preview=True)
+                        return True
+                    case QtCore.Qt.Key.Key_Left:
+                        selected = self.thumb_layout.select_prev()
+                        self.preview_panel.set_selection(selected, update_preview=True)
+                        return True
+                    case QtCore.Qt.Key.Key_Up:
+                        selected = self.thumb_layout.select_up()
+                        self.preview_panel.set_selection(selected, update_preview=True)
+                        return True
+                    case QtCore.Qt.Key.Key_Down:
+                        selected = self.thumb_layout.select_down()
+                        self.preview_panel.set_selection(selected, update_preview=True)
+                        return True
+
         return super().eventFilter(watched, event)
 
     def toggle_landing_page(self, enabled: bool):

--- a/src/tagstudio/resources/translations/en.json
+++ b/src/tagstudio/resources/translations/en.json
@@ -254,6 +254,8 @@
     "select.all": "Select All",
     "select.clear": "Clear Selection",
     "select.inverse": "Invert Selection",
+    "select.undo": "Undo Selection",
+    "select.redo": "Redo Selection",
     "settings.clear_thumb_cache.title": "Clear Thumbnail Cache",
     "settings.dateformat.english": "English",
     "settings.dateformat.international": "International",


### PR DESCRIPTION
- Added arrow key navigation for thumbnail grid #226
- Implemented selection history with undo/redo #1215

### Summary

#### Arrow key navigation
Arrow keys events in MainWindow are intercepted by an eventFilter and trigger callbacks in ThumbGridLayout. Shift key events are also intercepted but do not block the event from continuing down Qt's event pipeline. Arrow key navigation mimics the behaviour of windows file explorer as outlined in #226, including multi-selection.
closes #226 

#### Selection history
The last 30 (number chosen arbitrarily) selections are stored in a deque. Hitting R pops the most recent selection from the deque, and pushes the current selection to a second deque for redo-ing. Hitting Shift+R pops from the redo deque. It's very satisfying to use (I may be biased)
This feature could later be included into a higher level history, see #1215 for the full discussion !
Selection state changes are saved in the deques via a decorator for methods that modify the selection.
Because that includes the methods used for arrow key navigation, I wasn't able to cleanly separate these two features into two PRs... Sorry 😅


<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
