### PR TITLE
fix: 'Add Tag to Selected' action fails

### DIFF
--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -370,7 +370,7 @@ class QtDriver(DriverMixin, QObject):
         self.add_tag_modal.tsp.set_driver(self)
         self.add_tag_modal.tsp.tag_chosen.connect(
             lambda t, s=self.selected: (
-                self.add_tags_to_selected_callback(t),
+                self.add_tags_to_selected_callback([t]),
                 self.main_window.preview_panel.set_selection(s),
             )
         )
@@ -848,7 +848,7 @@ class QtDriver(DriverMixin, QObject):
         self.main_window.preview_panel.set_selection(self.selected)
 
     def add_tags_to_selected_callback(self, tag_ids: list[int]):
-        selected = self.selected
+        selected: list[int] = self.selected
         self.main_window.thumb_layout.add_tags(selected, tag_ids)
         self.lib.add_tags_to_entries(selected, tag_ids)
 


### PR DESCRIPTION
### Summary
Fixes a bug where using the 'Edit > Add Tag to Selected' action would fail and not add the chosen tag.

Was brought up in https://discord.com/channels/1229183630228848661/1229309667528806420/1442232941509083197.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
