### PR TITLE
fix: empty ORLists now return false

### DIFF
--- a/src/tagstudio/core/library/alchemy/visitors.py
+++ b/src/tagstudio/core/library/alchemy/visitors.py
@@ -6,7 +6,7 @@ import re
 from typing import TYPE_CHECKING, override
 
 import structlog
-from sqlalchemy import ColumnElement, and_, distinct, func, or_, select
+from sqlalchemy import ColumnElement, and_, distinct, false, func, or_, select, true
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.operators import ilike_op
 
@@ -48,9 +48,14 @@ class SQLBoolExpressionBuilder(BaseVisitor[ColumnElement[bool]]):
 
     @override
     def visit_or_list(self, node: ORList) -> ColumnElement[bool]:  # type: ignore
+        if len(node.elements) == 0:
+            return true()
+
         tag_ids, bool_expressions = self.__separate_tags(node.elements, only_single=False)
         if len(tag_ids) > 0:
             bool_expressions.append(self.__entry_has_any_tags(tag_ids))
+        if len(bool_expressions) == 0:
+            return false()
         return or_(*bool_expressions)
 
     @override


### PR DESCRIPTION
### Summary
If an `ORList` has only invalid tags return `False`.

The default query is an empty `ORList` so return `True` if the `ORList` contained no elements before seperating tags.

fixes #1287 
### Tasks Completed
-   Platforms Tested:
    -   [X] Linux x86
-   Tested For:
    -   [X] Basic functionality