### PR TITLE
fix: errors in DupeFilesRegistry

### DIFF
--- a/src/tagstudio/core/library/alchemy/registries/dupe_files_registry.py
+++ b/src/tagstudio/core/library/alchemy/registries/dupe_files_registry.py
@@ -7,6 +7,7 @@ import structlog
 from tagstudio.core.library.alchemy.enums import BrowsingState
 from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.models import Entry
+from tagstudio.core.utils.types import unwrap
 
 logger = structlog.get_logger()
 
@@ -28,7 +29,7 @@ class DupeFilesRegistry:
         A duplicate file is defined as an identical or near-identical file as determined
         by a DupeGuru results file.
         """
-        library_dir = self.library.library_dir
+        library_dir = unwrap(self.library.library_dir)
         if not isinstance(results_filepath, Path):
             results_filepath = Path(results_filepath)
 
@@ -43,7 +44,7 @@ class DupeFilesRegistry:
             files: list[Entry] = []
             for element in group:
                 if element.tag == "file":
-                    file_path = Path(element.attrib.get("path"))
+                    file_path = Path(unwrap(element.attrib.get("path")))
 
                     try:
                         path_relative = file_path.relative_to(library_dir)
@@ -82,5 +83,5 @@ class DupeFilesRegistry:
         for i, entries in enumerate(self.groups):
             remove_ids = entries[1:]
             logger.info("Removing entries group", ids=remove_ids)
-            self.library.remove_entries(remove_ids)
+            self.library.remove_entries([e.id for e in remove_ids])
             yield i - 1  # The -1 waits for the next step to finish


### PR DESCRIPTION
### Summary
Progress towards #1061 and #1232 by fixing the errors in DupeFilesRegistry.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
