### PR TITLE
fix: Fix update notification crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ pyinstaller = ["Pyinstaller~=6.13"]
 pytest = [
     "pytest==8.3.5",
     "pytest-cov==6.1.1",
+    "pytest-mock==3.15.1",
     "pytest-qt==4.4.0",
     "syrupy==4.9.1",
 ]

--- a/src/tagstudio/core/ts_core.py
+++ b/src/tagstudio/core/ts_core.py
@@ -196,7 +196,9 @@ class TagStudioCore:
     def get_most_recent_release_version() -> str | None:
         """Get the version of the most recent GitHub release."""
         try:
-            resp = requests.get("https://api.github.com/repos/TagStudioDev/TagStudio/releases/latest")
+            resp = requests.get(
+                "https://api.github.com/repos/TagStudioDev/TagStudio/releases/latest"
+            )
         except Exception as e:
             logger.error("Error getting most recent GitHub release.", error=e)
             return None

--- a/src/tagstudio/core/ts_core.py
+++ b/src/tagstudio/core/ts_core.py
@@ -216,7 +216,7 @@ class TagStudioCore:
         version = tag[1:]
         # the assertion does not allow for prerelease/build,
         # because the latest release should never have them
-        if re.match(r"^\d+\.\d+\.\d+$", version) is not None:
+        if re.match(r"^\d+\.\d+\.\d+$", version) is None:
             logger.error("Invalid version format.", version=version)
             return None
 

--- a/src/tagstudio/core/ts_core.py
+++ b/src/tagstudio/core/ts_core.py
@@ -193,18 +193,29 @@ class TagStudioCore:
 
     @staticmethod
     @lru_cache(maxsize=1)
-    def get_most_recent_release_version() -> str:
-        """Get the version of the most recent Github release."""
-        resp = requests.get("https://api.github.com/repos/TagStudioDev/TagStudio/releases/latest")
-        assert resp.status_code == 200, "Could not fetch information on latest release."
+    def get_most_recent_release_version() -> str | None:
+        """Get the version of the most recent GitHub release."""
+        try:
+            resp = requests.get("https://api.github.com/repos/TagStudioDev/TagStudio/releases/latest")
+        except Exception as e:
+            logger.error("Error getting most recent GitHub release.", error=e)
+            return None
+
+        if resp.status_code != 200:
+            logger.error("Error getting most recent GitHub release.", status_code=resp.status_code)
+            return None
 
         data = resp.json()
         tag: str = data["tag_name"]
-        assert tag.startswith("v")
+        if not tag.startswith("v"):
+            logger.error("Unexpected tag format.", tag=tag)
+            return None
 
         version = tag[1:]
-        # the assert does not allow for prerelease/build,
+        # the assertion does not allow for prerelease/build,
         # because the latest release should never have them
-        assert re.match(r"^\d+\.\d+\.\d+$", version) is not None, "Invalid version format."
+        if re.match(r"^\d+\.\d+\.\d+$", version) is not None:
+            logger.error("Invalid version format.", version=version)
+            return None
 
         return version

--- a/src/tagstudio/qt/controllers/out_of_date_message_box.py
+++ b/src/tagstudio/qt/controllers/out_of_date_message_box.py
@@ -4,6 +4,7 @@ from PySide6.QtWidgets import QMessageBox
 
 from tagstudio.core.constants import VERSION
 from tagstudio.core.ts_core import TagStudioCore
+from tagstudio.core.utils.types import unwrap
 from tagstudio.qt.models.palette import ColorType, UiColor, get_ui_color
 from tagstudio.qt.translations import Translations
 
@@ -30,7 +31,7 @@ class OutOfDateMessageBox(QMessageBox):
 
         red = get_ui_color(ColorType.PRIMARY, UiColor.RED)
         green = get_ui_color(ColorType.PRIMARY, UiColor.GREEN)
-        latest_release_version = TagStudioCore.get_most_recent_release_version()
+        latest_release_version = unwrap(TagStudioCore.get_most_recent_release_version())
         status = Translations.format(
             "version_modal.status",
             installed_version=f"<span style='color:{red}'>{VERSION}</span>",

--- a/src/tagstudio/qt/mixed/about_modal.py
+++ b/src/tagstudio/qt/mixed/about_modal.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
 from tagstudio.core.constants import VERSION, VERSION_BRANCH
 from tagstudio.core.enums import Theme
 from tagstudio.core.ts_core import TagStudioCore
+from tagstudio.core.utils.types import unwrap
 from tagstudio.qt.models.palette import ColorType, UiColor, get_ui_color
 from tagstudio.qt.previews.vendored import ffmpeg
 from tagstudio.qt.resource_manager import ResourceManager
@@ -106,7 +107,7 @@ class AboutModal(QWidget):
 
         # Version
         version_title = QLabel("Version")
-        most_recent_release = TagStudioCore.get_most_recent_release_version()
+        most_recent_release = unwrap(TagStudioCore.get_most_recent_release_version(), "UNKNOWN")
         version_content_style = self.form_content_style
         if most_recent_release == VERSION:
             version_content = QLabel(f"{VERSION}")

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -595,7 +595,8 @@ class QtDriver(DriverMixin, QObject):
         if not which(FFMPEG_CMD) or not which(FFPROBE_CMD):
             FfmpegMissingMessageBox().show()
 
-        if is_version_outdated(VERSION, TagStudioCore.get_most_recent_release_version()):
+        latest_version = TagStudioCore.get_most_recent_release_version()
+        if latest_version and is_version_outdated(VERSION, latest_version):
             OutOfDateMessageBox().exec()
 
         self.app.exec()

--- a/tests/qt/test_about_modal.py
+++ b/tests/qt/test_about_modal.py
@@ -8,7 +8,7 @@ def test_github_api_unavailable(qtbot: QtBot, mocker) -> None:
         "requests.get",
         side_effect=ConnectionError(
             "Failed to resolve 'api.github.com' ([Errno -3] Temporary failure in name resolution)"
-        )
+        ),
     )
     modal = AboutModal("/tmp")
     qtbot.addWidget(modal)

--- a/tests/qt/test_about_modal.py
+++ b/tests/qt/test_about_modal.py
@@ -1,0 +1,14 @@
+from pytestqt.qtbot import QtBot
+
+from tagstudio.qt.mixed.about_modal import AboutModal
+
+
+def test_github_api_unavailable(qtbot: QtBot, mocker) -> None:
+    mocker.patch(
+        "requests.get",
+        side_effect=ConnectionError(
+            "Failed to resolve 'api.github.com' ([Errno -3] Temporary failure in name resolution)"
+        )
+    )
+    modal = AboutModal("/tmp")
+    qtbot.addWidget(modal)


### PR DESCRIPTION
### Summary
Don't raise exceptions in `get_most_recent_release_version` to prevent crashes if they bubble up into `QtDriver`, log failures instead.

The about modal will show `9.5.6 (Latest Release: UNKNOWN)` if the GitHub API is unavilable
<img width="498" height="351" alt="version_unknown" src="https://github.com/user-attachments/assets/a52b8483-6e67-4b5a-88ab-a887117b900b" />

I have only tested the issue trough the about modal, since I couldn't make `QtDriver::start` work in tests.

In case of timeouts, the UI willstill be blocked until the request times out.

Fixes https://github.com/TagStudioDev/TagStudio/issues/1277

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
