### PR TITLE
Fix: correct ESCAPABLE_CHARS in query_lang tokenizer

### DIFF
--- a/src/tagstudio/core/query_lang/tokenizer.py
+++ b/src/tagstudio/core/query_lang/tokenizer.py
@@ -61,7 +61,7 @@ class Tokenizer:
     pos: int
     current_char: str | None
 
-    ESCAPABLE_CHARS = ["\\", '"', '"']
+    ESCAPABLE_CHARS = ["\\", '"', "'"]
     NOT_IN_ULITERAL = [":", " ", "[", "]", "(", ")", "=", ","]
 
     def __init__(self, text: str) -> None:


### PR DESCRIPTION
was tracing a parsing issue with names containing apostrophes and noticed the ESCAPABLE_CHARS list had a duplicate double-quote where a single-quote should be. fixed it and verified O'Brien now tokenizes correctly.

### Summary
Fixes a tokenizer bug where escaped single-quotes inside single-quoted strings were not handled properly due to a typo in ESCAPABLE_CHARS.

### Tasks Completed
- Platforms Tested:
    - [x] Windows x86
- Tested For:
    - [ ] Basic functionality
    - [ ] PyInstaller executable