### PR TITLE
fix: update thumb grid when adding tags from preview panel

### DIFF
--- a/src/tagstudio/qt/mixed/field_containers.py
+++ b/src/tagstudio/qt/mixed/field_containers.py
@@ -234,11 +234,7 @@ class FieldContainers(QWidget):
             selected=self.driver.selected,
             tags=tags,
         )
-        self.lib.add_tags_to_entries(
-            self.driver.selected,
-            tag_ids=tags,
-        )
-        self.driver.emit_badge_signals(tags, emit_on_absent=False)
+        self.driver.add_tags_to_selected_callback(tags)
 
     def write_container(self, index: int, field: BaseField, is_mixed: bool = False):
         """Update/Create data for a FieldContainer.

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -875,7 +875,7 @@ class QtDriver(DriverMixin, QObject):
         selected: list[int] = self.selected
         self.main_window.thumb_layout.add_tags(selected, tag_ids)
         self.lib.add_tags_to_entries(selected, tag_ids)
-        self.emit_badge_signals(tag_ids)
+        self.emit_badge_signals(tag_ids, emit_on_absent=False)
 
     def delete_files_callback(self, origin_path: str | Path, origin_id: int | None = None):
         """Callback to send on or more files to the system trash.


### PR DESCRIPTION
### Summary
Fix #1228 
The internal cache the thumbnail grid uses for badges was not being update when adding tags through the preview panel.

Changed the call to `emit_badge_signals` when adding tags to have `emit_on_absent=False` since it's only needed when removing tags.

### Tasks Completed
-   Platforms Tested:
    -   [x] Linux x86
-   Tested For:
    -   [x] Basic functionality
