### PR TITLE
refactor: sql migrations

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -536,8 +536,7 @@ class Library:
                     self.save_library_backup_to_disk()
                     self.library_dir = None
 
-                # NOTE: Depending on the data, some data and schema changes need to be applied in
-                # different orders. This chain of methods can likely be cleaned up and/or moved.
+                # migrate DB step by step from one version to the next
                 if loaded_db_version < 7:
                     # changes: value_type, tags
                     self.__apply_db7_migration(session)
@@ -558,7 +557,7 @@ class Library:
                     self.__apply_db103_migration(session)
 
                 # Convert file extension list to ts_ignore file, if a .ts_ignore file does not exist
-                # TODO: this currently does not delete the migrated data from the DB
+                # TODO: do this in the migration step that will remove the preferences table
                 self.migrate_sql_to_ts_ignore(library_dir)
 
             # Update DB_VERSION

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -548,13 +548,11 @@ class Library:
                 if loaded_db_version < 9:
                     # changes: entries
                     self.__apply_db9_schema_changes(session)
+                    self.__apply_db9_filename_population(session)
                 if loaded_db_version < 103:
                     # changes: tags (add column)
                     self.__apply_db103_schema_changes(session)
 
-                if loaded_db_version < 9:
-                    # changes: entries
-                    self.__apply_db9_filename_population(session)
                 if loaded_db_version < 100:
                     # changes: tag_parents
                     self.__apply_db100_parent_repairs(session)

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -538,6 +538,9 @@ class Library:
 
                 # NOTE: Depending on the data, some data and schema changes need to be applied in
                 # different orders. This chain of methods can likely be cleaned up and/or moved.
+                if loaded_db_version < 7:
+                    # changes: value_type, tags (remove invalid disam id)
+                    self.__apply_repairs_for_db6(session)
                 if loaded_db_version < 8:
                     # changes: tag_colors
                     self.__apply_db8_schema_changes(session)
@@ -547,9 +550,6 @@ class Library:
                 if loaded_db_version < 103:
                     # changes: tags (add column)
                     self.__apply_db103_schema_changes(session)
-                if loaded_db_version == 6:
-                    # changes: value_type, tags (remove invalid disam id)
-                    self.__apply_repairs_for_db6(session)
 
                 if loaded_db_version < 8:
                     # changes: tag_colors

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -549,13 +549,13 @@ class Library:
                     # changes: entries
                     self.__apply_db9_schema_changes(session)
                     self.__apply_db9_filename_population(session)
+                if loaded_db_version < 100:
+                    # changes: tag_parents
+                    self.__apply_db100_parent_repairs(session)
                 if loaded_db_version < 103:
                     # changes: tags (add column)
                     self.__apply_db103_schema_changes(session)
 
-                if loaded_db_version < 100:
-                    # changes: tag_parents
-                    self.__apply_db100_parent_repairs(session)
                 if loaded_db_version < 102:
                     # changes: tag_parents
                     self.__apply_db102_repairs(session)

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -544,6 +544,7 @@ class Library:
                 if loaded_db_version < 8:
                     # changes: tag_colors
                     self.__apply_db8_schema_changes(session)
+                    self.__apply_db8_default_data(session)
                 if loaded_db_version < 9:
                     # changes: entries
                     self.__apply_db9_schema_changes(session)
@@ -551,9 +552,6 @@ class Library:
                     # changes: tags (add column)
                     self.__apply_db103_schema_changes(session)
 
-                if loaded_db_version < 8:
-                    # changes: tag_colors
-                    self.__apply_db8_default_data(session)
                 if loaded_db_version < 9:
                     # changes: entries
                     self.__apply_db9_filename_population(session)

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -552,15 +552,12 @@ class Library:
                 if loaded_db_version < 100:
                     # changes: tag_parents
                     self.__apply_db100_parent_repairs(session)
-                if loaded_db_version < 103:
-                    # changes: tags (add column)
-                    self.__apply_db103_schema_changes(session)
-
                 if loaded_db_version < 102:
                     # changes: tag_parents
                     self.__apply_db102_repairs(session)
                 if loaded_db_version < 103:
-                    # changes: tags (mark archived as hidden)
+                    # changes: tags
+                    self.__apply_db103_schema_changes(session)
                     self.__apply_db103_default_data(session)
 
                 # Convert file extension list to ts_ignore file, if a .ts_ignore file does not exist

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -582,7 +582,7 @@ class Library:
             session.flush()
 
             # Repair tags that may have a disambiguation_id pointing towards a deleted tag.
-            all_tag_ids: set[int] = {tag.id for tag in self.tags}
+            all_tag_ids = session.scalars(text("SELECT DISTINCT id FROM tags")).all()
             disam_stmt = (
                 update(Tag)
                 .where(Tag.disambiguation_id.not_in(all_tag_ids))
@@ -695,7 +695,7 @@ class Library:
     def __apply_db102_migration(self, session: Session):
         """Migrate DB to DB_VERSION 102."""
         with session:
-            all_tag_ids: list[int] = [t.id for t in self.tags]
+            all_tag_ids = session.scalars(text("SELECT DISTINCT id FROM tags")).all()
             stmt = delete(TagParent).where(TagParent.parent_id.not_in(all_tag_ids))
             session.execute(stmt)
             session.commit()

--- a/src/tagstudio/qt/mixed/migration_modal.py
+++ b/src/tagstudio/qt/mixed/migration_modal.py
@@ -410,11 +410,12 @@ class JsonMigrationModal(QObject):
             self.temp_path: Path = (
                 self.json_lib.library_dir / TS_FOLDER_NAME / "migration_ts_library.sqlite"
             )
-            self.sql_lib.storage_path = self.temp_path
             if self.temp_path.exists():
                 logger.info('Temporary migration file "temp_path" already exists. Removing...')
                 self.temp_path.unlink()
-            self.sql_lib.open_sqlite_library(self.json_lib.library_dir, is_new=True)
+            self.sql_lib.open_sqlite_library(
+                self.json_lib.library_dir, is_new=True, storage_path=str(self.temp_path)
+            )
             yield Translations.format(
                 "json_migration.migrating_files_entries", entries=len(self.json_lib.entries)
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def cwd():
 def file_mediatypes_library():
     lib = Library()
 
-    status = lib.open_library(Path(""), ":memory:")
+    status = lib.open_library(Path(""), in_memory=True)
     assert status.success
     folder = unwrap(lib.folder)
 
@@ -84,7 +84,7 @@ def library(request, library_dir: Path):  # pyright: ignore
             library_path = Path(request.param)
 
     lib = Library()
-    status = lib.open_library(library_path, ":memory:")
+    status = lib.open_library(library_path, in_memory=True)
     assert status.success
     folder = unwrap(lib.folder)
 


### PR DESCRIPTION
### Summary

This PR refactors the SQL migrations for old DB versions. Previously these migrations happened out of order and were split between schema changes and data updates. This was done because some SQLAlchemy read operations would otherwise fail due to an incompatible schema[^1]. This refactor rearranges these migrations into chronological order. This was done, because
- the code was very entangled thus hard to understand und verify,
- the chronological step-wise way is the typical way of migrating DBs,
- and because this way, new migrations can be added easily and with confidence that none of the previous steps will interfere or be interfered with

Note for reviewers: The changes were intentionally split into small commits that should be easily verifiable individually, because they make small changes that should change nothing about the correctness of the migration steps.

Note for reviewers 2: This is based on #1294.

### Tasks Completed

-   Platforms Tested:
    -   [x] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable

[^1]: this was fixed in f28adfd6f9e718aca0b3e69778153a56e856194b