### PR TITLE
fix(nix): relax send2trash dependency

### DIFF
--- a/nix/package/default.nix
+++ b/nix/package/default.nix
@@ -82,6 +82,7 @@ python3Packages.buildPythonApplication {
     "rarfile"
     "requests"
     "semver"
+    "send2trash"
     "structlog"
     "typing-extensions"
   ];


### PR DESCRIPTION
### Summary

send2trash has recently increased it's major version to 2 and 2.1.0 has now landed in nixpkgs. This breaks the build as it doesn't fulfil the ~=1.8 constraint in pyproject.toml. From the [changelog](https://github.com/arsenetar/send2trash/blob/master/CHANGES.rst) the only breaking change should be dropped python 2 support, which doesn't affect us.
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [x] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
