### PR TITLE
fix: escape dash in URL regex

### DIFF
--- a/src/tagstudio/qt/mixed/text_field.py
+++ b/src/tagstudio/qt/mixed/text_field.py
@@ -34,9 +34,7 @@ class TextWidget(FieldWidget):
 
 # Regex from https://stackoverflow.com/a/6041965
 def linkify(text: str):
-    url_pattern = (
-        r"(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-*]*[\w@?^=%&\/~+#-*])"
-    )
+    url_pattern = r"(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#\-*]*[\w@?^=%&\/~+#\-*])"  # noqa: E501
     return re.sub(
         url_pattern,
         lambda url: f'<a href="{url.group(0)}">{url.group(0)}</a>',


### PR DESCRIPTION
### Summary
Escapes a dash in the URL regex that was preventing URLs with dashes from being correctly matched.

Closes and fix provided by #1254.

> Although this is also already fixed by #1168, this is a quick patch until then.

### Tasks Completed

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
