### PR TITLE
fix: tab order in build_tag modal

### DIFF
--- a/src/tagstudio/core/utils/silent_subprocess.py
+++ b/src/tagstudio/core/utils/silent_subprocess.py
@@ -2,8 +2,6 @@
 # Licensed under the GPL-3.0 License.
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
-# pyright: reportExplicitAny=false
-
 import os
 import subprocess
 import sys

--- a/src/tagstudio/qt/mixed/build_tag.py
+++ b/src/tagstudio/qt/mixed/build_tag.py
@@ -522,7 +522,7 @@ class BuildTagPanel(PanelWidget):
 
         self.alias_names.clear()
 
-        last: QWidget = self.panel_save_button
+        last: QWidget | None = self.panel_save_button
         for alias_id in self.alias_ids:
             alias = self.lib.get_alias(self.tag.id, alias_id)
 
@@ -549,7 +549,8 @@ class BuildTagPanel(PanelWidget):
             self.aliases_table.setCellWidget(row, 1, new_item)
             self.aliases_table.setCellWidget(row, 0, remove_btn)
 
-            self.setTabOrder(last, self.aliases_table.cellWidget(row, 1))
+            if last is not None:
+                self.setTabOrder(last, self.aliases_table.cellWidget(row, 1))
             self.setTabOrder(
                 self.aliases_table.cellWidget(row, 1), self.aliases_table.cellWidget(row, 0)
             )
@@ -624,3 +625,4 @@ class BuildTagPanel(PanelWidget):
         self.setTabOrder(unwrap(self.panel_save_button), self.aliases_table.cellWidget(0, 1))
         self.name_field.selectAll()
         self.name_field.setFocus()
+        self._set_aliases()


### PR DESCRIPTION
### Summary

Previously the tab order in the BuildTag Modal was broken.

This is now fixed and a pyright error accompanying it was also fixes (progress on #1061 and #1232).

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
