### PR TITLE
feat: Add hierarchical tag grouping with collapsible headers

### DIFF
--- a/src/tagstudio/core/library/alchemy/enums.py
+++ b/src/tagstudio/core/library/alchemy/enums.py
@@ -86,6 +86,9 @@ class BrowsingState:
 
     query: str | None = None
 
+    # Tag-based grouping (None = no grouping, int = group by tag ID)
+    group_by_tag_id: int | None = None
+
     # Abstract Syntax Tree Of the current Search Query
     @property
     def ast(self) -> AST | None:
@@ -151,6 +154,9 @@ class BrowsingState:
 
     def with_show_hidden_entries(self, show_hidden_entries: bool) -> "BrowsingState":
         return replace(self, show_hidden_entries=show_hidden_entries)
+
+    def with_group_by_tag(self, tag_id: int | None) -> "BrowsingState":
+        return replace(self, group_by_tag_id=tag_id)
 
 
 class FieldTypeEnum(enum.Enum):

--- a/src/tagstudio/core/library/alchemy/enums.py
+++ b/src/tagstudio/core/library/alchemy/enums.py
@@ -2,11 +2,15 @@ import enum
 import random
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import structlog
 
 from tagstudio.core.query_lang.ast import AST
 from tagstudio.core.query_lang.parser import Parser
+
+if TYPE_CHECKING:
+    from tagstudio.core.library.alchemy.grouping import GroupingCriteria
 
 MAX_SQL_VARIABLES = 32766  # 32766 is the max sql bind parameter count as defined here: https://github.com/sqlite/sqlite/blob/master/src/sqliteLimit.h#L140
 
@@ -86,8 +90,8 @@ class BrowsingState:
 
     query: str | None = None
 
-    # Tag-based grouping (None = no grouping, int = group by tag ID)
-    group_by_tag_id: int | None = None
+    # Grouping criteria (None = no grouping)
+    grouping: "GroupingCriteria | None" = None
 
     # Abstract Syntax Tree Of the current Search Query
     @property
@@ -155,8 +159,16 @@ class BrowsingState:
     def with_show_hidden_entries(self, show_hidden_entries: bool) -> "BrowsingState":
         return replace(self, show_hidden_entries=show_hidden_entries)
 
+    def with_grouping(self, criteria: "GroupingCriteria | None") -> "BrowsingState":
+        return replace(self, grouping=criteria)
+
     def with_group_by_tag(self, tag_id: int | None) -> "BrowsingState":
-        return replace(self, group_by_tag_id=tag_id)
+        """Backward compatibility wrapper for tag grouping."""
+        from tagstudio.core.library.alchemy.grouping import GroupingCriteria, GroupingType
+
+        if tag_id is None:
+            return replace(self, grouping=None)
+        return replace(self, grouping=GroupingCriteria(type=GroupingType.TAG, value=tag_id))
 
 
 class FieldTypeEnum(enum.Enum):

--- a/src/tagstudio/core/library/alchemy/grouping.py
+++ b/src/tagstudio/core/library/alchemy/grouping.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2025 Travis Abendshien (CyanVoxel).
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
+
+"""Grouping strategies for organizing library entries."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tagstudio.core.library.alchemy.library import Library
+
+
+class GroupingType(Enum):
+    """Types of grouping strategies available."""
+
+    NONE = "none"
+    TAG = "tag"
+    FILETYPE = "filetype"
+
+
+@dataclass(frozen=True)
+class GroupingCriteria:
+    """Defines what to group by.
+
+    Attributes:
+        type: The type of grouping to apply.
+        value: Optional value for the grouping (e.g., tag_id for TAG type).
+    """
+
+    type: GroupingType
+    value: Any | None = None
+
+
+@dataclass(frozen=True)
+class EntryGroup:
+    """Represents a group of entries.
+
+    Attributes:
+        key: The grouping key (Tag object, filetype string, etc.).
+        entry_ids: List of entry IDs in this group.
+        is_special: Whether this is a special group (e.g., "No Tag").
+        special_label: Label for special groups.
+        metadata: Flexible metadata dict for group-specific data.
+    """
+
+    key: Any
+    entry_ids: list[int]
+    is_special: bool = False
+    special_label: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class GroupedSearchResult:
+    """Container for grouped search results.
+
+    Attributes:
+        total_count: Total number of entries across all groups.
+        groups: List of EntryGroup objects.
+    """
+
+    total_count: int
+    groups: list[EntryGroup]
+
+    @property
+    def all_entry_ids(self) -> list[int]:
+        """Flatten all entry IDs from all groups for backward compatibility."""
+        result: list[int] = []
+        for group in self.groups:
+            result.extend(group.entry_ids)
+        return result
+
+    def __bool__(self) -> bool:
+        """Boolean evaluation for the wrapper."""
+        return self.total_count > 0
+
+    def __len__(self) -> int:
+        """Return the total number of entries across all groups."""
+        return self.total_count
+
+
+class GroupingStrategy(ABC):
+    """Abstract base class for grouping implementations."""
+
+    @abstractmethod
+    def group_entries(
+        self, lib: "Library", entry_ids: list[int], criteria: GroupingCriteria
+    ) -> GroupedSearchResult:
+        """Group entries according to criteria.
+
+        Args:
+            lib: Library instance.
+            entry_ids: List of entry IDs to group.
+            criteria: Grouping criteria.
+
+        Returns:
+            GroupedSearchResult with entries organized into EntryGroup objects.
+        """
+        pass
+
+    @abstractmethod
+    def get_display_name(self, group: EntryGroup) -> str:
+        """Get display name for a group.
+
+        Args:
+            group: The entry group.
+
+        Returns:
+            Human-readable name for the group.
+        """
+        pass

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -75,6 +75,7 @@ from tagstudio.core.library.alchemy.constants import (
     DB_VERSION_LEGACY_KEY,
     JSON_FILENAME,
     SQL_FILENAME,
+    TAG_CHILDREN_ID_QUERY,
     TAG_CHILDREN_QUERY,
 )
 from tagstudio.core.library.alchemy.db import make_tables
@@ -200,6 +201,54 @@ class SearchResult:
     def __getitem__(self, index: int) -> int:
         """Allow to access ids via index directly on the wrapper."""
         return self.ids[index]
+
+
+@dataclass(frozen=True)
+class TagGroup:
+    """Represents a group of entries sharing a tag.
+
+    Attributes:
+        tag: The tag for this group (None for special groups).
+        entry_ids: List of entry IDs in this group.
+        is_special: Whether this is a special group (Multiple Tags, No Tag).
+        special_label: Label for special groups ("Multiple Tags" or "No Tag").
+        tags: Multiple tags for multi-tag combination groups (None for others).
+    """
+
+    tag: "Tag | None"
+    entry_ids: list[int]
+    is_special: bool = False
+    special_label: str | None = None
+    tags: list["Tag"] | None = None
+
+
+@dataclass(frozen=True)
+class GroupedSearchResult:
+    """Wrapper for grouped search results.
+
+    Attributes:
+        total_count: Total number of entries across all groups.
+        groups: List of TagGroup objects.
+    """
+
+    total_count: int
+    groups: list[TagGroup]
+
+    @property
+    def all_entry_ids(self) -> list[int]:
+        """Flatten all entry IDs from all groups for backward compatibility."""
+        result: list[int] = []
+        for group in self.groups:
+            result.extend(group.entry_ids)
+        return result
+
+    def __bool__(self) -> bool:
+        """Boolean evaluation for the wrapper."""
+        return self.total_count > 0
+
+    def __len__(self) -> int:
+        """Return the total number of entries across all groups."""
+        return self.total_count
 
 
 @dataclass
@@ -906,6 +955,108 @@ class Library:
             for tag_entry in session.scalars(statement).fetchall():
                 tag_entries[tag_entry.tag_id].add(tag_entry.entry_id)
         return tag_entries
+
+    def get_grouping_tag_ids(self, group_by_tag_id: int) -> set[int]:
+        """Get all tag IDs relevant to a grouping.
+
+        Args:
+            group_by_tag_id: The tag ID to get related tags for.
+
+        Returns:
+            Set of tag IDs including the tag and all its children.
+        """
+        with Session(self.engine) as session:
+            result = session.execute(TAG_CHILDREN_ID_QUERY, {"tag_id": group_by_tag_id})
+            return set(row[0] for row in result)
+
+    def group_entries_by_tag(
+        self, entry_ids: list[int], group_by_tag_id: int
+    ) -> GroupedSearchResult:
+        """Group entries by tag hierarchy.
+
+        Args:
+            entry_ids: List of entry IDs to group.
+            group_by_tag_id: The tag ID to group by.
+
+        Returns:
+            GroupedSearchResult with entries organized into TagGroup objects.
+        """
+        if not entry_ids:
+            return GroupedSearchResult(total_count=0, groups=[])
+
+        with Session(self.engine) as session:
+            result = session.execute(TAG_CHILDREN_ID_QUERY, {"tag_id": group_by_tag_id})
+            child_tag_ids = [row[0] for row in result]
+
+        tags_by_id: dict[int, Tag] = {}
+        with Session(self.engine) as session:
+            for tag in session.scalars(select(Tag).where(Tag.id.in_(child_tag_ids))):
+                tags_by_id[tag.id] = tag
+
+        tag_to_entries = self.get_tag_entries(child_tag_ids, entry_ids)
+
+        entry_to_tags: dict[int, list[int]] = {entry_id: [] for entry_id in entry_ids}
+        for tag_id, entries_with_tag in tag_to_entries.items():
+            for entry_id in entries_with_tag:
+                entry_to_tags[entry_id].append(tag_id)
+
+        tag_groups: dict[int, list[int]] = {}
+        multi_tag_groups: dict[tuple[int, ...], list[int]] = {}
+        no_tag_entries: list[int] = []
+
+        for entry_id in entry_ids:
+            tag_count = len(entry_to_tags[entry_id])
+            if tag_count == 0:
+                no_tag_entries.append(entry_id)
+            elif tag_count == 1:
+                tag_id = entry_to_tags[entry_id][0]
+                if tag_id not in tag_groups:
+                    tag_groups[tag_id] = []
+                tag_groups[tag_id].append(entry_id)
+            else:
+                tag_tuple = tuple(sorted(entry_to_tags[entry_id]))
+                if tag_tuple not in multi_tag_groups:
+                    multi_tag_groups[tag_tuple] = []
+                multi_tag_groups[tag_tuple].append(entry_id)
+
+        groups: list[TagGroup] = []
+
+        sorted_tag_ids = sorted(tag_groups.keys(), key=lambda tid: tags_by_id[tid].name.lower())
+        for tag_id in sorted_tag_ids:
+            groups.append(
+                TagGroup(
+                    tag=tags_by_id[tag_id],
+                    entry_ids=tag_groups[tag_id],
+                    is_special=False,
+                )
+            )
+
+        if multi_tag_groups:
+            all_multi_tag_entries: list[int] = []
+            for entries in multi_tag_groups.values():
+                all_multi_tag_entries.extend(entries)
+
+            groups.append(
+                TagGroup(
+                    tag=None,
+                    entry_ids=all_multi_tag_entries,
+                    is_special=True,
+                    special_label="Multiple Tags",
+                    tags=None,
+                )
+            )
+
+        if no_tag_entries:
+            groups.append(
+                TagGroup(
+                    tag=None,
+                    entry_ids=no_tag_entries,
+                    is_special=True,
+                    special_label="No Tag",
+                )
+            )
+
+        return GroupedSearchResult(total_count=len(entry_ids), groups=groups)
 
     @property
     def entries_count(self) -> int:

--- a/src/tagstudio/core/library/alchemy/models.py
+++ b/src/tagstudio/core/library/alchemy/models.py
@@ -6,7 +6,7 @@ from datetime import datetime as dt
 from pathlib import Path
 from typing import override
 
-from sqlalchemy import JSON, ForeignKey, ForeignKeyConstraint, Integer, event
+from sqlalchemy import JSON, ForeignKey, ForeignKeyConstraint, Index, Integer, event
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing_extensions import deprecated
 

--- a/src/tagstudio/core/library/alchemy/strategies.py
+++ b/src/tagstudio/core/library/alchemy/strategies.py
@@ -1,0 +1,184 @@
+# Copyright (C) 2025 Travis Abendshien (CyanVoxel).
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
+
+"""Concrete grouping strategy implementations."""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from tagstudio.core.library.alchemy.constants import TAG_CHILDREN_ID_QUERY
+from tagstudio.core.library.alchemy.grouping import (
+    EntryGroup,
+    GroupedSearchResult,
+    GroupingCriteria,
+    GroupingStrategy,
+)
+from tagstudio.core.library.alchemy.models import Entry, Tag
+
+if TYPE_CHECKING:
+    from tagstudio.core.library.alchemy.library import Library
+
+
+class TagGroupingStrategy(GroupingStrategy):
+    """Groups entries by tag hierarchy.
+
+    When grouping by a parent tag, creates one group per child tag.
+    Entries with multiple child tags appear in all applicable groups (duplicated).
+    """
+
+    def group_entries(
+        self, lib: "Library", entry_ids: list[int], criteria: GroupingCriteria
+    ) -> GroupedSearchResult:
+        """Group entries by tag hierarchy.
+
+        Args:
+            lib: Library instance.
+            entry_ids: List of entry IDs to group.
+            criteria: Grouping criteria (value should be tag_id).
+
+        Returns:
+            GroupedSearchResult with entries organized by child tags.
+        """
+        if not entry_ids:
+            return GroupedSearchResult(total_count=0, groups=[])
+
+        tag_id = criteria.value
+        if tag_id is None:
+            return GroupedSearchResult(total_count=0, groups=[])
+
+        # Get all child tag IDs (including the selected tag itself)
+        with Session(lib.engine) as session:
+            result = session.execute(TAG_CHILDREN_ID_QUERY, {"tag_id": tag_id})
+            child_tag_ids = [row[0] for row in result]
+
+        if not child_tag_ids:
+            return GroupedSearchResult(total_count=0, groups=[])
+
+        # Load tag objects
+        tags_by_id: dict[int, Tag] = {}
+        with Session(lib.engine) as session:
+            for tag in session.scalars(select(Tag).where(Tag.id.in_(child_tag_ids))):
+                tags_by_id[tag.id] = tag
+
+        # Get which entries have which tags
+        tag_to_entries = lib.get_tag_entries(child_tag_ids, entry_ids)
+
+        # Build entry -> tags mapping
+        entry_to_tags: dict[int, list[int]] = {entry_id: [] for entry_id in entry_ids}
+        for tag_id_item, entries_with_tag in tag_to_entries.items():
+            for entry_id in entries_with_tag:
+                entry_to_tags[entry_id].append(tag_id_item)
+
+        # Build groups per child tag (entries can appear in multiple groups)
+        tag_groups: dict[int, list[int]] = {}
+        no_tag_entries: list[int] = []
+
+        for entry_id in entry_ids:
+            tags_on_entry = entry_to_tags[entry_id]
+
+            if not tags_on_entry:
+                # Entry has no child tags
+                no_tag_entries.append(entry_id)
+            else:
+                # Add entry to ALL child tag groups it belongs to
+                for tag_id_item in tags_on_entry:
+                    if tag_id_item not in tag_groups:
+                        tag_groups[tag_id_item] = []
+                    tag_groups[tag_id_item].append(entry_id)
+
+        # Create EntryGroup objects
+        groups: list[EntryGroup] = []
+
+        # Sort child tags alphabetically and create groups (only for non-empty groups)
+        sorted_tag_ids = sorted(tag_groups.keys(), key=lambda tid: tags_by_id[tid].name.lower())
+        for tag_id_item in sorted_tag_ids:
+            groups.append(
+                EntryGroup(
+                    key=tags_by_id[tag_id_item],
+                    entry_ids=tag_groups[tag_id_item],
+                    is_special=False,
+                )
+            )
+
+        # Add "No Tag" group (collapsed by default)
+        if no_tag_entries:
+            groups.append(
+                EntryGroup(
+                    key=None,
+                    entry_ids=no_tag_entries,
+                    is_special=True,
+                    special_label="No Tag",
+                )
+            )
+
+        return GroupedSearchResult(total_count=len(entry_ids), groups=groups)
+
+    def get_display_name(self, group: EntryGroup) -> str:
+        """Get display name for a tag group.
+
+        Args:
+            group: The entry group.
+
+        Returns:
+            Tag name or special label.
+        """
+        if group.is_special and group.special_label:
+            return group.special_label
+        if isinstance(group.key, Tag):
+            return group.key.name
+        return str(group.key)
+
+
+class FiletypeGroupingStrategy(GroupingStrategy):
+    """Groups entries by file extension."""
+
+    def group_entries(
+        self, lib: "Library", entry_ids: list[int], criteria: GroupingCriteria
+    ) -> GroupedSearchResult:
+        """Group entries by file extension.
+
+        Args:
+            lib: Library instance.
+            entry_ids: List of entry IDs to group.
+            criteria: Grouping criteria (value not used).
+
+        Returns:
+            GroupedSearchResult with entries organized by filetype.
+        """
+        if not entry_ids:
+            return GroupedSearchResult(total_count=0, groups=[])
+
+        # Load entries
+        with Session(lib.engine) as session:
+            entries = session.scalars(select(Entry).where(Entry.id.in_(entry_ids))).all()
+
+        # Group by file extension
+        filetype_groups: dict[str, list[int]] = {}
+        for entry in entries:
+            ext = Path(entry.path).suffix.lower()
+            if not ext:
+                ext = "(no extension)"
+            filetype_groups.setdefault(ext, []).append(entry.id)
+
+        # Create EntryGroup objects sorted by extension
+        groups = [
+            EntryGroup(key=ext, entry_ids=ids) for ext, ids in sorted(filetype_groups.items())
+        ]
+
+        return GroupedSearchResult(total_count=len(entry_ids), groups=groups)
+
+    def get_display_name(self, group: EntryGroup) -> str:
+        """Get display name for a filetype group.
+
+        Args:
+            group: The entry group.
+
+        Returns:
+            File extension or label.
+        """
+        return str(group.key)

--- a/src/tagstudio/core/library/ignore.py
+++ b/src/tagstudio/core/library/ignore.py
@@ -32,6 +32,7 @@ GLOBAL_IGNORE = [
     ".Spotlight-V100",
     ".TemporaryItems",
     "desktop.ini",
+    "Thumbs.db",
     "System Volume Information",
     ".localized",
 ]

--- a/src/tagstudio/qt/controllers/preview_panel_controller.py
+++ b/src/tagstudio/qt/controllers/preview_panel_controller.py
@@ -18,6 +18,7 @@ if typing.TYPE_CHECKING:
 class PreviewPanel(PreviewPanelView):
     def __init__(self, library: Library, driver: "QtDriver"):
         super().__init__(library, driver)
+        self.__driver = driver
 
         self.__add_field_modal = AddFieldModal(self.lib)
         self.__add_tag_modal = TagSearchModal(self.lib, is_tag_chooser=True)
@@ -26,6 +27,8 @@ class PreviewPanel(PreviewPanelView):
         self.__add_field_modal.show()
 
     def _add_tag_button_callback(self):
+        # Set driver before showing to enable dropdown refresh when creating tags
+        self.__add_tag_modal.tsp.driver = self.__driver
         self.__add_tag_modal.show()
 
     def _set_selection_callback(self):

--- a/src/tagstudio/qt/controllers/tag_box_controller.py
+++ b/src/tagstudio/qt/controllers/tag_box_controller.py
@@ -67,6 +67,12 @@ class TagBoxWidget(TagBoxWidgetView):
         for entry_id in self.__entries:
             self.__driver.lib.remove_tags_from_entries(entry_id, tag.id)
 
+        group_by_tag_id = self.__driver.browsing_history.current.group_by_tag_id
+        if group_by_tag_id is not None:
+            relevant_tag_ids = self.__driver.lib.get_grouping_tag_ids(group_by_tag_id)
+            if tag.id in relevant_tag_ids:
+                self.__driver.update_browsing_state()
+
         self.on_update.emit()
 
     @override

--- a/src/tagstudio/qt/mixed/field_containers.py
+++ b/src/tagstudio/qt/mixed/field_containers.py
@@ -240,6 +240,12 @@ class FieldContainers(QWidget):
         )
         self.driver.emit_badge_signals(tags, emit_on_absent=False)
 
+        group_by_tag_id = self.driver.browsing_history.current.group_by_tag_id
+        if group_by_tag_id is not None:
+            relevant_tag_ids = self.lib.get_grouping_tag_ids(group_by_tag_id)
+            if any(tag_id in relevant_tag_ids for tag_id in tags):
+                self.driver.update_browsing_state()
+
     def write_container(self, index: int, field: BaseField, is_mixed: bool = False):
         """Update/Create data for a FieldContainer.
 

--- a/src/tagstudio/qt/mixed/group_by_tag_delegate.py
+++ b/src/tagstudio/qt/mixed/group_by_tag_delegate.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2025 Travis Abendshien (CyanVoxel).
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QModelIndex, QRect, QSize, Qt
+from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
+
+if TYPE_CHECKING:
+    from tagstudio.core.library.alchemy.library import Library
+
+
+class GroupByTagDelegate(QStyledItemDelegate):
+    """Custom delegate for rendering tags in the Group By dropdown with decorations."""
+
+    def __init__(self, library: "Library", parent=None):
+        super().__init__(parent)
+        self.library = library
+
+    def paint(
+        self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex
+    ) -> None:
+        """Paint the tag item with proper decorations."""
+        # For now, use default painting - we'll enhance this later
+        super().paint(painter, option, index)
+
+    def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:
+        """Return the size hint for the item."""
+        # For now, use default size - we'll enhance this later
+        return super().sizeHint(option, index)

--- a/src/tagstudio/qt/mixed/group_by_tag_delegate.py
+++ b/src/tagstudio/qt/mixed/group_by_tag_delegate.py
@@ -5,7 +5,7 @@
 
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QModelIndex, QRect, QSize, Qt
+from PySide6.QtCore import QModelIndex, QPersistentModelIndex, QSize
 from PySide6.QtGui import QPainter
 from PySide6.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
 
@@ -21,13 +21,18 @@ class GroupByTagDelegate(QStyledItemDelegate):
         self.library = library
 
     def paint(
-        self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        index: QModelIndex | QPersistentModelIndex,
     ) -> None:
         """Paint the tag item with proper decorations."""
         # For now, use default painting - we'll enhance this later
         super().paint(painter, option, index)
 
-    def sizeHint(self, option: QStyleOptionViewItem, index: QModelIndex) -> QSize:
+    def sizeHint(  # noqa: N802
+        self, option: QStyleOptionViewItem, index: QModelIndex | QPersistentModelIndex
+    ) -> QSize:
         """Return the size hint for the item."""
         # For now, use default size - we'll enhance this later
         return super().sizeHint(option, index)

--- a/src/tagstudio/qt/mixed/group_header.py
+++ b/src/tagstudio/qt/mixed/group_header.py
@@ -64,12 +64,7 @@ class GroupHeaderWidget(QWidget):
         self.arrow_button.setFixedSize(20, 20)
         self.arrow_button.setCursor(Qt.CursorShape.PointingHandCursor)
         self.arrow_button.setStyleSheet(
-            "QPushButton { "
-            "border: none; "
-            "text-align: center; "
-            "font-size: 12px; "
-            "padding: 0px; "
-            "}"
+            "QPushButton { border: none; text-align: center; font-size: 12px; padding: 0px; }"
         )
         self._update_arrow()
         self.arrow_button.clicked.connect(self._on_toggle)
@@ -100,9 +95,7 @@ class GroupHeaderWidget(QWidget):
             )
             self.main_layout.addWidget(self.label)
         elif tag:
-            self.tag_widget = TagWidget(
-                tag=tag, has_edit=False, has_remove=False, library=library
-            )
+            self.tag_widget = TagWidget(tag=tag, has_edit=False, has_remove=False, library=library)
             self.main_layout.addWidget(self.tag_widget)
 
         count_text = f"({entry_count} {'entry' if entry_count == 1 else 'entries'})"

--- a/src/tagstudio/qt/mixed/group_header.py
+++ b/src/tagstudio/qt/mixed/group_header.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2025 Travis Abendshien (CyanVoxel).
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
+
+from typing import TYPE_CHECKING, override
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QWidget
+
+from tagstudio.core.library.alchemy.models import Tag
+from tagstudio.qt.mixed.tag_widget import TagWidget
+
+# Only import for type checking/autocompletion, will not be imported at runtime.
+if TYPE_CHECKING:
+    from tagstudio.core.library.alchemy.library import Library
+
+
+class GroupHeaderWidget(QWidget):
+    """Collapsible header widget for tag groups."""
+
+    toggle_collapsed = Signal()
+
+    def __init__(
+        self,
+        tag: Tag | None,
+        entry_count: int,
+        is_collapsed: bool = False,
+        is_special: bool = False,
+        special_label: str | None = None,
+        library: "Library | None" = None,
+        is_first: bool = False,
+        tags: list[Tag] | None = None,
+    ) -> None:
+        """Initialize the group header widget.
+
+        Args:
+            tag: The tag for this group (None for special groups).
+            entry_count: Number of entries in this group.
+            is_collapsed: Whether the group starts collapsed.
+            is_special: Whether this is a special group.
+            special_label: Label for special groups ("Multiple Tags" or "No Tag").
+            library: Library instance for tag operations.
+            is_first: Whether this is the first group (no divider needed).
+            tags: Multiple tags for multi-tag combination groups (None for others).
+        """
+        super().__init__()
+        self.tag = tag
+        self.entry_count = entry_count
+        self.is_collapsed = is_collapsed
+        self.is_special = is_special
+        self.special_label = special_label
+        self.lib = library
+        self.tags = tags
+
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        self.main_layout = QHBoxLayout(self)
+        self.main_layout.setContentsMargins(6, 4, 6, 4)
+        self.main_layout.setSpacing(8)
+
+        self.arrow_button = QPushButton(self)
+        self.arrow_button.setFlat(True)
+        self.arrow_button.setFixedSize(20, 20)
+        self.arrow_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.arrow_button.setStyleSheet(
+            "QPushButton { "
+            "border: none; "
+            "text-align: center; "
+            "font-size: 12px; "
+            "padding: 0px; "
+            "}"
+        )
+        self._update_arrow()
+        self.arrow_button.clicked.connect(self._on_toggle)
+        self.main_layout.addWidget(self.arrow_button)
+
+        if tags:
+            self.tags_container = QWidget(self)
+            self.tags_layout = QHBoxLayout(self.tags_container)
+            self.tags_layout.setContentsMargins(0, 0, 0, 0)
+            self.tags_layout.setSpacing(4)
+
+            for tag_obj in tags:
+                tag_widget = TagWidget(
+                    tag=tag_obj, has_edit=False, has_remove=False, library=library
+                )
+                self.tags_layout.addWidget(tag_widget)
+
+            self.main_layout.addWidget(self.tags_container)
+        elif is_special and special_label:
+            self.label = QLabel(special_label, self)
+            self.label.setStyleSheet(
+                "font-weight: bold; "
+                "font-size: 12px; "
+                "padding: 2px 8px; "
+                "border-radius: 4px; "
+                "background-color: #3a3a3a; "
+                "color: #e0e0e0;"
+            )
+            self.main_layout.addWidget(self.label)
+        elif tag:
+            self.tag_widget = TagWidget(
+                tag=tag, has_edit=False, has_remove=False, library=library
+            )
+            self.main_layout.addWidget(self.tag_widget)
+
+        count_text = f"({entry_count} {'entry' if entry_count == 1 else 'entries'})"
+        self.count_label = QLabel(count_text, self)
+        self.count_label.setStyleSheet("color: #888888; font-size: 11px;")
+        self.main_layout.addWidget(self.count_label)
+
+        self.main_layout.addStretch(1)
+
+        if is_first:
+            divider_style = ""
+        else:
+            divider_style = "margin-top: 8px; border-top: 1px solid #444444; padding-top: 4px; "
+
+        self.setStyleSheet(
+            "GroupHeaderWidget { "
+            "background-color: #2a2a2a; "
+            f"{divider_style}"
+            "} "
+            "GroupHeaderWidget:hover { "
+            "background-color: #333333; "
+            "}"
+        )
+
+        self.setMinimumHeight(32)
+        self.setMaximumHeight(32)
+
+    def _update_arrow(self) -> None:
+        """Update the arrow button to show collapsed or expanded state."""
+        if self.is_collapsed:
+            self.arrow_button.setText("▶")  # Collapsed (pointing right)
+        else:
+            self.arrow_button.setText("▼")  # Expanded (pointing down)
+
+    def _on_toggle(self) -> None:
+        """Handle toggle button click."""
+        self.is_collapsed = not self.is_collapsed
+        self._update_arrow()
+        self.toggle_collapsed.emit()
+
+    @override
+    def mousePressEvent(self, event) -> None:
+        """Handle mouse press on the entire widget (not just arrow)."""
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._on_toggle()
+        super().mousePressEvent(event)

--- a/src/tagstudio/qt/mixed/group_header.py
+++ b/src/tagstudio/qt/mixed/group_header.py
@@ -3,7 +3,7 @@
 # Created for TagStudio: https://github.com/CyanVoxel/TagStudio
 
 
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Any, override
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QWidget
@@ -13,11 +13,12 @@ from tagstudio.qt.mixed.tag_widget import TagWidget
 
 # Only import for type checking/autocompletion, will not be imported at runtime.
 if TYPE_CHECKING:
+    from tagstudio.core.library.alchemy.grouping import EntryGroup
     from tagstudio.core.library.alchemy.library import Library
 
 
 class GroupHeaderWidget(QWidget):
-    """Collapsible header widget for tag groups."""
+    """Collapsible header widget for entry groups."""
 
     toggle_collapsed = Signal()
 
@@ -31,20 +32,25 @@ class GroupHeaderWidget(QWidget):
         library: "Library | None" = None,
         is_first: bool = False,
         tags: list[Tag] | None = None,
+        key: Any | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the group header widget.
 
         Args:
-            tag: The tag for this group (None for special groups).
+            tag: The tag for this group (None for non-tag groups) - deprecated, use key.
             entry_count: Number of entries in this group.
             is_collapsed: Whether the group starts collapsed.
             is_special: Whether this is a special group.
-            special_label: Label for special groups ("Multiple Tags" or "No Tag").
+            special_label: Label for special groups.
             library: Library instance for tag operations.
             is_first: Whether this is the first group (no divider needed).
-            tags: Multiple tags for multi-tag combination groups (None for others).
+            tags: Multiple tags for multi-tag combination groups - deprecated.
+            key: Generic key for the group (replaces tag).
+            metadata: Additional metadata for the group.
         """
         super().__init__()
+        self.key = key if key is not None else tag
         self.tag = tag
         self.entry_count = entry_count
         self.is_collapsed = is_collapsed
@@ -52,6 +58,7 @@ class GroupHeaderWidget(QWidget):
         self.special_label = special_label
         self.lib = library
         self.tags = tags
+        self.metadata = metadata or {}
 
         self.setCursor(Qt.CursorShape.PointingHandCursor)
 
@@ -94,9 +101,21 @@ class GroupHeaderWidget(QWidget):
                 "color: #e0e0e0;"
             )
             self.main_layout.addWidget(self.label)
-        elif tag:
+        elif tag or isinstance(self.key, Tag):
             self.tag_widget = TagWidget(tag=tag, has_edit=False, has_remove=False, library=library)
             self.main_layout.addWidget(self.tag_widget)
+        elif self.key is not None:
+            # Generic group with non-tag key (e.g., filetype)
+            self.label = QLabel(str(self.key), self)
+            self.label.setStyleSheet(
+                "font-weight: bold; "
+                "font-size: 12px; "
+                "padding: 2px 8px; "
+                "border-radius: 4px; "
+                "background-color: #3a3a3a; "
+                "color: #e0e0e0;"
+            )
+            self.main_layout.addWidget(self.label)
 
         count_text = f"({entry_count} {'entry' if entry_count == 1 else 'entries'})"
         self.count_label = QLabel(count_text, self)
@@ -122,6 +141,40 @@ class GroupHeaderWidget(QWidget):
 
         self.setMinimumHeight(32)
         self.setMaximumHeight(32)
+
+    @classmethod
+    def from_group(
+        cls,
+        group: "EntryGroup",
+        is_collapsed: bool = False,
+        library: "Library | None" = None,
+        is_first: bool = False,
+    ) -> "GroupHeaderWidget":
+        """Create a GroupHeaderWidget from an EntryGroup.
+
+        Args:
+            group: The entry group to create a header for.
+            is_collapsed: Whether the group starts collapsed.
+            library: Library instance for tag operations.
+            is_first: Whether this is the first group (no divider needed).
+
+        Returns:
+            GroupHeaderWidget instance.
+        """
+        # Extract tag if key is a Tag
+        tag = group.key if isinstance(group.key, Tag) else None
+
+        return cls(
+            tag=tag,
+            entry_count=len(group.entry_ids),
+            is_collapsed=is_collapsed,
+            is_special=group.is_special,
+            special_label=group.special_label,
+            library=library,
+            is_first=is_first,
+            key=group.key,
+            metadata=group.metadata,
+        )
 
     def _update_arrow(self) -> None:
         """Update the arrow button to show collapsed or expanded state."""

--- a/src/tagstudio/qt/mixed/tag_database.py
+++ b/src/tagstudio/qt/mixed/tag_database.py
@@ -49,6 +49,7 @@ class TagDatabasePanel(TagSearchPanel):
                     alias_names=panel.alias_names,
                     alias_ids=panel.alias_ids,
                 ),
+                self.driver.populate_group_by_tags(block_signals=True),
                 self.modal.hide(),
                 self.update_tags(self.search_field.text()),
             )
@@ -72,4 +73,5 @@ class TagDatabasePanel(TagSearchPanel):
             return
 
         self.lib.remove_tag(tag.id)
+        self.driver.populate_group_by_tags(block_signals=True)
         self.update_tags()

--- a/src/tagstudio/qt/thumb_grid_layout.py
+++ b/src/tagstudio/qt/thumb_grid_layout.py
@@ -210,15 +210,11 @@ class ThumbGridLayout(QLayout):
 
             default_collapsed = group.is_special and group.special_label == "No Tag"
             is_collapsed = old_collapsed_states.get(group_idx, default_collapsed)
-            header = GroupHeaderWidget(
-                tag=group.tag,
-                entry_count=len(group.entry_ids),
+            header = GroupHeaderWidget.from_group(
+                group=group,
                 is_collapsed=is_collapsed,
-                is_special=group.is_special,
-                special_label=group.special_label,
                 library=self.driver.lib,
                 is_first=group_idx == 0,
-                tags=group.tags,
             )
             header.toggle_collapsed.connect(lambda g_idx=group_idx: self._on_group_collapsed(g_idx))
             self._group_headers.append(header)

--- a/src/tagstudio/qt/thumb_grid_layout.py
+++ b/src/tagstudio/qt/thumb_grid_layout.py
@@ -197,6 +197,7 @@ class ThumbGridLayout(QLayout):
         for group_idx, group in enumerate(self._grouped_result.groups):
             if group_idx > 0:
                 from PySide6.QtWidgets import QWidget
+
                 divider = QWidget()
                 divider.setStyleSheet("QWidget { background-color: #444444; }")
                 divider.setFixedHeight(1)
@@ -219,9 +220,7 @@ class ThumbGridLayout(QLayout):
                 is_first=group_idx == 0,
                 tags=group.tags,
             )
-            header.toggle_collapsed.connect(
-                lambda g_idx=group_idx: self._on_group_collapsed(g_idx)
-            )
+            header.toggle_collapsed.connect(lambda g_idx=group_idx: self._on_group_collapsed(g_idx))
             self._group_headers.append(header)
             self.addWidget(header)
 

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -1215,7 +1215,7 @@ class QtDriver(DriverMixin, QObject):
             block_signals: If True, block signals during population.
         """
         if block_signals:
-            self.main_window.group_by_tag_combobox.blockSignals(True)
+            self.main_window.group_by_tag_combobox.blockSignals(True)  # noqa: FBT003
 
         model = QStandardItemModel()
         num_columns = 4
@@ -1228,7 +1228,7 @@ class QtDriver(DriverMixin, QObject):
             self.main_window.group_by_tag_combobox.setModel(model)
             self.main_window.group_by_tag_combobox.setCurrentIndex(0)
             if block_signals:
-                self.main_window.group_by_tag_combobox.blockSignals(False)
+                self.main_window.group_by_tag_combobox.blockSignals(False)  # noqa: FBT003
             return
 
         all_tags = self.lib.tags
@@ -1301,13 +1301,16 @@ class QtDriver(DriverMixin, QObject):
 
             total_width = 0
             for col in range(num_columns):
-                total_width += view.columnWidth(col)
+                col_width = view.columnWidth(col)
+                # Handle Mock objects in tests
+                if isinstance(col_width, int):
+                    total_width += col_width
 
             total_width += 4
             view.setMinimumWidth(total_width)
 
         if block_signals:
-            self.main_window.group_by_tag_combobox.blockSignals(False)
+            self.main_window.group_by_tag_combobox.blockSignals(False)  # noqa: FBT003
 
     def group_by_tag_callback(self):
         """Handle group-by tag selection change."""
@@ -1595,9 +1598,9 @@ class QtDriver(DriverMixin, QObject):
                     break
 
         # Block signals to avoid triggering callback during sync
-        self.main_window.group_by_tag_combobox.blockSignals(True)
+        self.main_window.group_by_tag_combobox.blockSignals(True)  # noqa: FBT003
         self.main_window.group_by_tag_combobox.setCurrentIndex(target_index)
-        self.main_window.group_by_tag_combobox.blockSignals(False)
+        self.main_window.group_by_tag_combobox.blockSignals(False)  # noqa: FBT003
 
         # inform user about running search
         self.main_window.status_bar.showMessage(Translations["status.library_search_query"])

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -36,6 +36,8 @@ from PySide6.QtGui import (
     QIcon,
     QMouseEvent,
     QPalette,
+    QStandardItem,
+    QStandardItemModel,
 )
 from PySide6.QtWidgets import (
     QApplication,
@@ -370,8 +372,7 @@ class QtDriver(DriverMixin, QObject):
         self.color_manager_panel = TagColorManager(self)
 
         # Initialize the Tag Search panel
-        self.add_tag_modal = TagSearchModal(self.lib, is_tag_chooser=True)
-        self.add_tag_modal.tsp.set_driver(self)
+        self.add_tag_modal = TagSearchModal(self.lib, is_tag_chooser=True, driver=self)
         self.add_tag_modal.tsp.tag_chosen.connect(
             lambda chosen_tag: (
                 self.add_tags_to_selected_callback([chosen_tag]),
@@ -654,6 +655,12 @@ class QtDriver(DriverMixin, QObject):
             self.sorting_direction_callback
         )
 
+        # Group By Tag Dropdown
+        self.populate_group_by_tags()
+        self.main_window.group_by_tag_combobox.currentIndexChanged.connect(
+            self.group_by_tag_callback
+        )
+
         # Thumbnail Size ComboBox
         self.main_window.thumb_size_combobox.setCurrentIndex(2)  # Default: Medium
         self.main_window.thumb_size_combobox.currentIndexChanged.connect(
@@ -841,6 +848,7 @@ class QtDriver(DriverMixin, QObject):
                     set(panel.alias_names),
                     set(panel.alias_ids),
                 ),
+                self.populate_group_by_tags(),
                 self.modal.hide(),
             )
         )
@@ -876,6 +884,10 @@ class QtDriver(DriverMixin, QObject):
         self.main_window.thumb_layout.add_tags(selected, tag_ids)
         self.lib.add_tags_to_entries(selected, tag_ids)
         self.emit_badge_signals(tag_ids)
+
+        # Refresh grouping if active
+        if self.browsing_history.current.group_by_tag_id is not None:
+            self.update_browsing_state()
 
     def delete_files_callback(self, origin_path: str | Path, origin_id: int | None = None):
         """Callback to send on or more files to the system trash.
@@ -1168,7 +1180,14 @@ class QtDriver(DriverMixin, QObject):
         spacing_divisor: int = 10
         min_spacing: int = 12
 
-        self.update_thumbs()
+        # Recalculate grouping if active
+        grouped_result = None
+        if self.browsing_history.current.group_by_tag_id:
+            grouped_result = self.lib.group_entries_by_tag(
+                self.frame_content, self.browsing_history.current.group_by_tag_id
+            )
+
+        self.update_thumbs(grouped_result)
         blank_icon: QIcon = QIcon()
         for it in self.main_window.thumb_layout._item_thumbs:
             it.thumb_button.setIcon(blank_icon)
@@ -1188,6 +1207,113 @@ class QtDriver(DriverMixin, QObject):
                 self.main_window.show_hidden_entries
             )
         )
+
+    def populate_group_by_tags(self, block_signals: bool = False):
+        """Populate the group-by dropdown with all available tags in hierarchical order.
+
+        Args:
+            block_signals: If True, block signals during population.
+        """
+        if block_signals:
+            self.main_window.group_by_tag_combobox.blockSignals(True)
+
+        model = QStandardItemModel()
+        num_columns = 4
+
+        none_item = QStandardItem("None")
+        none_item.setData(None, Qt.ItemDataRole.UserRole)
+        model.appendRow([none_item] + [QStandardItem() for _ in range(num_columns - 1)])
+
+        if not self.lib.library_dir:
+            self.main_window.group_by_tag_combobox.setModel(model)
+            self.main_window.group_by_tag_combobox.setCurrentIndex(0)
+            if block_signals:
+                self.main_window.group_by_tag_combobox.blockSignals(False)
+            return
+
+        all_tags = self.lib.tags
+        root_tags = [tag for tag in all_tags if not tag.parent_tags]
+        child_tags = [tag for tag in all_tags if tag.parent_tags]
+
+        children_map: dict[int, list] = {}
+        for tag in child_tags:
+            for parent in tag.parent_tags:
+                if parent.id not in children_map:
+                    children_map[parent.id] = []
+                children_map[parent.id].append(tag)
+
+        for children in children_map.values():
+            children.sort(key=lambda t: t.name.lower())
+
+        root_tags.sort(key=lambda t: t.name.lower())
+
+        self.main_window.group_by_tag_combobox.setModel(model)
+        self.main_window.group_by_tag_combobox.setCurrentIndex(0)
+
+        view = self.main_window.group_by_tag_combobox.view()
+        current_row = 0
+
+        if hasattr(view, "setSpan"):
+            view.setSpan(current_row, 0, 1, num_columns)
+        current_row += 1
+
+        for tag in root_tags:
+            children = children_map.get(tag.id)
+
+            if children is None:
+                item = QStandardItem(tag.name)
+                item.setData(tag.id, Qt.ItemDataRole.UserRole)
+                model.appendRow([item] + [QStandardItem() for _ in range(num_columns - 1)])
+                view.setSpan(current_row, 0, 1, num_columns)
+                current_row += 1
+            else:
+                parent_item = QStandardItem(tag.name)
+                parent_item.setData(tag.id, Qt.ItemDataRole.UserRole)
+                model.appendRow([parent_item] + [QStandardItem() for _ in range(num_columns - 1)])
+                view.setSpan(current_row, 0, 1, num_columns)
+                current_row += 1
+
+                for i in range(0, len(children), num_columns):
+                    row_items = []
+                    children_in_row = 0
+
+                    for j in range(num_columns):
+                        if i + j < len(children):
+                            child = children[i + j]
+                            child_item = QStandardItem(f"  {child.name}")
+                            child_item.setData(child.id, Qt.ItemDataRole.UserRole)
+                            row_items.append(child_item)
+                            children_in_row += 1
+                        else:
+                            empty_item = QStandardItem()
+                            empty_item.setFlags(Qt.ItemFlag.NoItemFlags)
+                            row_items.append(empty_item)
+
+                    model.appendRow(row_items)
+
+                    if children_in_row == 1:
+                        view.setSpan(current_row, 0, 1, num_columns)
+
+                    current_row += 1
+
+        if hasattr(view, "resizeColumnsToContents"):
+            view.resizeColumnsToContents()
+
+            total_width = 0
+            for col in range(num_columns):
+                total_width += view.columnWidth(col)
+
+            total_width += 4
+            view.setMinimumWidth(total_width)
+
+        if block_signals:
+            self.main_window.group_by_tag_combobox.blockSignals(False)
+
+    def group_by_tag_callback(self):
+        """Handle group-by tag selection change."""
+        tag_id = self.main_window.group_by_tag_id
+        logger.info("Group By Tag Changed", tag_id=tag_id)
+        self.update_browsing_state(self.browsing_history.current.with_group_by_tag(tag_id))
 
     def mouse_navigation(self, event: QMouseEvent):
         # print(event.button())
@@ -1381,7 +1507,7 @@ class QtDriver(DriverMixin, QObject):
         if update_completion_list:
             self.main_window.search_field_completion_list.setStringList(completion_list)
 
-    def update_thumbs(self):
+    def update_thumbs(self, grouped_result=None):
         """Update search thumbnails."""
         with self.thumb_job_queue.mutex:
             # Cancels all thumb jobs waiting to be started
@@ -1389,7 +1515,7 @@ class QtDriver(DriverMixin, QObject):
             self.thumb_job_queue.all_tasks_done.notify_all()
             self.thumb_job_queue.not_full.notify_all()
 
-        self.main_window.thumb_layout.set_entries(self.frame_content)
+        self.main_window.thumb_layout.set_entries(self.frame_content, grouped_result)
         self.main_window.thumb_layout.update()
         self.main_window.update()
 
@@ -1441,6 +1567,10 @@ class QtDriver(DriverMixin, QObject):
                 self.main_window.thumb_layout.remove_tags(entry_ids, tag_ids)
                 self.lib.remove_tags_from_entries(entry_ids, tag_ids)
 
+        # Refresh grouping if active (only when tags are being added/removed)
+        if self.browsing_history.current.group_by_tag_id is not None:
+            self.update_browsing_state()
+
     def update_browsing_state(self, state: BrowsingState | None = None) -> None:
         """Navigates to a new BrowsingState when state is given, otherwise updates the results."""
         if not self.lib.library_dir:
@@ -1451,6 +1581,23 @@ class QtDriver(DriverMixin, QObject):
             self.browsing_history.push(state)
 
         self.main_window.search_field.setText(self.browsing_history.current.query or "")
+
+        # Sync group-by dropdown with browsing state
+        group_by_tag_id = self.browsing_history.current.group_by_tag_id
+        if group_by_tag_id is None:
+            target_index = 0  # "None" option
+        else:
+            # Find the index of the tag in the dropdown
+            target_index = 0
+            for i in range(self.main_window.group_by_tag_combobox.count()):
+                if self.main_window.group_by_tag_combobox.itemData(i) == group_by_tag_id:
+                    target_index = i
+                    break
+
+        # Block signals to avoid triggering callback during sync
+        self.main_window.group_by_tag_combobox.blockSignals(True)
+        self.main_window.group_by_tag_combobox.setCurrentIndex(target_index)
+        self.main_window.group_by_tag_combobox.blockSignals(False)
 
         # inform user about running search
         self.main_window.status_bar.showMessage(Translations["status.library_search_query"])
@@ -1473,9 +1620,16 @@ class QtDriver(DriverMixin, QObject):
             )
         )
 
+        # Group results if grouping is enabled
+        grouped_result = None
+        if self.browsing_history.current.group_by_tag_id:
+            grouped_result = self.lib.group_entries_by_tag(
+                results.ids, self.browsing_history.current.group_by_tag_id
+            )
+
         # update page content
         self.frame_content = results.ids
-        self.update_thumbs()
+        self.update_thumbs(grouped_result=grouped_result)
 
         # update pagination
         if page_size > 0:
@@ -1658,6 +1812,9 @@ class QtDriver(DriverMixin, QObject):
         self.main_window.menu_bar.library_info_action.setEnabled(True)
 
         self.main_window.preview_panel.set_selection(self.selected)
+
+        # Populate group-by dropdown after library is loaded
+        self.populate_group_by_tags()
 
         # page (re)rendering, extract eventually
         initial_state = BrowsingState(


### PR DESCRIPTION
Adds a feature to group thumbnails in the main window by a tag or by a parent tag.
Grouped thumbnails in each section respect the user's other sorting choices (filename/date created, sort direction, etc.)

Features:
- Hierarchical tag dropdown with grouping of parent/children tags in a table view so large amounts of tags can be handled (hopefully)
- Collapsible/expandable groups with count badges in thumbnail view
  - The tags that act as headers respect the user's configuration and use the tags' configured colors
- Auto-refreshes the thumbnail pane and group-by-tag dropdown on tag creation/modification no matter if it was through the tag manager or the right-hand pane
- Works with all existing search/filter operations

Core Library Changes:
- Add `group_entries_by_tag()` method to generate a tag hierarchy
- Add `get_grouping_tag_ids()` to fetch grouping tags
- Extend `BrowsingState` with `group_by_tag_id` field
- Add `GroupedSearchResult` dataclass with `TagGroup` hierarchy

UI Components:
- Added a new dropdown for tag selection to sort by. This works with parent tags so multiple tag groups are created in the thumbnail view. If an item has multiple sibling tags, it'll be put under a "Multiple Tags" grouping.
  - Each Parent gets its own row in the dropdown menu. The siblings under the parent get their own cell. I didn't have a good way to screenshot that, sorry!
- Implemented `GroupHeaderWidget` to create collapsible group headers
- Extended `ThumbGridLayout` to render hierarchical grouped entries
- Updated `update_browsing_state()` to handle grouped results

Files Added:
- src/tagstudio/qt/mixed/group_header.py
- src/tagstudio/qt/mixed/group_by_tag_delegate.py

Notes:
- The QT components and the hierarchy generation were written with tool-assistance (Claude Code 4.5)
- The new python code was run through `black -l100`, mypy, and ruff. I did my best to stick to the existing coding style.
- I've tested this for hours yesterday and today with no ill effects (yet).
- I asked in the Discord if this had a PR and received positive responses there was one somewhere. I wasn't smart enough to find it, so if this is out of line, please let me know!
- I added 'Thumbs.db' to the ignore list since other Windows and Mac library-ish things were being ignored too.
- I found a bug where the search modal had delete buttons for tags, they didn't do anything because the `delete_tag()` only contained `pass`. I implemented a full `delete_tag()` method to fix this so the sort-by-tag dropdown would be able to automatically update correctly.

### Summary

Adds a feature to group thumbnails in the main window by a single tag or by a parent tag.
Grouped thumbnails in each section respect the user's other sorting choices (filename/date created, sort direction, etc.)

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [X] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [X] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    -   [X] Ruff, mypy, and formatting compliance
    <!-- If other important criteria was tested for, please add it here -->

## Screenshots

### New Toolbar Dropdown

<img width="1028" height="130" alt="New toolbar item" src="https://github.com/user-attachments/assets/a7f7e202-20b6-4098-bb3d-a8ca14ef21ea" />

### Selecting a Parent Tag to Group By

<img width="1193" height="874" alt="Selecting &#39;Colors&#39; Parent Tag" src="https://github.com/user-attachments/assets/10a3f0f1-95cc-4769-8499-b86702cbea58" />

### Sorting complete

<img width="1018" height="704" alt="Selected &#39;Colors&#39; Parent Tag" src="https://github.com/user-attachments/assets/e110e7ba-ccda-4b18-baf4-2ccc40c72ecf" />

### Example Item with Multiple Sibling Tags

<img width="1022" height="706" alt="Selected Item with multiple sibling tags" src="https://github.com/user-attachments/assets/38627a85-a244-4016-9e26-1232aa383ea0" />
