### PR TITLE
fix(nix): add requests and semver to nix package

### DIFF
--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -80,6 +80,8 @@ python3Packages.buildPythonApplication {
     "py7zr"
     "pyside6"
     "rarfile"
+    "requests"
+    "semver"
     "structlog"
     "typing-extensions"
   ];
@@ -103,6 +105,8 @@ python3Packages.buildPythonApplication {
       pyside6
       rarfile
       rawpy
+      requests
+      semver
       send2trash
       sqlalchemy
       srctools


### PR DESCRIPTION
### Summary
The addition of the update notification in #1166 added `requests` and `semver` to the dependencies. They were however not added to the nix package, breaking the build.

This adds both of them as dependencies to the nix package. It also add `requests` to `pythonRelaxDeps` as `requests` is already on 2.32.5 in nixpkgs but the `pyproject.toml` specifies `requests~=2.31.0`.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
