### PR TITLE
minor refactor: cleanup parameters of open_library and open_sqlite_library

### DIFF
--- a/src/tagstudio/qt/mixed/migration_modal.py
+++ b/src/tagstudio/qt/mixed/migration_modal.py
@@ -410,11 +410,12 @@ class JsonMigrationModal(QObject):
             self.temp_path: Path = (
                 self.json_lib.library_dir / TS_FOLDER_NAME / "migration_ts_library.sqlite"
             )
-            self.sql_lib.storage_path = self.temp_path
             if self.temp_path.exists():
                 logger.info('Temporary migration file "temp_path" already exists. Removing...')
                 self.temp_path.unlink()
-            self.sql_lib.open_sqlite_library(self.json_lib.library_dir, is_new=True)
+            self.sql_lib.open_sqlite_library(
+                self.json_lib.library_dir, is_new=True, storage_path=str(self.temp_path)
+            )
             yield Translations.format(
                 "json_migration.migrating_files_entries", entries=len(self.json_lib.entries)
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def cwd():
 def file_mediatypes_library():
     lib = Library()
 
-    status = lib.open_library(Path(""), ":memory:")
+    status = lib.open_library(Path(""), in_memory=True)
     assert status.success
     folder = unwrap(lib.folder)
 
@@ -84,7 +84,7 @@ def library(request, library_dir: Path):  # pyright: ignore
             library_path = Path(request.param)
 
     lib = Library()
-    status = lib.open_library(library_path, ":memory:")
+    status = lib.open_library(library_path, in_memory=True)
     assert status.success
     folder = unwrap(lib.folder)
 


### PR DESCRIPTION
### Summary

A minor refactor of the `Library.open_library` method and the parameters of the `Library.open_sqlite_library` method.
No functional changes were made; a pure refactor.

Note: Ignore the invisible unicode char in the head ref; windows was doing windows things.

### Tasks Completed

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable
