### PR TITLE
docs/chore: add .editorconfig and .prettierrc.toml configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,8 +18,5 @@ trim_trailing_whitespace = true
 [*.{css,json,md}]
 indent_size = 4
 
-[*.md]
-trim_trailing_whitespace = false
-
 [*.{yaml,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: (c) TagStudio Contributors
+# SPDX-License-Identifier: MIT
+
+# EditorConfig https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+trim_trailing_whitespace = true
+
+[*.{css,json,md}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: (c) TagStudio Contributors
+# SPDX-License-Identifier: MIT
+
+# Prettier https://prettier.io/
+
+bracketSameLine = false
+bracketSpacing = true
+objectWrap = "preserve"
+quoteProps = "as-needed"
+singleQuote = false

--- a/docs/style.md
+++ b/docs/style.md
@@ -21,6 +21,9 @@ Most of the style guidelines can be checked, fixed, and enforced via Ruff. Older
 -   When writing text for window titles or form titles, use "[Title Case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)" capitalization. Your IDE may have a command to format this for you automatically, although some may incorrectly capitalize short prepositions. In a pinch you can use a website such as [capitalizemytitle.com](https://capitalizemytitle.com/) to check.
 -   If it wasn't mentioned above, then stick to [**PEP-8**](https://peps.python.org/pep-0008/)!
 
+### Formatter Configs
+TagStudio provides an [EditorConfig](https://editorconfig.org/#example-file) file ([`.editorconfig`](../.editorconfig)) along with a [Prettier](https://prettier.io/) config file ([`.prettierrc.toml`](../.prettierrc.toml)) for formatting files other than .py files (Markdown, JSON, YAML, HTML, CSS, etc.). If editing these types of files it's recommended that you use a formatter that supports EditorConfig or has its settings matched to the EditorConfig and Prettier configs. Lastly, please pay attention to the `prettier-ignore` flags in present in some files if you are not using Prettier, as formatting these sections will break formatting used elsewhere such as the [MkDocs site](https://docs.tagstud.io/).
+
 ## Qt
 
 As of writing this section, the QT part of the code base is quite unstructured and the View and Controller parts are completely intermixed[^1]. This makes maintenance, fixes and general understanding of the code base quite challenging, because the interesting parts you are looking for are entangled in a bunch of repetitive UI setup code. To address this we are aiming to more strictly separate the view and controller aspects of the QT frontend.


### PR DESCRIPTION
### Summary

This PR adds [EditorConfig](https://editorconfig.org/#example-file) and [Prettier](https://prettier.io/) config files for use in formatting non-Python files (Markdown, JSON, YAML, HTML, CSS, etc.) and updates the STYLE.md to reference them.

If approved, I can follow this up with an additional PR that applies the solidified formatting rules across all applicable files and put that squashed commit inside `.git-blame-ignore-revs`. 

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
