### PR TITLE
fix(security): Use bounded parameters for reserved-tag init

### DIFF
--- a/src/tagstudio/core/library/alchemy/db.py
+++ b/src/tagstudio/core/library/alchemy/db.py
@@ -57,11 +57,15 @@ def make_tables(engine: Engine) -> None:
                 conn.execute(
                     text(
                         "INSERT INTO tags "
-                        "(id, name, color_namespace, color_slug, is_category, is_hidden) VALUES "
-                        f"({RESERVED_TAG_END}, 'temp', NULL, NULL, false, false)"
-                    )
+                        "(id, name, color_namespace, color_slug, is_category, is_hidden) "
+                        "VALUES (:tag_id, 'temp', NULL, NULL, false, false)"
+                    ),
+                    {"tag_id": RESERVED_TAG_END},
                 )
-                conn.execute(text(f"DELETE FROM tags WHERE id = {RESERVED_TAG_END}"))
+                conn.execute(
+                    text("DELETE FROM tags WHERE id = :tag_id"),
+                    {"tag_id": RESERVED_TAG_END},
+                )
                 conn.commit()
             except OperationalError as e:
                 logger.error("Could not initialize built-in tags", error=e)


### PR DESCRIPTION
### Summary

The startup migration that bumps tags-table autoincrement past the reserved range is built from a pair of SQL statements using f-strings.

While `RESERVED_TAG_END` is hard-coded at the moment, it's a scary pattern that can turn into a SQL injection site if that value ever originates from another location.

I swapped the `tag_id` to a SQLAlchemy bind paramter (`:tag_id`) to fix that and so it matches the other queries in the codebase.

This really just amounts to a code smell that could be a footgun in the future.

### Why no new tests

This a  simple refactor with no behavioral changes.

`make_tables(engine)` is already exercised through every library-creating fixture in the existing test suite.

### Tasks Completed

- Platforms Tested:
  - [ ] Windows x86
  - [ ] Windows ARM
  - [ ] macOS x86
  - [ ] macOS ARM
  - [X] Linux x86
  - [ ] Linux ARM
- Tested For:
  - [x] Basic Functionality
  - [ ] PyInstalled Executable
  - [x] `pytest` 231  tests still pass
  - [x] `ruff check src/tagstudio tests`
  - [x] `mypy` on changed files