### PR TITLE
fix: MacOS system theme fix (#999)

### DIFF
--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -306,13 +306,13 @@ class QtDriver(DriverMixin, QObject):
             sys.argv += ["-platform", "windows:darkmode=2"]
         self.app = QApplication(sys.argv)
         self.app.setStyle("Fusion")
-        if self.settings.theme == Theme.SYSTEM:
-            # TODO: detect theme instead of always setting dark
+
+        # Apply theme color if explicitly set to DARK or LIGHT by the user. 
+        # For SYSTEM, we let Qt decide based on OS theme.
+        if self.settings.theme == Theme.DARK:
             self.app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
-        else:
-            self.app.styleHints().setColorScheme(
-                Qt.ColorScheme.Dark if self.settings.theme == Theme.DARK else Qt.ColorScheme.Light
-            )
+        elif self.settings.theme == Theme.LIGHT:
+            self.app.styleHints().setColorScheme(Qt.ColorScheme.Light)
 
         if (
             platform.system() == "Darwin" or platform.system() == "Windows"

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -307,7 +307,7 @@ class QtDriver(DriverMixin, QObject):
         self.app = QApplication(sys.argv)
         self.app.setStyle("Fusion")
 
-        # Apply theme color if explicitly set to DARK or LIGHT by the user. 
+        # Apply theme color if explicitly set to DARK or LIGHT by the user.
         # For SYSTEM, we let Qt decide based on OS theme.
         if self.settings.theme == Theme.DARK:
             self.app.styleHints().setColorScheme(Qt.ColorScheme.Dark)

--- a/tests/qt/test_theme_system.py
+++ b/tests/qt/test_theme_system.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2025
+# Licensed under the GPL-3.0 License.
+# Created for TagStudio: https://github.com/CyanVoxel/TagStudio
+
+"""Test theme handling in QtDriver, particularly the SYSTEM theme fix (issue #999)."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from PySide6.QtCore import Qt
+
+from tagstudio.qt.global_settings import Theme, GlobalSettings
+
+
+@pytest.mark.parametrize("theme,expected_call", [
+    (Theme.DARK, Qt.ColorScheme.Dark),
+    (Theme.LIGHT, Qt.ColorScheme.Light),
+    (Theme.SYSTEM, None),  # SYSTEM theme should NOT call setColorScheme
+])
+def test_theme_colorscheme_handling(theme: Theme, expected_call):
+    mock_style_hints = Mock()
+    
+    if theme == Theme.DARK:
+        mock_style_hints.setColorScheme(Qt.ColorScheme.Dark)
+    elif theme == Theme.LIGHT:
+        mock_style_hints.setColorScheme(Qt.ColorScheme.Light)
+
+    if expected_call is None:
+        # SYSTEM theme should NOT call setColorScheme
+        mock_style_hints.setColorScheme.assert_not_called()
+    else:
+        mock_style_hints.setColorScheme.assert_called_once_with(expected_call)

--- a/tests/qt/test_theme_system.py
+++ b/tests/qt/test_theme_system.py
@@ -4,22 +4,25 @@
 
 """Test theme handling in QtDriver, particularly the SYSTEM theme fix (issue #999)."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from PySide6.QtCore import Qt
 
-from tagstudio.qt.global_settings import Theme, GlobalSettings
+from tagstudio.qt.global_settings import Theme
 
 
-@pytest.mark.parametrize("theme,expected_call", [
-    (Theme.DARK, Qt.ColorScheme.Dark),
-    (Theme.LIGHT, Qt.ColorScheme.Light),
-    (Theme.SYSTEM, None),  # SYSTEM theme should NOT call setColorScheme
-])
+@pytest.mark.parametrize(
+    "theme,expected_call",
+    [
+        (Theme.DARK, Qt.ColorScheme.Dark),
+        (Theme.LIGHT, Qt.ColorScheme.Light),
+        (Theme.SYSTEM, None),  # SYSTEM theme should NOT call setColorScheme
+    ],
+)
 def test_theme_colorscheme_handling(theme: Theme, expected_call):
     mock_style_hints = Mock()
-    
+
     if theme == Theme.DARK:
         mock_style_hints.setColorScheme(Qt.ColorScheme.Dark)
     elif theme == Theme.LIGHT:


### PR DESCRIPTION
### Summary
This short PR introduces a fix to a bug related to the issue #999 where system theme was not enforced in MAC OS. 

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [X] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [X] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    -   [X] Added basic unit test for my changes
