### PR TITLE
fix: use optimized SQL when selecting non-hidden entries

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -1041,7 +1041,11 @@ class Library:
             ast = search.ast
 
             if not search.show_hidden_entries:
-                statement = statement.where(~Entry.tags.any(Tag.is_hidden))
+                hidden_tag_ids = select(Tag.id).where(Tag.is_hidden)
+                hidden_entry_ids = select(TagEntry.entry_id).where(
+                    TagEntry.tag_id.in_(hidden_tag_ids)
+                )
+                statement = statement.where(Entry.id.not_in(hidden_entry_ids))
 
             if ast:
                 start_time = time.time()


### PR DESCRIPTION
### Summary

This fixes #1239 by rewriting the sqlalchemy code that fetches non-hidden entries. Such that references to the main query are no longer used in the sub-query. This is done in 2 steps:
1. A sub-query that selects all the entry ids with hidden tags by joining TagEntry and Tag.
2. Select all entries where they have that id
This is done by first querying all tags that are hidden and joining with the TagEntry binding table and selecting only the entry ids.

Previous generated SQL for simple query:
```sql
SELECT DISTINCT entries.id
FROM entries
WHERE NOT (EXISTS (SELECT 1 
    FROM tags, tag_entries 
    WHERE entries.id = tag_entries.entry_id AND tags.id = tag_entries.tag_id AND tags.is_hidden)) 
ORDER BY entries.id DESC
```

New SQL (edited to match current version):
```sql
SELECT DISTINCT entries.id 
FROM entries 
WHERE NOT 
    (entries.id IN 
        (SELECT tag_entries.entry_id 
        FROM tag_entries 
        WHERE tag_entries.tag_id IN (SELECT tags.id from tags WHERE tags.is_hidden)) 
ORDER BY entries.id DESC
```

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
Reused existing tests, as this should be a "do the same but faster"
