### PR TITLE
fix: pyright errors in blender_renderer.py

### DIFF
--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -780,25 +780,17 @@ class ThumbRenderer(QObject):
         )
         im: Image.Image | None = None
         try:
-            blend_image = blend_thumb(str(filepath))
-
-            bg = Image.new("RGB", blend_image.size, color=bg_color)
-            bg.paste(blend_image, mask=blend_image.getchannel(3))
-            im = bg
-
-        except (
-            AttributeError,
-            UnidentifiedImageError,
-            TypeError,
-        ) as e:
-            if str(e) == "expected string or buffer":
+            if (blend_image := blend_thumb(str(filepath))) is not None:
+                bg = Image.new("RGB", blend_image.size, color=bg_color)
+                bg.paste(blend_image, mask=blend_image.getchannel(3))
+                im = bg
+            else:
                 logger.info(
                     f"[ThumbRenderer][BLENDER][INFO] {filepath.name} "
-                    f"Doesn't have an embedded thumbnail. ({type(e).__name__})"
+                    "Doesn't have an embedded thumbnail."
                 )
-
-            else:
-                logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
+        except Exception as e:
+            logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
         return im
 
     @staticmethod

--- a/src/tagstudio/qt/previews/vendored/blender_renderer.py
+++ b/src/tagstudio/qt/previews/vendored/blender_renderer.py
@@ -32,7 +32,7 @@ from io import BufferedReader
 from PIL import Image, ImageOps
 
 
-def blend_extract_thumb(path):
+def blend_extract_thumb(path) -> tuple[bytes | None, int, int]:
     rend = b"REND"
     test = b"TEST"
 
@@ -97,8 +97,10 @@ def blend_extract_thumb(path):
     return image_buffer, x, y
 
 
-def blend_thumb(file_in):
+def blend_thumb(file_in) -> Image.Image | None:
     buf, width, height = blend_extract_thumb(file_in)
+    if buf is None:
+        return None
     image = Image.frombuffer(
         "RGBA",
         (width, height),

--- a/src/tagstudio/qt/thumb_grid_layout.py
+++ b/src/tagstudio/qt/thumb_grid_layout.py
@@ -383,7 +383,7 @@ class ThumbGridLayout(QLayout):
     @override
     def itemAt(self, index: int) -> QLayoutItem:
         if index >= len(self._items):
-            return None
+            return None  # pyright: ignore[reportReturnType]
         return self._items[index]
 
     @override


### PR DESCRIPTION
### Summary

Progress towards #1061 and #1232 by fixing the errors in blender_renderer.py.

NOTE: I can confirm that blender thumbnails still work, however, I don't have a `.blend` file without a thumbnail (and couldn't figure out how to create one) so I wasn't able to test that.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable
