### PR TITLE
refactor(docs): uniform formatting pass

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (c) TagStudio Contributors
 # SPDX-License-Identifier: GPL-3.0-only
 
-
 ---
 patreon: cyanvoxel

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,8 +3,8 @@
 ---
 name: Bug Report
 description: File a bug or issue report.
-title: '[Bug]: '
-labels: ['Type: Bug']
+title: "[Bug]: "
+labels: ["Type: Bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,8 +3,8 @@
 ---
 name: Feature Request
 description: Suggest a new feature.
-title: '[Feature Request]: '
-labels: ['Type: Enhancement']
+title: "[Feature Request]: "
+labels: ["Type: Enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
+
 ### Summary
 
 <!--
@@ -19,15 +20,15 @@ Thank you for your eagerness to contribute!
 
 <!-- No requirements, just context for reviewers. -->
 
--   Platforms Tested:
-    -   [ ] Windows x86
-    -   [ ] Windows ARM
-    -   [ ] macOS x86
-    -   [ ] macOS ARM
-    -   [ ] Linux x86
-    -   [ ] Linux ARM
-    <!-- If an unspecified platform was tested, please add it here -->
--   Tested For:
-    -   [ ] Basic functionality
-    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
-    <!-- If other important criteria was tested for, please add it here -->
+- Platforms Tested:
+    - [ ] Windows x86
+    - [ ] Windows ARM
+    - [ ] macOS x86
+    - [ ] macOS ARM
+    - [ ] Linux x86
+    - [ ] Linux ARM
+      <!-- If an unspecified platform was tested, please add it here -->
+- Tested For:
+    - [ ] Basic functionality
+    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
+      <!-- If other important criteria was tested for, please add it here -->

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: pip
 
       - name: Install Python dependencies

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: pip
 
       - name: Install Python dependencies
@@ -45,7 +45,7 @@ jobs:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
-                  mkdocs-material-
+            mkdocs-material-
 
       - name: Execute mkdocs
         run: mkdocs gh-deploy --force

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,7 +19,7 @@ jobs:
         name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: pip
 
       - &install-dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   linux:
     strategy:
       matrix:
-        build-type: ['', portable]
+        build-type: ["", portable]
         include:
-          - build-type: ''
-            build-flag: ''
-            suffix: ''
+          - build-type: ""
+            build-flag: ""
+            suffix: ""
           - build-type: portable
             build-flag: --portable
             suffix: _portable
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: pip
 
       - name: Install Python dependencies
@@ -50,18 +50,18 @@ jobs:
   macos:
     strategy:
       matrix:
-        os-version: ['14', '15']
+        os-version: ["14", "15"]
         include:
-          - os-version: '14'
+          - os-version: "14"
             arch: x86_64
-          - os-version: '15'
+          - os-version: "15"
             arch: aarch64
 
     runs-on: macos-${{ matrix.os-version }}
 
     env:
       # INFO: Even though we run on 14, target towards compatibility
-      MACOSX_DEPLOYMENT_TARGET: '11.0'
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
 
     steps:
       - name: Checkout repo
@@ -70,14 +70,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: pip
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade uv
           uv pip install --system .[pyinstaller]
-
 
       - name: Execute PyInstaller
         run: |
@@ -92,12 +91,12 @@ jobs:
   windows:
     strategy:
       matrix:
-        build-type: ['', portable]
+        build-type: ["", portable]
         include:
-          - build-type: ''
-            build-flag: ''
-            suffix: ''
-            file-end: ''
+          - build-type: ""
+            build-flag: ""
+            suffix: ""
+            file-end: ""
           - build-type: portable
             build-flag: --portable
             suffix: _portable
@@ -112,7 +111,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: pip
 
       - name: Install Python dependencies

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: (c) TagStudio Contributors
+# SPDX-License-Identifier: MIT
+
 overrides/partials/*.html
 tests/fixtures/json_library/.TagStudio/*.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+overrides/partials/*.html
+tests/fixtures/json_library/.TagStudio/*.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
+
 # TagStudio: A User-Focused Photo & File Management System
 
 [![Downloads](https://img.shields.io/github/downloads/TagStudioDev/TagStudio/total.svg?maxAge=2592001)](https://github.com/TagStudioDev/TagStudio/releases)
@@ -23,11 +24,11 @@ TagStudio is a photo & file organization application with an underlying tag-base
 
 ## Contents
 
--   [Feature Highlights](#feature-highlights)
--   [Basic Usage](#basic-usage)
--   [Installation](#installation)
--   [Goals & Priorities](#goals--priorities)
--   [FAQ](#faq)
+- [Feature Highlights](#feature-highlights)
+- [Basic Usage](#basic-usage)
+- [Installation](#installation)
+- [Goals & Priorities](#goals--priorities)
+- [FAQ](#faq)
 
 Translation hosting generously provided by [Weblate](https://weblate.org/en/). Check out our [project page](https://hosted.weblate.org/projects/tagstudio/) to help translate TagStudio!
 
@@ -45,16 +46,16 @@ All file types are supported in TagStudio libraries, just not all have dedicated
 
 For a generalized list of what's currently supported:
 
--   **Images**
-    -   Raster Images (JPEG, PNG, etc.)
-    -   Vector (SVG)
-    -   Animated (GIF, WEBP, APNG)
-    -   RAW Formats
--   **Videos**
--   **Plaintext Files**
--   **Documents** _(If supported)_
--   **eBooks** _(If supported)_
--   **Photoshop PSDs**, **Blender Projects**, **Krita Projects**, and more!
+- **Images**
+    - Raster Images (JPEG, PNG, etc.)
+    - Vector (SVG)
+    - Animated (GIF, WEBP, APNG)
+    - RAW Formats
+- **Videos**
+- **Plaintext Files**
+- **Documents** _(If supported)_
+- **eBooks** _(If supported)_
+- **Photoshop PSDs**, **Blender Projects**, **Krita Projects**, and more!
 
 ### [Tags](https://docs.tagstud.io/tags) and [Fields](https://docs.tagstud.io/fields)
 
@@ -62,28 +63,28 @@ Tags represent an object or attribute - this could be a person, place, object, c
 
 Tags currently consist of the following attributes:
 
--   **Name**: The full name for your tag. **_This does NOT have to be unique!_**
--   **Shorthand Name**: The shortest alternate name for your tag, used for abbreviations.
--   **Aliases**: Alternate names your tag goes by.
--   **Color**: The display color of your tag.
--   **Parent Tags**: Other tags in which this tag inherits from. In practice, this means that this tag can be substituted in searches for any listed parent tags.
-    -   Parent tags checked with the "disambiguation" checkbox next to them will be used to help disambiguate tag names that may not be unique.
-    -   For example: If you had a tag for "Freddy Fazbear", you might add "Five Nights at Freddy's" as one of the parent tags. If the disambiguation box is checked next to "Five Nights at Freddy's" parent tag, then the tag "Freddy Fazbear" will display as "Freddy Fazbear (Five Nights at Freddy's)". Furthermore, if the "Five Nights at Freddy's" tag has a shorthand like "FNAF", then the "Freddy Fazbear" tag will display as "Freddy Fazbear (FNAF)".
--   **Is Category**: A property that when checked, treats this tag as a category in the preview panel.
+- **Name**: The full name for your tag. **_This does NOT have to be unique!_**
+- **Shorthand Name**: The shortest alternate name for your tag, used for abbreviations.
+- **Aliases**: Alternate names your tag goes by.
+- **Color**: The display color of your tag.
+- **Parent Tags**: Other tags in which this tag inherits from. In practice, this means that this tag can be substituted in searches for any listed parent tags.
+    - Parent tags checked with the "disambiguation" checkbox next to them will be used to help disambiguate tag names that may not be unique.
+    - For example: If you had a tag for "Freddy Fazbear", you might add "Five Nights at Freddy's" as one of the parent tags. If the disambiguation box is checked next to "Five Nights at Freddy's" parent tag, then the tag "Freddy Fazbear" will display as "Freddy Fazbear (Five Nights at Freddy's)". Furthermore, if the "Five Nights at Freddy's" tag has a shorthand like "FNAF", then the "Freddy Fazbear" tag will display as "Freddy Fazbear (FNAF)".
+- **Is Category**: A property that when checked, treats this tag as a category in the preview panel.
 
 Fields, like tags, are additional pieces of custom metadata that you can add to your file entries. Fields currently have several hardcoded names (e.g. "Title", "Author", "Series") but custom field names are planned for an upcoming update.
 
 Field types currently include:
 
--   **Text Lines**: Single lines of text.
--   **Text Boxes**: Multi-line pieces of text.
--   **Datetimes**: Dates and times.
+- **Text Lines**: Single lines of text.
+- **Text Boxes**: Multi-line pieces of text.
+- **Datetimes**: Dates and times.
 
 ### [Search](https://docs.tagstud.io/search)
 
--   Search for file entries based on tags, file path (`path:`), file types (`filetype:`), and even media types! (`mediatype:`). Path searches currently use [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) syntax, so you may need to wrap your filename or filepath in asterisks while searching. This will not be strictly necessary in future versions of the program.
--   Use and combine boolean operators (`AND`, `OR`, `NOT`) along with parentheses groups, quotation escaping, and underscore substitution to create detailed search queries
--   Use special search conditions (`special:untagged` and `special:empty`) to find file entries without tags or fields, respectively
+- Search for file entries based on tags, file path (`path:`), file types (`filetype:`), and even media types! (`mediatype:`). Path searches currently use [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) syntax, so you may need to wrap your filename or filepath in asterisks while searching. This will not be strictly necessary in future versions of the program.
+- Use and combine boolean operators (`AND`, `OR`, `NOT`) along with parentheses groups, quotation escaping, and underscore substitution to create detailed search queries
+- Use special search conditions (`special:untagged` and `special:empty`) to find file entries without tags or fields, respectively
 
 ## Basic Usage
 
@@ -167,11 +168,11 @@ See the [**Roadmap**](docs/roadmap.md) on the documentation site for a complete 
 
 ### Overall Goals
 
--   To achieve a portable, private, extensible, open-format, and feature-rich system of organizing and rediscovering files.
--   To provide powerful methods for organization, notably the concept of tag inheritance, or "taggable tags" _(and in the near future, the combination of composition-based tags)._
--   To create an implementation of such a system that is resilient against a user’s actions outside the program (modifying, moving, or renaming files) while also not burdening the user with mandatory sidecar files or requiring them to change their existing file structures and workflows.
--   To support a wide range of users spanning across different platforms, multi-user setups, and those with large (several terabyte) libraries.
--   To make the dang thing look nice, too. It’s 2025, not 1995.
+- To achieve a portable, private, extensible, open-format, and feature-rich system of organizing and rediscovering files.
+- To provide powerful methods for organization, notably the concept of tag inheritance, or "taggable tags" _(and in the near future, the combination of composition-based tags)._
+- To create an implementation of such a system that is resilient against a user’s actions outside the program (modifying, moving, or renaming files) while also not burdening the user with mandatory sidecar files or requiring them to change their existing file structures and workflows.
+- To support a wide range of users spanning across different platforms, multi-user setups, and those with large (several terabyte) libraries.
+- To make the dang thing look nice, too. It’s 2025, not 1995.
 
 ### Project Priorities
 
@@ -199,29 +200,29 @@ See the [roadmap](https://docs.tagstud.io/roadmap) page for the core features be
 
 The most important remaining features before I consider the program to be "feature complete" are:
 
--   Custom names for Fields
--   List views for files
--   Multiple root directory support for libraries
--   Improved file entry relinking
--   File entry groups
--   Sorting by file date modified and created
--   Macros
--   Improved search bar with visualized tags and improved autocomplete
--   Side panel for easier tagging (pinned tags, recent tags, tag search, tag palette)
--   Improved tag management interface
--   Improved and finalized Tag Categories
--   Fixed and improved mixed entry data displays (see: [#337](https://github.com/TagStudioDev/TagStudio/issues/337))
--   Sharable tag data
--   Separate core library + API
+- Custom names for Fields
+- List views for files
+- Multiple root directory support for libraries
+- Improved file entry relinking
+- File entry groups
+- Sorting by file date modified and created
+- Macros
+- Improved search bar with visualized tags and improved autocomplete
+- Side panel for easier tagging (pinned tags, recent tags, tag search, tag palette)
+- Improved tag management interface
+- Improved and finalized Tag Categories
+- Fixed and improved mixed entry data displays (see: [#337](https://github.com/TagStudioDev/TagStudio/issues/337))
+- Sharable tag data
+- Separate core library + API
 
 ### What features will NOT be added?
 
--   Native Cloud Integration
-    -   There are plenty of services already (native or third-party) that allow you to mount your cloud drives as virtual drives on your system. Hosting a TagStudio library on one of these mounts should function similarly to what native integration would look like.
-    -   Supporting native cloud integrations such as these would be an unnecessary "reinventing the wheel" burden for us that is outside the scope of this project.
--   Native ChatGPT/Claude/Gemini/_Non-Local_ LLM Integration
-    -   This could mean different things depending on your intentions. Whether it's trying to use an LLM to replace the native search, or to trying to use a model for image recognition, I'm not interested in hooking people's TagStudio libraries into non-local LLMs such as ChatGPT and/or turn the program into a "chatbot" interface (see: [Overall Goals/Privacy](#overall-goals)).
-    -   With that being said, the future TagStudio API should be well-suited to connect to any sort of service you'd like, including machine learning models if so you choose. I just won't _personally_ add any native integrations with online services.
+- Native Cloud Integration
+    - There are plenty of services already (native or third-party) that allow you to mount your cloud drives as virtual drives on your system. Hosting a TagStudio library on one of these mounts should function similarly to what native integration would look like.
+    - Supporting native cloud integrations such as these would be an unnecessary "reinventing the wheel" burden for us that is outside the scope of this project.
+- Native ChatGPT/Claude/Gemini/_Non-Local_ LLM Integration
+    - This could mean different things depending on your intentions. Whether it's trying to use an LLM to replace the native search, or to trying to use a model for image recognition, I'm not interested in hooking people's TagStudio libraries into non-local LLMs such as ChatGPT and/or turn the program into a "chatbot" interface (see: [Overall Goals/Privacy](#overall-goals)).
+    - With that being said, the future TagStudio API should be well-suited to connect to any sort of service you'd like, including machine learning models if so you choose. I just won't _personally_ add any native integrations with online services.
 
 ### Is a Rust port coming?
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -41,6 +41,9 @@ SPDX-FileCopyrightText = "(c) 2026 Boxicons"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
-path = ["src/tagstudio/resources/qt/images/volume.svg", "src/tagstudio/resources/qt/images/volume_mute.svg"]
+path = [
+    "src/tagstudio/resources/qt/images/volume.svg",
+    "src/tagstudio/resources/qt/images/volume_mute.svg",
+]
 SPDX-FileCopyrightText = "(c) github:google/material-design-icons Contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/contrib/.vscode/launch.json
+++ b/contrib/.vscode/launch.json
@@ -8,10 +8,7 @@
             "program": "${workspaceRoot}/src/tagstudio/main.py",
             "console": "integratedTerminal",
             "justMyCode": true,
-            "args": [
-                "-o",
-                "~/Documents/Example"
-            ]
+            "args": ["-o", "~/Documents/Example"]
         }
     ]
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@ title: Changelog
 icon: material/script-text
 toc_depth: 2
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -14,44 +15,44 @@ toc_depth: 2
 
 #### New Settings
 
--   feat(ui): add thumbnail cache size setting to settings panel by @CyanVoxel in #1088
--   feat: add cached thumbnail quality and resolution settings by @CyanVoxel in #1101
-    -   Only available by editing the `cached_thumb_quality` and `cached_thumb_resolution` options in the `settings.toml` config file
--   fix: add option to use old Windows 'start' command by @CyanVoxel in #1084
-    -   Only available by editing the `windows_start_command` option in the `settings.toml` file
-    -   Fixes niche issue on Windows systems, see #1036
--   translations: add Czech, Portuguese (Portugal), and Romanian to settings panel (2db8bed)
+- feat(ui): add thumbnail cache size setting to settings panel by @CyanVoxel in #1088
+- feat: add cached thumbnail quality and resolution settings by @CyanVoxel in #1101
+    - Only available by editing the `cached_thumb_quality` and `cached_thumb_resolution` options in the `settings.toml` config file
+- fix: add option to use old Windows 'start' command by @CyanVoxel in #1084
+    - Only available by editing the `windows_start_command` option in the `settings.toml` file
+    - Fixes niche issue on Windows systems, see #1036
+- translations: add Czech, Portuguese (Portugal), and Romanian to settings panel (2db8bed)
 
 #### File Previews
 
--   feat: render .cbr thumbnails by @Sola-ris in #1112
--   feat: render .cbt thumbnails by @Sola-ris in #1116
+- feat: render .cbr thumbnails by @Sola-ris in #1112
+- feat: render .cbt thumbnails by @Sola-ris in #1116
 
 ### Fixed
 
--   fix: JSON migration window getting stuck on finishing migration by @CyanVoxel in #1094
--   fix: VTF files not rendering on Linux by @CyanVoxel in #1093
--   fix: account for leading slash ignore pattern by @CyanVoxel in #1092
--   fix: add option to use old Windows 'start' command by @CyanVoxel in #1084
--   fix: always show first frame of video; autoplay will always play by @SumithSudheer and @CyanVoxel in #1104
--   feat: read epub cover from ComicInfo.xml, if available. by @Sola-ris in #1109 and #1111
--   fix: prevent mnemonic removal from removing escaped ampersands by @CyanVoxel in #1110
--   fix: properly delete tag_parents row when deleting tag by @CyanVoxel in #1107
+- fix: JSON migration window getting stuck on finishing migration by @CyanVoxel in #1094
+- fix: VTF files not rendering on Linux by @CyanVoxel in #1093
+- fix: account for leading slash ignore pattern by @CyanVoxel in #1092
+- fix: add option to use old Windows 'start' command by @CyanVoxel in #1084
+- fix: always show first frame of video; autoplay will always play by @SumithSudheer and @CyanVoxel in #1104
+- feat: read epub cover from ComicInfo.xml, if available. by @Sola-ris in #1109 and #1111
+- fix: prevent mnemonic removal from removing escaped ampersands by @CyanVoxel in #1110
+- fix: properly delete tag_parents row when deleting tag by @CyanVoxel in #1107
 
 ### Changed
 
 #### Translations
 
--   **French** updated by @kitsumed , @RustyNova016
--   **Hungarian** updated by @smileyhead
--   **Russian** updated by @purpletennisball
--   **Spanish** updated by @danpg94
--   **Toki Pona** updated by @Math-Bee
+- **French** updated by @kitsumed , @RustyNova016
+- **Hungarian** updated by @smileyhead
+- **Russian** updated by @purpletennisball
+- **Spanish** updated by @danpg94
+- **Toki Pona** updated by @Math-Bee
 
 #### Internal Changes
 
--   refactor: untangle backend and frontend files by @CyanVoxel in #1095
--   refactor: fix most pyright issues in `library/alchemy/` by @CyanVoxel in #1103
+- refactor: untangle backend and frontend files by @CyanVoxel in #1095
+- refactor: fix most pyright issues in `library/alchemy/` by @CyanVoxel in #1103
 
 ---
 
@@ -67,14 +68,14 @@ The previous system for ignoring file extensions has been replaced by a new `.gi
 
 Along with this system also comes the additional features:
 
--   TagStudio can now traverse symlinks in your library folders
--   TagStudio can now leverage [ripgrep](https://github.com/BurntSushi/ripgrep), a rust-based directory search tool, for faster library refreshing
-    -   ripgrep must be [installed on your system](https://docs.tagstud.io/install/#ripgrep) and able to be located by TagStudio
+- TagStudio can now traverse symlinks in your library folders
+- TagStudio can now leverage [ripgrep](https://github.com/BurntSushi/ripgrep), a rust-based directory search tool, for faster library refreshing
+    - ripgrep must be [installed on your system](https://docs.tagstud.io/install/#ripgrep) and able to be located by TagStudio
 
 ##### Pull Requests:
 
--   feat: add `.ts_ignore` pattern ignoring system by @CyanVoxel in #897
--   feat: replace extension exclusion system with `.ts_ignore` by @CyanVoxel in #1046
+- feat: add `.ts_ignore` pattern ignoring system by @CyanVoxel in #897
+- feat: replace extension exclusion system with `.ts_ignore` by @CyanVoxel in #1046
 
 #### Library Information Window
 
@@ -84,59 +85,59 @@ A new "Library Information" window has been added and is accessible under the "V
 
 ##### Pull Requests:
 
--   feat: add LibraryInfoWindow with library statistics by @CyanVoxel in #1056
--   feat: add library cleanup screen and 'fix ignored files' window by @CyanVoxel in #1070
+- feat: add LibraryInfoWindow with library statistics by @CyanVoxel in #1056
+- feat: add library cleanup screen and 'fix ignored files' window by @CyanVoxel in #1070
 
 #### Other Additions
 
--   feat: add random sorting by @TheBobBobs in #1029
--   feat: add exr thumbnail support by @CyanVoxel in #1035
--   feat: add thumbnail generation toggle by @ZwodahS in #1057
--   feat: cli version argument by @HeikoWasTaken in #1060
--   feat: add setting to select splash screen by @CyanVoxel in #1077
-    -   Includes a new "'95" splash screen originally intended for the [9.5.0](https://github.com/TagStudioDev/TagStudio/releases/tag/v9.5.0) release
+- feat: add random sorting by @TheBobBobs in #1029
+- feat: add exr thumbnail support by @CyanVoxel in #1035
+- feat: add thumbnail generation toggle by @ZwodahS in #1057
+- feat: cli version argument by @HeikoWasTaken in #1060
+- feat: add setting to select splash screen by @CyanVoxel in #1077
+    - Includes a new "'95" splash screen originally intended for the [9.5.0](https://github.com/TagStudioDev/TagStudio/releases/tag/v9.5.0) release
 
 <img width="540" height="360" alt="splash_selection_half" src="https://github.com/user-attachments/assets/3cd6562f-0eaf-420d-9d70-d10d1519da84" />
 
 ### Fixed
 
--   fix: searching with internal tag ids ignores sorting order by @CyanVoxel in #1038
--   fix: folders with names of unlinked entries are linked by @purpletennisball in #1027
--   fix: parent tags in tag editor are uneditable by @purpletennisball in #1073
--   feat: auto mnemonics by @Computerdores in #1082 and #1083
+- fix: searching with internal tag ids ignores sorting order by @CyanVoxel in #1038
+- fix: folders with names of unlinked entries are linked by @purpletennisball in #1027
+- fix: parent tags in tag editor are uneditable by @purpletennisball in #1073
+- feat: auto mnemonics by @Computerdores in #1082 and #1083
 
 ### Changed
 
 #### Performance
 
--   perf: optimize sql for or queries by @TheBobBobs in #948
--   perf: Optimize db queries for preview panel by @TheBobBobs in #942
--   fix: add tags to selected entries in bulk not individually by @Computerdores in #1028
+- perf: optimize sql for or queries by @TheBobBobs in #948
+- perf: Optimize db queries for preview panel by @TheBobBobs in #942
+- fix: add tags to selected entries in bulk not individually by @Computerdores in #1028
 
 #### Translations
 
--   **Chinese** _(Traditional Han Script)_ by @tkiuvvv233
--   **French** updated by @Bamowen, @kitsumed
--   **German** updated by @Livesi5e
--   **Hungarian** updated by @smileyhead
--   **Japanese** updated by wany-oh
--   **Polish** updated by @FeatherPrince
--   **Portuguese** updated by @SantosSi
--   **Romanian** updated by @VLTNOgithub
--   **Russian** updated by @Dott-rus
--   **Spanish** updated by @JCC1998
--   **Swedish** updated by konto
+- **Chinese** _(Traditional Han Script)_ by @tkiuvvv233
+- **French** updated by @Bamowen, @kitsumed
+- **German** updated by @Livesi5e
+- **Hungarian** updated by @smileyhead
+- **Japanese** updated by wany-oh
+- **Polish** updated by @FeatherPrince
+- **Portuguese** updated by @SantosSi
+- **Romanian** updated by @VLTNOgithub
+- **Russian** updated by @Dott-rus
+- **Spanish** updated by @JCC1998
+- **Swedish** updated by konto
 
 #### Internal Changes
 
--   feat: swap IDs in tag_parents table by @HeikoWasTaken in #998
-    -   fix: swap parent and child logic for TAG_CHILDREN_QUERY by @CyanVoxel in #1064
--   fix(nix): fixup and rework, always use nixpkgs PySide/Qt by @xarvex in #1048
--   refactor: make cache_manager thread safe by @TheBobBobs in #1039
--   ci(tests): fix broken tests and add type hints by @CyanVoxel in #1062
--   refactor: store DB version inside `versions` table by @CyanVoxel in #1058
--   refactor: unwrap instead of assert not None by @Computerdores in #1068
--   chore(thumb_renderer): prepare for pillow_heif removing AVIF support by @xarvex in #1065
+- feat: swap IDs in tag_parents table by @HeikoWasTaken in #998
+    - fix: swap parent and child logic for TAG_CHILDREN_QUERY by @CyanVoxel in #1064
+- fix(nix): fixup and rework, always use nixpkgs PySide/Qt by @xarvex in #1048
+- refactor: make cache_manager thread safe by @TheBobBobs in #1039
+- ci(tests): fix broken tests and add type hints by @CyanVoxel in #1062
+- refactor: store DB version inside `versions` table by @CyanVoxel in #1058
+- refactor: unwrap instead of assert not None by @Computerdores in #1068
+- chore(thumb_renderer): prepare for pillow_heif removing AVIF support by @xarvex in #1065
 
 ---
 
@@ -144,78 +145,78 @@ A new "Library Information" window has been added and is accessible under the "V
 
 ### Added
 
--   Datetime fields by @Computerdores in #921, #946, and #926
--   Add date_format and hour_format settings by @JCC1998 in #904
--   Invert selection by @zfbx in #909
--   Show stems for extension-less files by @CyanVoxel in #899
--   Press enter when adding fields by @rsazra in #941
--   Option to change tag click behavior by @Computerdores in #945
--   Krita/Open Raster thumbnails by @mashed5894 in #985
--   Zoom keyboard shortcuts by @purpletennisball in #956
--   Clickable links in text fields by @TrigamDev in #924
+- Datetime fields by @Computerdores in #921, #946, and #926
+- Add date_format and hour_format settings by @JCC1998 in #904
+- Invert selection by @zfbx in #909
+- Show stems for extension-less files by @CyanVoxel in #899
+- Press enter when adding fields by @rsazra in #941
+- Option to change tag click behavior by @Computerdores in #945
+- Krita/Open Raster thumbnails by @mashed5894 in #985
+- Zoom keyboard shortcuts by @purpletennisball in #956
+- Clickable links in text fields by @TrigamDev in #924
 
 ### Fixed
 
--   Restore page navigation state by @Computerdores in #933
--   Proper error on unterminated quoted string by @Computerdores in #936
--   Creating new tag now refreshes the menu using the current search text by @purpletennisball in #939
--   Preview thumbnails don't scale as large as they could by @Computerdores in #1005
--   Add Nix path to FFmpeg locations on macOS by @thibmaek in #990
--   Use srctools instead of vtf2img to render vtf files by @CyanVoxel in #1014
+- Restore page navigation state by @Computerdores in #933
+- Proper error on unterminated quoted string by @Computerdores in #936
+- Creating new tag now refreshes the menu using the current search text by @purpletennisball in #939
+- Preview thumbnails don't scale as large as they could by @Computerdores in #1005
+- Add Nix path to FFmpeg locations on macOS by @thibmaek in #990
+- Use srctools instead of vtf2img to render vtf files by @CyanVoxel in #1014
 
 ### Changed
 
--   Add parent tags to `folders_to_tags` macro and start tagging at root folder by @rsazra in #940
--   Optimize page loading by @TheBobBobs in #954
--   Add arrow icons for navigation buttons by @CyanVoxel in #1016
--   Tweak media player style and behavior by @CyanVoxel in #1025
+- Add parent tags to `folders_to_tags` macro and start tagging at root folder by @rsazra in #940
+- Optimize page loading by @TheBobBobs in #954
+- Add arrow icons for navigation buttons by @CyanVoxel in #1016
+- Tweak media player style and behavior by @CyanVoxel in #1025
 
 ### Translations
 
--   **Chinese** _(Simplified Han Script)_ added and updated by @tkiuvvv233, Luoyu, @ngivanyh
--   **Dutch** updated by @Pheubel
--   **Filipino** updated by @searinminecraft
--   **French** updated by @kitsumed
--   **German** updated by @Livesi5e, @Stereo157E
--   **Hungarian** updated by @smileyhead
--   **Japanese** updated by wany-oh
--   **Norwegian Bokmål** updated by @Neemek
--   **Polish** updated by @FeatherPrince
--   **Russian** updated by @Dott-rus, Utof, @maximmax42
--   **Spanish** updated by @JCC1998, Joan, Sunny, @danpg94
--   **Tamil** updated by @TamilNeram
--   **Toki Pona** updated by @Math-Bee
--   **Viossa** updated by @Nginearing
+- **Chinese** _(Simplified Han Script)_ added and updated by @tkiuvvv233, Luoyu, @ngivanyh
+- **Dutch** updated by @Pheubel
+- **Filipino** updated by @searinminecraft
+- **French** updated by @kitsumed
+- **German** updated by @Livesi5e, @Stereo157E
+- **Hungarian** updated by @smileyhead
+- **Japanese** updated by wany-oh
+- **Norwegian Bokmål** updated by @Neemek
+- **Polish** updated by @FeatherPrince
+- **Russian** updated by @Dott-rus, Utof, @maximmax42
+- **Spanish** updated by @JCC1998, Joan, Sunny, @danpg94
+- **Tamil** updated by @TamilNeram
+- **Toki Pona** updated by @Math-Bee
+- **Viossa** updated by @Nginearing
 
 ### Internal Changes
 
--   refactor: type fixes and minor improvements to preview_thumb.py by @VasigaranAndAngel in #906
--   fix(test): Fix tests to pass on windows without disrupting other platforms by @zfbx in #903
--   chore(pyproject): version bumping/relaxing by @xarvex in #886
--   fix: tests were overwriting the settings.toml by @Computerdores in #928
--   fix(nix/package): override PySide6 if later version is being used by @xarvex in #917
--   refactor: split QtDriver into View and Controller to follow MVC model by @Computerdores in #935
--   refactor: resource_manager.py by @VasigaranAndAngel in #958
--   Type fixes to folders_to_tags.py, collage_icon.py and item_thumb.py by @VasigaranAndAngel in #959
--   Type fixes to preview_panel.py, progress.py, tag.py and tag_box.py by @VasigaranAndAngel in #961
--   Type improvements to landing.py and panel.py by @VasigaranAndAngel in #960
--   refactor(preview_panel): mvc split by @Computerdores in #952
--   refactor(preview_thumb): mvc split by @Computerdores in #978
--   refactor: type improvements for main_window.py by @VasigaranAndAngel in #957
--   fix(library): get_tag_by_name by @Computerdores in #1006
--   fix: ensure initial browsing state uses UI values by @CyanVoxel in #1008
--   refactor(tag_box): mvc split by @Computerdores in #1003
--   fix(ui): hide empty ProgressWidget cancel button by @CyanVoxel in #1011
--   fix(ui): fix audio waveform generation on numpy 2.3 by @CyanVoxel in #1013
--   refactor: replace remaining instances of logging with structlog by @CyanVoxel in #1012
--   fix: don't fail when posix env var is not present by @Computerdores in #1018
--   fix(ui): show correct thumb labels by @CyanVoxel in #1010
+- refactor: type fixes and minor improvements to preview_thumb.py by @VasigaranAndAngel in #906
+- fix(test): Fix tests to pass on windows without disrupting other platforms by @zfbx in #903
+- chore(pyproject): version bumping/relaxing by @xarvex in #886
+- fix: tests were overwriting the settings.toml by @Computerdores in #928
+- fix(nix/package): override PySide6 if later version is being used by @xarvex in #917
+- refactor: split QtDriver into View and Controller to follow MVC model by @Computerdores in #935
+- refactor: resource_manager.py by @VasigaranAndAngel in #958
+- Type fixes to folders_to_tags.py, collage_icon.py and item_thumb.py by @VasigaranAndAngel in #959
+- Type fixes to preview_panel.py, progress.py, tag.py and tag_box.py by @VasigaranAndAngel in #961
+- Type improvements to landing.py and panel.py by @VasigaranAndAngel in #960
+- refactor(preview_panel): mvc split by @Computerdores in #952
+- refactor(preview_thumb): mvc split by @Computerdores in #978
+- refactor: type improvements for main_window.py by @VasigaranAndAngel in #957
+- fix(library): get_tag_by_name by @Computerdores in #1006
+- fix: ensure initial browsing state uses UI values by @CyanVoxel in #1008
+- refactor(tag_box): mvc split by @Computerdores in #1003
+- fix(ui): hide empty ProgressWidget cancel button by @CyanVoxel in #1011
+- fix(ui): fix audio waveform generation on numpy 2.3 by @CyanVoxel in #1013
+- refactor: replace remaining instances of logging with structlog by @CyanVoxel in #1012
+- fix: don't fail when posix env var is not present by @Computerdores in #1018
+- fix(ui): show correct thumb labels by @CyanVoxel in #1010
 
 ### Documentation
 
--   Update CHANGELOG.md by @Math-Bee in #914
--   Add QT MVC structure to style guide by @Computerdores in #950
--   Fix wrong date on Changelog by @ugurozturk in #966
+- Update CHANGELOG.md by @Math-Bee in #914
+- Add QT MVC structure to style guide by @Computerdores in #950
+- Fix wrong date on Changelog by @ugurozturk in #966
 
 ---
 
@@ -225,68 +226,68 @@ A new "Library Information" window has been added and is accessible under the "V
 
 #### Search
 
--   feat(ui): add setting to not display full filepaths by [@HermanKassler](https://github.com/HermanKassler) in [#841](https://github.com/TagStudioDev/TagStudio/pull/841)
--   feat: add filename and path sorting by [@Computerdores](https://github.com/Computerdores) in [#842](https://github.com/TagStudioDev/TagStudio/pull/842)
+- feat(ui): add setting to not display full filepaths by [@HermanKassler](https://github.com/HermanKassler) in [#841](https://github.com/TagStudioDev/TagStudio/pull/841)
+- feat: add filename and path sorting by [@Computerdores](https://github.com/Computerdores) in [#842](https://github.com/TagStudioDev/TagStudio/pull/842)
 
 #### Settings
 
--   feat: new settings menu + settings backend by [@Computerdores](https://github.com/Computerdores) in [#859](https://github.com/TagStudioDev/TagStudio/pull/859)
+- feat: new settings menu + settings backend by [@Computerdores](https://github.com/Computerdores) in [#859](https://github.com/TagStudioDev/TagStudio/pull/859)
 
 #### UI
 
--   feat(ui): merge media controls by [@csponge](https://github.com/csponge) in [#805](https://github.com/TagStudioDev/TagStudio/pull/805)
-    -   fix: Remove border from video preview top and left by [@zfbx](https://github.com/zfbx) in [#900](https://github.com/TagStudioDev/TagStudio/pull/900)
--   feat(ui): add more default icons and file type equivalencies by [@CyanVoxel](https://github.com/CyanVoxel) in [#882](https://github.com/TagStudioDev/TagStudio/pull/882)
--   ui: recent libraries list improvements by [@CyanVoxel](https://github.com/CyanVoxel) in [#881](https://github.com/TagStudioDev/TagStudio/pull/881)
+- feat(ui): merge media controls by [@csponge](https://github.com/csponge) in [#805](https://github.com/TagStudioDev/TagStudio/pull/805)
+    - fix: Remove border from video preview top and left by [@zfbx](https://github.com/zfbx) in [#900](https://github.com/TagStudioDev/TagStudio/pull/900)
+- feat(ui): add more default icons and file type equivalencies by [@CyanVoxel](https://github.com/CyanVoxel) in [#882](https://github.com/TagStudioDev/TagStudio/pull/882)
+- ui: recent libraries list improvements by [@CyanVoxel](https://github.com/CyanVoxel) in [#881](https://github.com/TagStudioDev/TagStudio/pull/881)
 
 #### Misc
 
--   feat: provide a .desktop file by [@xarvex](https://github.com/xarvex) in [#870](https://github.com/TagStudioDev/TagStudio/pull/870)
+- feat: provide a .desktop file by [@xarvex](https://github.com/xarvex) in [#870](https://github.com/TagStudioDev/TagStudio/pull/870)
 
 ### Fixed
 
--   fix: catch NotImplementedError for Float16 JPEG-XL files by [@CyanVoxel](https://github.com/CyanVoxel) in [#849](https://github.com/TagStudioDev/TagStudio/pull/849)
--   fix(nix/package): account for GTK platform by [@xarvex](https://github.com/xarvex) in [#868](https://github.com/TagStudioDev/TagStudio/pull/868)
--   fix: do not set palette for Linux-like systems that offer theming by [@xarvex](https://github.com/xarvex) in [#869](https://github.com/TagStudioDev/TagStudio/pull/869)
--   fix(flake): remove pinned input, only consume in Nix shell by [@xarvex](https://github.com/xarvex) in [#872](https://github.com/TagStudioDev/TagStudio/pull/872)
--   fix: stop ffmpeg cmd windows, refactor ffmpeg_checker by [@CyanVoxel](https://github.com/CyanVoxel) in [#855](https://github.com/TagStudioDev/TagStudio/pull/855)
--   fix: hide mnemonics on macOS by [@CyanVoxel](https://github.com/CyanVoxel) in [#856](https://github.com/TagStudioDev/TagStudio/pull/856)
--   fix: use UNION instead of UNION ALL by [@CyanVoxel](https://github.com/CyanVoxel) in [#877](https://github.com/TagStudioDev/TagStudio/pull/877)
--   fix: remove unescaped ampersand from "about.description" by [@CyanVoxel](https://github.com/CyanVoxel) in [#885](https://github.com/TagStudioDev/TagStudio/pull/885)
--   fix(ui): display 0 frame webp files in preview panel by [@CyanVoxel](https://github.com/CyanVoxel) in [64dc88a](https://github.com/TagStudioDev/TagStudio/commit/64dc88afa90bb11f3c9b74a2522f947370ce21db)
--   fix: close pdf file object in thumb renderer by [@Computerdores](https://github.com/Computerdores) in [#893](https://github.com/TagStudioDev/TagStudio/pull/893)
--   perf: improve responsiveness of GIF entries by [@Computerdores](https://github.com/Computerdores) in [#894](https://github.com/TagStudioDev/TagStudio/pull/894)
--   fix(ui): seamlessly loop videos by [@CyanVoxel](https://github.com/CyanVoxel) in [#902](https://github.com/TagStudioDev/TagStudio/pull/902)
+- fix: catch NotImplementedError for Float16 JPEG-XL files by [@CyanVoxel](https://github.com/CyanVoxel) in [#849](https://github.com/TagStudioDev/TagStudio/pull/849)
+- fix(nix/package): account for GTK platform by [@xarvex](https://github.com/xarvex) in [#868](https://github.com/TagStudioDev/TagStudio/pull/868)
+- fix: do not set palette for Linux-like systems that offer theming by [@xarvex](https://github.com/xarvex) in [#869](https://github.com/TagStudioDev/TagStudio/pull/869)
+- fix(flake): remove pinned input, only consume in Nix shell by [@xarvex](https://github.com/xarvex) in [#872](https://github.com/TagStudioDev/TagStudio/pull/872)
+- fix: stop ffmpeg cmd windows, refactor ffmpeg_checker by [@CyanVoxel](https://github.com/CyanVoxel) in [#855](https://github.com/TagStudioDev/TagStudio/pull/855)
+- fix: hide mnemonics on macOS by [@CyanVoxel](https://github.com/CyanVoxel) in [#856](https://github.com/TagStudioDev/TagStudio/pull/856)
+- fix: use UNION instead of UNION ALL by [@CyanVoxel](https://github.com/CyanVoxel) in [#877](https://github.com/TagStudioDev/TagStudio/pull/877)
+- fix: remove unescaped ampersand from "about.description" by [@CyanVoxel](https://github.com/CyanVoxel) in [#885](https://github.com/TagStudioDev/TagStudio/pull/885)
+- fix(ui): display 0 frame webp files in preview panel by [@CyanVoxel](https://github.com/CyanVoxel) in [64dc88a](https://github.com/TagStudioDev/TagStudio/commit/64dc88afa90bb11f3c9b74a2522f947370ce21db)
+- fix: close pdf file object in thumb renderer by [@Computerdores](https://github.com/Computerdores) in [#893](https://github.com/TagStudioDev/TagStudio/pull/893)
+- perf: improve responsiveness of GIF entries by [@Computerdores](https://github.com/Computerdores) in [#894](https://github.com/TagStudioDev/TagStudio/pull/894)
+- fix(ui): seamlessly loop videos by [@CyanVoxel](https://github.com/CyanVoxel) in [#902](https://github.com/TagStudioDev/TagStudio/pull/902)
 
 ### Internal Changes
 
--   refactor!: change layout; import and build change by [@xarvex](https://github.com/xarvex) and [@CyanVoxel](https://github.com/CyanVoxel) in [#844](https://github.com/TagStudioDev/TagStudio/pull/844)
--   fix: log all problems in translation test by [@Computerdores](https://github.com/Computerdores) in [#839](https://github.com/TagStudioDev/TagStudio/pull/839)
--   refactor: split translation keys for about screen by [@CyanVoxel](https://github.com/CyanVoxel) in [#845](https://github.com/TagStudioDev/TagStudio/pull/845)
--   feat(ci): development tooling refresh and split documentation by [@xarvex](https://github.com/xarvex) in [#867](https://github.com/TagStudioDev/TagStudio/pull/867)
--   refactor: type hints and improvements in file_opener.py by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#876](https://github.com/TagStudioDev/TagStudio/pull/876)
--   build: update spec file to use proper pathex and datas paths by [@Leonard2](https://github.com/Leonard2) in [#895](https://github.com/TagStudioDev/TagStudio/pull/895)
--   refactor: fix various missing and broken type hints@VasigaranAndAngel in [#901](https://github.com/TagStudioDev/TagStudio/pull/901)
--   refactor: fix type hints and overrides in flowlayout.py by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#880](https://github.com/TagStudioDev/TagStudio/pull/880)
+- refactor!: change layout; import and build change by [@xarvex](https://github.com/xarvex) and [@CyanVoxel](https://github.com/CyanVoxel) in [#844](https://github.com/TagStudioDev/TagStudio/pull/844)
+- fix: log all problems in translation test by [@Computerdores](https://github.com/Computerdores) in [#839](https://github.com/TagStudioDev/TagStudio/pull/839)
+- refactor: split translation keys for about screen by [@CyanVoxel](https://github.com/CyanVoxel) in [#845](https://github.com/TagStudioDev/TagStudio/pull/845)
+- feat(ci): development tooling refresh and split documentation by [@xarvex](https://github.com/xarvex) in [#867](https://github.com/TagStudioDev/TagStudio/pull/867)
+- refactor: type hints and improvements in file_opener.py by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#876](https://github.com/TagStudioDev/TagStudio/pull/876)
+- build: update spec file to use proper pathex and datas paths by [@Leonard2](https://github.com/Leonard2) in [#895](https://github.com/TagStudioDev/TagStudio/pull/895)
+- refactor: fix various missing and broken type hints@VasigaranAndAngel in [#901](https://github.com/TagStudioDev/TagStudio/pull/901)
+- refactor: fix type hints and overrides in flowlayout.py by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#880](https://github.com/TagStudioDev/TagStudio/pull/880)
 
 ### Documentation
 
--   docs: fix typos and grammar by [@Gawidev](https://github.com/Gawidev) in [#879](https://github.com/TagStudioDev/TagStudio/pull/879)
--   docs: update `ThumbRenderer` source by [@emmanuel-ferdman](https://github.com/emmanuel-ferdman) in [#896](https://github.com/TagStudioDev/TagStudio/pull/896)
+- docs: fix typos and grammar by [@Gawidev](https://github.com/Gawidev) in [#879](https://github.com/TagStudioDev/TagStudio/pull/879)
+- docs: update `ThumbRenderer` source by [@emmanuel-ferdman](https://github.com/emmanuel-ferdman) in [#896](https://github.com/TagStudioDev/TagStudio/pull/896)
 
 ### Translations
 
--   **Filipino** updated by [@searinminecraft](https://github.com/searinminecraft)
--   **French** updated by [@kitsumed](https://github.com/kitsumed)
--   **German** updated by [@DontBlameMe99](https://github.com/DontBlameMe99), [@Computerdores](https://github.com/Computerdores)
--   **Hungarian** updated by Szíjártó Levente Pál
--   **Japanese** added by [@needledetector](https://github.com/needledetector)
--   **Portuguese** _(Brazil)_ updated by [@viniciushelder](https://github.com/viniciushelder)
--   **Russian** updated by werdi, [@Dott-rus](https://github.com/Dott-rus)
--   **Spanish** updated by Joan, [@Nginearing](https://github.com/Nginearing)
--   **Tamil** updated by [@TamilNeram](https://github.com/TamilNeram)
--   **Toki Pona** updated by [@Math-Bee](https://github.com/Math-Bee)
--   **Turkish** updated by [@Nyghl](https://github.com/Nyghl)
+- **Filipino** updated by [@searinminecraft](https://github.com/searinminecraft)
+- **French** updated by [@kitsumed](https://github.com/kitsumed)
+- **German** updated by [@DontBlameMe99](https://github.com/DontBlameMe99), [@Computerdores](https://github.com/Computerdores)
+- **Hungarian** updated by Szíjártó Levente Pál
+- **Japanese** added by [@needledetector](https://github.com/needledetector)
+- **Portuguese** _(Brazil)_ updated by [@viniciushelder](https://github.com/viniciushelder)
+- **Russian** updated by werdi, [@Dott-rus](https://github.com/Dott-rus)
+- **Spanish** updated by Joan, [@Nginearing](https://github.com/Nginearing)
+- **Tamil** updated by [@TamilNeram](https://github.com/TamilNeram)
+- **Toki Pona** updated by [@Math-Bee](https://github.com/Math-Bee)
+- **Turkish** updated by [@Nyghl](https://github.com/Nyghl)
 
 ---
 
@@ -294,24 +295,24 @@ A new "Library Information" window has been added and is accessible under the "V
 
 ### Fixed
 
--   Fixed translations crashing the program and preventing it from being reopened ([#827](https://github.com/TagStudioDev/TagStudio/issues/827))
-    -   fix: restore `translate_formatted()` method as `format()` by [@CyanVoxel](https://github.com/CyanVoxel) in [#830](https://github.com/TagStudioDev/TagStudio/pull/830)
-    -   tests: add tests for translations by [@Computerdores](https://github.com/Computerdores) in [#833](https://github.com/TagStudioDev/TagStudio/pull/833)
-    -   fix(translations): fix invalid placeholders by [@CyanVoxel](https://github.com/CyanVoxel) in [#835](https://github.com/TagStudioDev/TagStudio/pull/835)
--   Removed empty parentheses from the "About" screen title
-    -   fix: separate about screen title from translations by [@CyanVoxel](https://github.com/CyanVoxel) in [#836](https://github.com/TagStudioDev/TagStudio/pull/836)
+- Fixed translations crashing the program and preventing it from being reopened ([#827](https://github.com/TagStudioDev/TagStudio/issues/827))
+    - fix: restore `translate_formatted()` method as `format()` by [@CyanVoxel](https://github.com/CyanVoxel) in [#830](https://github.com/TagStudioDev/TagStudio/pull/830)
+    - tests: add tests for translations by [@Computerdores](https://github.com/Computerdores) in [#833](https://github.com/TagStudioDev/TagStudio/pull/833)
+    - fix(translations): fix invalid placeholders by [@CyanVoxel](https://github.com/CyanVoxel) in [#835](https://github.com/TagStudioDev/TagStudio/pull/835)
+- Removed empty parentheses from the "About" screen title
+    - fix: separate about screen title from translations by [@CyanVoxel](https://github.com/CyanVoxel) in [#836](https://github.com/TagStudioDev/TagStudio/pull/836)
 
 ### Translations
 
--   **French** updated by [@alessdangelo](https://github.com/alessdangelo), [@Bamowen](https://github.com/Bamowen), [@kitsumed](https://github.com/kitsumed)
--   **German** updated by [@Thesacraft](https://github.com/Thesacraft)
--   **Portuguese** _(Brazil)_ updated by [@viniciushelder](https://github.com/viniciushelder)
--   **Russian** updated by werdei
--   **Spanish** updated by [@JCC1998](https://github.com/JCC1998)
+- **French** updated by [@alessdangelo](https://github.com/alessdangelo), [@Bamowen](https://github.com/Bamowen), [@kitsumed](https://github.com/kitsumed)
+- **German** updated by [@Thesacraft](https://github.com/Thesacraft)
+- **Portuguese** _(Brazil)_ updated by [@viniciushelder](https://github.com/viniciushelder)
+- **Russian** updated by werdei
+- **Spanish** updated by [@JCC1998](https://github.com/JCC1998)
 
 ### Documentation
 
--   docs: fix category typo by [@salem404](https://github.com/salem404) in [#834](https://github.com/TagStudioDev/TagStudio/pull/834)
+- docs: fix category typo by [@salem404](https://github.com/salem404) in [#834](https://github.com/TagStudioDev/TagStudio/pull/834)
 
 ---
 
@@ -325,30 +326,30 @@ A new "Library Information" window has been added and is accessible under the "V
 
 ##### Boolean Operators
 
--   feat: implement query language by [@Computerdores](https://github.com/Computerdores) in [#606](https://github.com/TagStudioDev/TagStudio/pull/606)
--   feat: optimize AND queries by [@Computerdores](https://github.com/Computerdores) in [#679](https://github.com/TagStudioDev/TagStudio/pull/679)
+- feat: implement query language by [@Computerdores](https://github.com/Computerdores) in [#606](https://github.com/TagStudioDev/TagStudio/pull/606)
+- feat: optimize AND queries by [@Computerdores](https://github.com/Computerdores) in [#679](https://github.com/TagStudioDev/TagStudio/pull/679)
 
 ##### Filetype, Mediatype, and Glob Path + Smartcase Searches
 
--   fix: remove wildcard requirement for tags by [@Tyrannicodin](https://github.com/Tyrannicodin) in [#481](https://github.com/TagStudioDev/TagStudio/pull/481)
--   feat: add filetype and mediatype searches by [@python357-1](https://github.com/python357-1) in [#575](https://github.com/TagStudioDev/TagStudio/pull/575)
--   feat: make path search use globs by [@python357-1](https://github.com/python357-1) in [#582](https://github.com/TagStudioDev/TagStudio/pull/582)
--   feat: implement search equivalence of "jpg" and "jpeg" filetypes by [@Computerdores](https://github.com/Computerdores) in [#649](https://github.com/TagStudioDev/TagStudio/pull/649)
--   feat: add smartcase and globless path searches by [@CyanVoxel](https://github.com/CyanVoxel) in [#743](https://github.com/TagStudioDev/TagStudio/pull/743)
+- fix: remove wildcard requirement for tags by [@Tyrannicodin](https://github.com/Tyrannicodin) in [#481](https://github.com/TagStudioDev/TagStudio/pull/481)
+- feat: add filetype and mediatype searches by [@python357-1](https://github.com/python357-1) in [#575](https://github.com/TagStudioDev/TagStudio/pull/575)
+- feat: make path search use globs by [@python357-1](https://github.com/python357-1) in [#582](https://github.com/TagStudioDev/TagStudio/pull/582)
+- feat: implement search equivalence of "jpg" and "jpeg" filetypes by [@Computerdores](https://github.com/Computerdores) in [#649](https://github.com/TagStudioDev/TagStudio/pull/649)
+- feat: add smartcase and globless path searches by [@CyanVoxel](https://github.com/CyanVoxel) in [#743](https://github.com/TagStudioDev/TagStudio/pull/743)
 
 ##### Sortable Results
 
--   feat: sort by "date added" in library by [@Computerdores](https://github.com/Computerdores) in [#674](https://github.com/TagStudioDev/TagStudio/pull/674)
+- feat: sort by "date added" in library by [@Computerdores](https://github.com/Computerdores) in [#674](https://github.com/TagStudioDev/TagStudio/pull/674)
 
 ##### Autocomplete
 
--   feat: add autocomplete for search engine by [@python357-1](https://github.com/python357-1) in [#586](https://github.com/TagStudioDev/TagStudio/pull/586)
+- feat: add autocomplete for search engine by [@python357-1](https://github.com/python357-1) in [#586](https://github.com/TagStudioDev/TagStudio/pull/586)
 
 #### Replaced "Tag Fields" with Tag Categories
 
 Instead of tags needing to be added to a tag field type such as "Meta Tags", "Content Tags", or just the "Tags" field, tags are now added directly to file entries with no intermediary step. While tag field types offered a way to further organize tags, it was cumbersome, inflexible, and simply not fully fleshed out. Tag Categories offer all of the previous (intentional) functionality while greatly increasing the ease of use and customization.
 
--   feat!: tag categories by [@CyanVoxel](https://github.com/CyanVoxel) in [#655](https://github.com/TagStudioDev/TagStudio/pull/655)
+- feat!: tag categories by [@CyanVoxel](https://github.com/CyanVoxel) in [#655](https://github.com/TagStudioDev/TagStudio/pull/655)
 
     <img width="200" alt="Screenshot 2025-01-04 at 04 23 43" src="https://github.com/user-attachments/assets/0b92eca5-db8f-4e3e-954b-1b4f3795f073" />
 
@@ -356,49 +357,49 @@ Instead of tags needing to be added to a tag field type such as "Meta Tags", "Co
 
 ##### New Thumbnail Support
 
--   feat: add svg thumbnail support (port [#442](https://github.com/TagStudioDev/TagStudio/pull/442)) by [@Tyrannicodin](https://github.com/Tyrannicodin) and [@CyanVoxel](https://github.com/CyanVoxel) in [#540](https://github.com/TagStudioDev/TagStudio/pull/540)
--   feat: add pdf thumbnail support (port [#378](https://github.com/TagStudioDev/TagStudio/pull/378)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#543](https://github.com/TagStudioDev/TagStudio/pull/543)
--   feat: add ePub thumbnail support (port [#387](https://github.com/TagStudioDev/TagStudio/pull/387)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#539](https://github.com/TagStudioDev/TagStudio/pull/539)
--   feat: add OpenDocument thumbnail support (port [#366](https://github.com/TagStudioDev/TagStudio/pull/366)) by [@Joshua-Beatty](https://github.com/Joshua-Beatty) and [@CyanVoxel](https://github.com/CyanVoxel) in [#545](https://github.com/TagStudioDev/TagStudio/pull/545)
--   feat: add JXL thumbnail and animated APNG + WEBP support (port [#344](https://github.com/TagStudioDev/TagStudio/pull/344) and partially port [#357](https://github.com/TagStudioDev/TagStudio/pull/357)) by [@BPplays](https://github.com/BPplays) and [@CyanVoxel](https://github.com/CyanVoxel) in [#549](https://github.com/TagStudioDev/TagStudio/pull/549)
-    -   fix: catch ImportError for pillow_jxl module by [@CyanVoxel](https://github.com/CyanVoxel) in [a2f9685](https://github.com/TagStudioDev/TagStudio/commit/a2f9685bc0d744ea6f5334c6d2926aad3f6d375a)
+- feat: add svg thumbnail support (port [#442](https://github.com/TagStudioDev/TagStudio/pull/442)) by [@Tyrannicodin](https://github.com/Tyrannicodin) and [@CyanVoxel](https://github.com/CyanVoxel) in [#540](https://github.com/TagStudioDev/TagStudio/pull/540)
+- feat: add pdf thumbnail support (port [#378](https://github.com/TagStudioDev/TagStudio/pull/378)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#543](https://github.com/TagStudioDev/TagStudio/pull/543)
+- feat: add ePub thumbnail support (port [#387](https://github.com/TagStudioDev/TagStudio/pull/387)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#539](https://github.com/TagStudioDev/TagStudio/pull/539)
+- feat: add OpenDocument thumbnail support (port [#366](https://github.com/TagStudioDev/TagStudio/pull/366)) by [@Joshua-Beatty](https://github.com/Joshua-Beatty) and [@CyanVoxel](https://github.com/CyanVoxel) in [#545](https://github.com/TagStudioDev/TagStudio/pull/545)
+- feat: add JXL thumbnail and animated APNG + WEBP support (port [#344](https://github.com/TagStudioDev/TagStudio/pull/344) and partially port [#357](https://github.com/TagStudioDev/TagStudio/pull/357)) by [@BPplays](https://github.com/BPplays) and [@CyanVoxel](https://github.com/CyanVoxel) in [#549](https://github.com/TagStudioDev/TagStudio/pull/549)
+    - fix: catch ImportError for pillow_jxl module by [@CyanVoxel](https://github.com/CyanVoxel) in [a2f9685](https://github.com/TagStudioDev/TagStudio/commit/a2f9685bc0d744ea6f5334c6d2926aad3f6d375a)
 
 ##### Audio Playback
 
--   feat: audio playback by [@csponge](https://github.com/csponge) in [#576](https://github.com/TagStudioDev/TagStudio/pull/576)
-    -   feat(ui): add audio volume slider by [@SkeleyM](https://github.com/SkeleyM) in [#691](https://github.com/TagStudioDev/TagStudio/pull/691)
+- feat: audio playback by [@csponge](https://github.com/csponge) in [#576](https://github.com/TagStudioDev/TagStudio/pull/576)
+    - feat(ui): add audio volume slider by [@SkeleyM](https://github.com/SkeleyM) in [#691](https://github.com/TagStudioDev/TagStudio/pull/691)
 
 ##### Thumbnail Caching
 
--   feat(ui): add thumbnail caching by [@CyanVoxel](https://github.com/CyanVoxel) in [#694](https://github.com/TagStudioDev/TagStudio/pull/694)
+- feat(ui): add thumbnail caching by [@CyanVoxel](https://github.com/CyanVoxel) in [#694](https://github.com/TagStudioDev/TagStudio/pull/694)
 
 #### Tags
 
 ##### Delete Tags _(Finally!)_
 
--   feat: remove and create tags from tag database panel by [@DandyDev01](https://github.com/DandyDev01) in [#569](https://github.com/TagStudioDev/TagStudio/pull/569)
+- feat: remove and create tags from tag database panel by [@DandyDev01](https://github.com/DandyDev01) in [#569](https://github.com/TagStudioDev/TagStudio/pull/569)
 
 ##### Custom User-Created Tag Colors
 
 Create your own custom tag colors via the new Tag Color Manager! Tag colors are assigned a namespace (group) and include a name, primary color, and optional secondary color. By default the secondary color is used for the tag text color, but this can also be toggled to apply to the border color as well!
 
--   feat(ui)!: user-created tag colors@CyanVoxel in [#801](https://github.com/TagStudioDev/TagStudio/pull/801)
+- feat(ui)!: user-created tag colors@CyanVoxel in [#801](https://github.com/TagStudioDev/TagStudio/pull/801)
 
     <img width="300" src="https://github.com/user-attachments/assets/b591f1fe-1c44-4d82-b6e5-d166590aeab1" />
     <img width="500" src="https://github.com/user-attachments/assets/96e81b08-6993-4a5e-96d0-3b05b50fbe44" />
 
 ##### New Tag Colors + UI
 
--   feat: expanded tag color system by [@CyanVoxel](https://github.com/CyanVoxel) in [#709](https://github.com/TagStudioDev/TagStudio/pull/709)
--   fix(ui): use correct pink tag color by [@CyanVoxel](https://github.com/CyanVoxel) in [431efe4](https://github.com/TagStudioDev/TagStudio/commit/431efe4fe93213141c763e59ca9887215766fd42)
--   fix(ui): use consistent tag outline colors by [@CyanVoxel](https://github.com/CyanVoxel) in [020a73d](https://github.com/TagStudioDev/TagStudio/commit/020a73d095c74283d6c80426d3c3db8874409952)
+- feat: expanded tag color system by [@CyanVoxel](https://github.com/CyanVoxel) in [#709](https://github.com/TagStudioDev/TagStudio/pull/709)
+- fix(ui): use correct pink tag color by [@CyanVoxel](https://github.com/CyanVoxel) in [431efe4](https://github.com/TagStudioDev/TagStudio/commit/431efe4fe93213141c763e59ca9887215766fd42)
+- fix(ui): use consistent tag outline colors by [@CyanVoxel](https://github.com/CyanVoxel) in [020a73d](https://github.com/TagStudioDev/TagStudio/commit/020a73d095c74283d6c80426d3c3db8874409952)
 
 <img width="250" alt="Screenshot 2025-01-04 at 04 23 43" src="https://github.com/user-attachments/assets/c8f82d89-ad7e-4be6-830e-b91cdc58e4c6" />
 
 ##### New Tag Alias UI
 
--   fix: preview panel aliases not staying up to date with database by [@DandyDev01](https://github.com/DandyDev01) in [#641](https://github.com/TagStudioDev/TagStudio/pull/641)
--   fix: subtags/parent tags & aliases update the UI for building a tag by [@DandyDev01](https://github.com/DandyDev01) in [#534](https://github.com/TagStudioDev/TagStudio/pull/534)
+- fix: preview panel aliases not staying up to date with database by [@DandyDev01](https://github.com/DandyDev01) in [#641](https://github.com/TagStudioDev/TagStudio/pull/641)
+- fix: subtags/parent tags & aliases update the UI for building a tag by [@DandyDev01](https://github.com/DandyDev01) in [#534](https://github.com/TagStudioDev/TagStudio/pull/534)
 
 #### Translations
 
@@ -406,50 +407,50 @@ TagStudio now has official translation support! Head to the new settings panel a
 
 Translation hosting generously provided by [Weblate](https://weblate.org/en/). Check out our [project page](https://hosted.weblate.org/projects/tagstudio/) to help translate TagStudio! Thank you to everyone who's helped contribute to the translations so far!
 
--   translations: add string tokens for en.json by [@Bamowen](https://github.com/Bamowen) in [#507](https://github.com/TagStudioDev/TagStudio/pull/507)
--   feat: translations by [@Computerdores](https://github.com/Computerdores) in [#662](https://github.com/TagStudioDev/TagStudio/pull/662)
--   feat(ui): add language setting by [@CyanVoxel](https://github.com/CyanVoxel) in [#803](https://github.com/TagStudioDev/TagStudio/pull/803)
+- translations: add string tokens for en.json by [@Bamowen](https://github.com/Bamowen) in [#507](https://github.com/TagStudioDev/TagStudio/pull/507)
+- feat: translations by [@Computerdores](https://github.com/Computerdores) in [#662](https://github.com/TagStudioDev/TagStudio/pull/662)
+- feat(ui): add language setting by [@CyanVoxel](https://github.com/CyanVoxel) in [#803](https://github.com/TagStudioDev/TagStudio/pull/803)
 
 Initial Languages:
 
--   **Chinese** _(Traditional Han Script)_ by [@brisu](https://github.com/brisu)
--   **Dutch** by [@Pheubel](https://github.com/Pheubel)
--   **Filipino** by [@searinminecraft](https://github.com/searinminecraft)
--   **French** by [@Bamowen](https://github.com/Bamowen), [@alessdangelo](https://github.com/alessdangelo), [@kitsumed](https://github.com/kitsumed), Obscaeris
--   **German** by [@Ryussei](https://github.com/Ryussei), [@Computerdores](https://github.com/Computerdores), Aaron M, [@JoeJoeTV](https://github.com/JoeJoeTV), [@Kurty00](https://github.com/Kurty00)
--   **Hungarian** by [@smileyhead](https://github.com/smileyhead)
--   **Norwegian Bokmål** by [@comradekingu](https://github.com/comradekingu)
--   **Polish** by Anonymous
--   **Portuguese** _(Brazil)_ by [@LoboMetalurgico](https://github.com/LoboMetalurgico), [@SpaceFox1](https://github.com/SpaceFox1), [@DaviMarquezeli](https://github.com/DaviMarquezeli), [@viniciushelder](https://github.com/viniciushelder), Alexander Lennart Formiga Johnsson
--   **Russian** by [@The-Stolas](https://github.com/The-Stolas)
--   **Spanish** by [@gallegonovato](https://github.com/gallegonovato), [@Nginearing](https://github.com/Nginearing), [@noceno](https://github.com/noceno)
--   **Swedish** by [@adampawelec](https://github.com/adampawelec), [@mashed5894](https://github.com/mashed5894)
--   **Tamil** by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel)
--   **Toki Pona** by [@goldstargloww](https://github.com/goldstargloww)
--   **Turkish** by [@Nyghl](https://github.com/Nyghl)
+- **Chinese** _(Traditional Han Script)_ by [@brisu](https://github.com/brisu)
+- **Dutch** by [@Pheubel](https://github.com/Pheubel)
+- **Filipino** by [@searinminecraft](https://github.com/searinminecraft)
+- **French** by [@Bamowen](https://github.com/Bamowen), [@alessdangelo](https://github.com/alessdangelo), [@kitsumed](https://github.com/kitsumed), Obscaeris
+- **German** by [@Ryussei](https://github.com/Ryussei), [@Computerdores](https://github.com/Computerdores), Aaron M, [@JoeJoeTV](https://github.com/JoeJoeTV), [@Kurty00](https://github.com/Kurty00)
+- **Hungarian** by [@smileyhead](https://github.com/smileyhead)
+- **Norwegian Bokmål** by [@comradekingu](https://github.com/comradekingu)
+- **Polish** by Anonymous
+- **Portuguese** _(Brazil)_ by [@LoboMetalurgico](https://github.com/LoboMetalurgico), [@SpaceFox1](https://github.com/SpaceFox1), [@DaviMarquezeli](https://github.com/DaviMarquezeli), [@viniciushelder](https://github.com/viniciushelder), Alexander Lennart Formiga Johnsson
+- **Russian** by [@The-Stolas](https://github.com/The-Stolas)
+- **Spanish** by [@gallegonovato](https://github.com/gallegonovato), [@Nginearing](https://github.com/Nginearing), [@noceno](https://github.com/noceno)
+- **Swedish** by [@adampawelec](https://github.com/adampawelec), [@mashed5894](https://github.com/mashed5894)
+- **Tamil** by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel)
+- **Toki Pona** by [@goldstargloww](https://github.com/goldstargloww)
+- **Turkish** by [@Nyghl](https://github.com/Nyghl)
 
 #### Miscellaneous
 
--   feat: about section by [@mashed5894](https://github.com/mashed5894) in [#712](https://github.com/TagStudioDev/TagStudio/pull/712)
--   feat(ui): add configurable splash screens by [@CyanVoxel](https://github.com/CyanVoxel) in [#703](https://github.com/TagStudioDev/TagStudio/pull/703)
--   feat(ui): show filenames in thumbnail grid by [@CyanVoxel](https://github.com/CyanVoxel) in [#633](https://github.com/TagStudioDev/TagStudio/pull/633)
--   feat(about): clickable links to docs/discord/etc in about modal by [@SkeleyM](https://github.com/SkeleyM) in [#799](https://github.com/TagStudioDev/TagStudio/pull/799)
+- feat: about section by [@mashed5894](https://github.com/mashed5894) in [#712](https://github.com/TagStudioDev/TagStudio/pull/712)
+- feat(ui): add configurable splash screens by [@CyanVoxel](https://github.com/CyanVoxel) in [#703](https://github.com/TagStudioDev/TagStudio/pull/703)
+- feat(ui): show filenames in thumbnail grid by [@CyanVoxel](https://github.com/CyanVoxel) in [#633](https://github.com/TagStudioDev/TagStudio/pull/633)
+- feat(about): clickable links to docs/discord/etc in about modal by [@SkeleyM](https://github.com/SkeleyM) in [#799](https://github.com/TagStudioDev/TagStudio/pull/799)
 
 ### Fixed
 
--   fix(ui): display all tags in panel during empty search by [@samuellieberman](https://github.com/samuellieberman) in [#328](https://github.com/TagStudioDev/TagStudio/pull/328)
--   fix: avoid `KeyError` in `add_folders_to_tree()` (fix [#346](https://github.com/TagStudioDev/TagStudio/issues/346)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#347](https://github.com/TagStudioDev/TagStudio/pull/347)
--   fix: error on closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#484](https://github.com/TagStudioDev/TagStudio/pull/484)
--   fix: resolution info [#550](https://github.com/TagStudioDev/TagStudio/issues/550) by [@Roc25](https://github.com/Roc25) in [#551](https://github.com/TagStudioDev/TagStudio/pull/551)
--   fix: remove queued thumnail jobs when closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#583](https://github.com/TagStudioDev/TagStudio/pull/583)
--   fix: use absolute ffprobe path on macos (Fix [#511](https://github.com/TagStudioDev/TagStudio/issues/511)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#629](https://github.com/TagStudioDev/TagStudio/pull/629)
--   fix(ui): prevent duplicate parent tags in UI by [@SkeleyM](https://github.com/SkeleyM) in [#665](https://github.com/TagStudioDev/TagStudio/pull/665)
--   fix: fix -o flag not working if path has whitespace around it by [@python357-1](https://github.com/python357-1) in [#670](https://github.com/TagStudioDev/TagStudio/pull/670)
--   fix: better file opening compatibility with non-ascii filenames by [@SkeleyM](https://github.com/SkeleyM) in [#667](https://github.com/TagStudioDev/TagStudio/pull/667)
--   fix: restore environment before launching external programs by [@mashed5894](https://github.com/mashed5894) in [#707](https://github.com/TagStudioDev/TagStudio/pull/707)
--   fix: have pydub use known ffmpeg + ffprobe locations by [@CyanVoxel](https://github.com/CyanVoxel) in [#724](https://github.com/TagStudioDev/TagStudio/pull/724)
--   fix: add ".DS_Store" to `GLOBAL_IGNORE_SET` by [@CyanVoxel](https://github.com/CyanVoxel) in [b72a2f2](https://github.com/TagStudioDev/TagStudio/commit/b72a2f233141db4db6aa6be8796b626ebd3f0756)
--   fix: don't add ".\_" files to libraries by [@CyanVoxel](https://github.com/CyanVoxel) in [eb1f634](https://github.com/TagStudioDev/TagStudio/commit/eb1f634d386cd8a5ecee1e6ff6a0b7d8811550fa)
+- fix(ui): display all tags in panel during empty search by [@samuellieberman](https://github.com/samuellieberman) in [#328](https://github.com/TagStudioDev/TagStudio/pull/328)
+- fix: avoid `KeyError` in `add_folders_to_tree()` (fix [#346](https://github.com/TagStudioDev/TagStudio/issues/346)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#347](https://github.com/TagStudioDev/TagStudio/pull/347)
+- fix: error on closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#484](https://github.com/TagStudioDev/TagStudio/pull/484)
+- fix: resolution info [#550](https://github.com/TagStudioDev/TagStudio/issues/550) by [@Roc25](https://github.com/Roc25) in [#551](https://github.com/TagStudioDev/TagStudio/pull/551)
+- fix: remove queued thumnail jobs when closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#583](https://github.com/TagStudioDev/TagStudio/pull/583)
+- fix: use absolute ffprobe path on macos (Fix [#511](https://github.com/TagStudioDev/TagStudio/issues/511)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#629](https://github.com/TagStudioDev/TagStudio/pull/629)
+- fix(ui): prevent duplicate parent tags in UI by [@SkeleyM](https://github.com/SkeleyM) in [#665](https://github.com/TagStudioDev/TagStudio/pull/665)
+- fix: fix -o flag not working if path has whitespace around it by [@python357-1](https://github.com/python357-1) in [#670](https://github.com/TagStudioDev/TagStudio/pull/670)
+- fix: better file opening compatibility with non-ascii filenames by [@SkeleyM](https://github.com/SkeleyM) in [#667](https://github.com/TagStudioDev/TagStudio/pull/667)
+- fix: restore environment before launching external programs by [@mashed5894](https://github.com/mashed5894) in [#707](https://github.com/TagStudioDev/TagStudio/pull/707)
+- fix: have pydub use known ffmpeg + ffprobe locations by [@CyanVoxel](https://github.com/CyanVoxel) in [#724](https://github.com/TagStudioDev/TagStudio/pull/724)
+- fix: add ".DS_Store" to `GLOBAL_IGNORE_SET` by [@CyanVoxel](https://github.com/CyanVoxel) in [b72a2f2](https://github.com/TagStudioDev/TagStudio/commit/b72a2f233141db4db6aa6be8796b626ebd3f0756)
+- fix: don't add ".\_" files to libraries by [@CyanVoxel](https://github.com/CyanVoxel) in [eb1f634](https://github.com/TagStudioDev/TagStudio/commit/eb1f634d386cd8a5ecee1e6ff6a0b7d8811550fa)
 
 ### Changed
 
@@ -457,74 +458,74 @@ Initial Languages:
 
 This was the main focus of this update, and where the majority of development time and resources have been spent since v9.4. These changes include everything that was done to migrate from the JSON format to SQLite starting from the initial SQLite PR, while re-implementing every feature from v9.4 as the initial SQLite PR was based on v9.3.x at the time.
 
--   refactor!: use SQLite and SQLAlchemy for database backend by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#332](https://github.com/TagStudioDev/TagStudio/pull/332)
--   feat: make search results more ergonomic by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#498](https://github.com/TagStudioDev/TagStudio/pull/498)
--   feat: store `Entry` suffix separately by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#503](https://github.com/TagStudioDev/TagStudio/pull/503)
--   feat: port thumbnail ([#390](https://github.com/TagStudioDev/TagStudio/pull/390)) and related features to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#522](https://github.com/TagStudioDev/TagStudio/pull/522)
--   fix: don't check db version with new library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#536](https://github.com/TagStudioDev/TagStudio/pull/536)
--   fix(ui): update ui when removing fields by [@DandyDev01](https://github.com/DandyDev01) in [#560](https://github.com/TagStudioDev/TagStudio/pull/560)
--   feat(parity): backend for aliases and parent tags by [@DandyDev01](https://github.com/DandyDev01) in [#596](https://github.com/TagStudioDev/TagStudio/pull/596)
--   fix: "open in explorer" opens correct folder by [@KirilBourakov](https://github.com/KirilBourakov) in [#603](https://github.com/TagStudioDev/TagStudio/pull/603)
--   fix: ui/ux parity fixes for thumbnails and files by [@CyanVoxel](https://github.com/CyanVoxel) in [#608](https://github.com/TagStudioDev/TagStudio/pull/608)
--   feat(parity): migrate json libraries to sqlite by [@CyanVoxel](https://github.com/CyanVoxel) in [#604](https://github.com/TagStudioDev/TagStudio/pull/604)
--   fix: clear all setting values when opening a library by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#622](https://github.com/TagStudioDev/TagStudio/pull/622)
--   fix: remove/rework windows path tests by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#625](https://github.com/TagStudioDev/TagStudio/pull/625)
--   fix: add check to see if library is loaded in filter_items by [@Roc25](https://github.com/Roc25) in [#547](https://github.com/TagStudioDev/TagStudio/pull/547)
--   fix: multiple macro errors by [@Computerdores](https://github.com/Computerdores) in [#612](https://github.com/TagStudioDev/TagStudio/pull/612)
--   fix: don't allow blank tag alias values in db by [@CyanVoxel](https://github.com/CyanVoxel) in [#628](https://github.com/TagStudioDev/TagStudio/pull/628)
--   feat: Reimplement drag drop files on sql migration by [@seakrueger](https://github.com/seakrueger) in [#528](https://github.com/TagStudioDev/TagStudio/pull/528)
--   fix: stop sqlite db from being updated while running tests by [@python357-1](https://github.com/python357-1) in [#648](https://github.com/TagStudioDev/TagStudio/pull/648)
--   fix: enter/return adds top result tag by [@SkeleyM](https://github.com/SkeleyM) in [#651](https://github.com/TagStudioDev/TagStudio/pull/651)
--   fix: show correct unlinked files count by [@SkeleyM](https://github.com/SkeleyM) in [#653](https://github.com/TagStudioDev/TagStudio/pull/653)
--   feat: implement parent tag search by [@Computerdores](https://github.com/Computerdores) in [#673](https://github.com/TagStudioDev/TagStudio/pull/673)
--   fix: only close add tag menu with no search by [@SkeleyM](https://github.com/SkeleyM) in [#685](https://github.com/TagStudioDev/TagStudio/pull/685)
--   fix: drag and drop no longer resets by [@SkeleyM](https://github.com/SkeleyM) in [#710](https://github.com/TagStudioDev/TagStudio/pull/710)
--   feat(ui): port "create and add tag" to main branch by [@SkeleyM](https://github.com/SkeleyM) in [#711](https://github.com/TagStudioDev/TagStudio/pull/711)
--   fix: don't add default title field, use proper phrasing for adding files by [@CyanVoxel](https://github.com/CyanVoxel) in [#701](https://github.com/TagStudioDev/TagStudio/pull/701)
--   fix: preview panel + main window fixes and optimizations by [@CyanVoxel](https://github.com/CyanVoxel) in [#700](https://github.com/TagStudioDev/TagStudio/pull/700)
--   fix: sort tag results by [@mashed5894](https://github.com/mashed5894) in [#721](https://github.com/TagStudioDev/TagStudio/pull/721)
--   fix: restore opening last library on startup by [@SkeleyM](https://github.com/SkeleyM) in [#729](https://github.com/TagStudioDev/TagStudio/pull/729)
--   fix(ui): don't always create tag on enter by [@SkeleyM](https://github.com/SkeleyM) in [#731](https://github.com/TagStudioDev/TagStudio/pull/731)
--   fix: use tag aliases in tag search by [@CyanVoxel](https://github.com/CyanVoxel) in [#726](https://github.com/TagStudioDev/TagStudio/pull/726)
--   fix: keep initial id order in `get_entries_full()` by [@CyanVoxel](https://github.com/CyanVoxel) in [#736](https://github.com/TagStudioDev/TagStudio/pull/736)
--   fix: always catch db mismatch by [@CyanVoxel](https://github.com/CyanVoxel) in [#738](https://github.com/TagStudioDev/TagStudio/pull/738)
--   fix: relink unlinked entry to existing entry without sql error by [@mashed5894](https://github.com/mashed5894) in [#730](https://github.com/TagStudioDev/TagStudio/issues/730)
--   fix: refactor and fix bugs with missing_files.py by [@CyanVoxel](https://github.com/CyanVoxel) in [#739](https://github.com/TagStudioDev/TagStudio/pull/739)
--   fix: dragging files references correct entry IDs [@CyanVoxel](https://github.com/CyanVoxel) in [44ff17c](https://github.com/TagStudioDev/TagStudio/commit/44ff17c0b3f05570e356c112f005dbc14c7cc05d)
--   ui: port splash screen from Alpha-v9.4 by [@CyanVoxel](https://github.com/CyanVoxel) in [af760ee](https://github.com/TagStudioDev/TagStudio/commit/af760ee61a523c84bab0fb03a68d7465866d0e05)
--   fix: tags created from tag database now add aliases by [@CyanVoxel](https://github.com/CyanVoxel) in [2903dd2](https://github.com/TagStudioDev/TagStudio/commit/2903dd22c45c02498687073d075bb88886de6b62)
--   fix: check for tag name parity during JSON migration by [@CyanVoxel](https://github.com/CyanVoxel) in [#748](https://github.com/TagStudioDev/TagStudio/pull/748)
--   feat(ui): re-implement tag display names on sql by [@CyanVoxel](https://github.com/CyanVoxel) in [#747](https://github.com/TagStudioDev/TagStudio/pull/747)
--   fix(ui): restore Windows accent color on PySide 6.8.0.1 by [@CyanVoxel](https://github.com/CyanVoxel) in [#755](https://github.com/TagStudioDev/TagStudio/pull/755)
--   fix(ui): (mostly) fix right-click search option on tags by [@CyanVoxel](https://github.com/CyanVoxel) in [#756](https://github.com/TagStudioDev/TagStudio/pull/756)
--   feat: copy/paste fields and tags by [@mashed5894](https://github.com/mashed5894) in [#722](https://github.com/TagStudioDev/TagStudio/pull/722)
--   perf: optimize query methods and reduce preview panel updates by [@CyanVoxel](https://github.com/CyanVoxel) in [#794](https://github.com/TagStudioDev/TagStudio/pull/794)
--   feat: port file trashing ([#409](https://github.com/TagStudioDev/TagStudio/pull/409)) to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#792](https://github.com/TagStudioDev/TagStudio/pull/792)
--   fix: prevent future library versions from being opened by [@CyanVoxel](https://github.com/CyanVoxel) in [bcf3b2f](https://github.com/TagStudioDev/TagStudio/commit/bcf3b2f96bc8b876ca4b0c1d1882ce14a190f249)
+- refactor!: use SQLite and SQLAlchemy for database backend by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#332](https://github.com/TagStudioDev/TagStudio/pull/332)
+- feat: make search results more ergonomic by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#498](https://github.com/TagStudioDev/TagStudio/pull/498)
+- feat: store `Entry` suffix separately by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#503](https://github.com/TagStudioDev/TagStudio/pull/503)
+- feat: port thumbnail ([#390](https://github.com/TagStudioDev/TagStudio/pull/390)) and related features to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#522](https://github.com/TagStudioDev/TagStudio/pull/522)
+- fix: don't check db version with new library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#536](https://github.com/TagStudioDev/TagStudio/pull/536)
+- fix(ui): update ui when removing fields by [@DandyDev01](https://github.com/DandyDev01) in [#560](https://github.com/TagStudioDev/TagStudio/pull/560)
+- feat(parity): backend for aliases and parent tags by [@DandyDev01](https://github.com/DandyDev01) in [#596](https://github.com/TagStudioDev/TagStudio/pull/596)
+- fix: "open in explorer" opens correct folder by [@KirilBourakov](https://github.com/KirilBourakov) in [#603](https://github.com/TagStudioDev/TagStudio/pull/603)
+- fix: ui/ux parity fixes for thumbnails and files by [@CyanVoxel](https://github.com/CyanVoxel) in [#608](https://github.com/TagStudioDev/TagStudio/pull/608)
+- feat(parity): migrate json libraries to sqlite by [@CyanVoxel](https://github.com/CyanVoxel) in [#604](https://github.com/TagStudioDev/TagStudio/pull/604)
+- fix: clear all setting values when opening a library by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#622](https://github.com/TagStudioDev/TagStudio/pull/622)
+- fix: remove/rework windows path tests by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#625](https://github.com/TagStudioDev/TagStudio/pull/625)
+- fix: add check to see if library is loaded in filter_items by [@Roc25](https://github.com/Roc25) in [#547](https://github.com/TagStudioDev/TagStudio/pull/547)
+- fix: multiple macro errors by [@Computerdores](https://github.com/Computerdores) in [#612](https://github.com/TagStudioDev/TagStudio/pull/612)
+- fix: don't allow blank tag alias values in db by [@CyanVoxel](https://github.com/CyanVoxel) in [#628](https://github.com/TagStudioDev/TagStudio/pull/628)
+- feat: Reimplement drag drop files on sql migration by [@seakrueger](https://github.com/seakrueger) in [#528](https://github.com/TagStudioDev/TagStudio/pull/528)
+- fix: stop sqlite db from being updated while running tests by [@python357-1](https://github.com/python357-1) in [#648](https://github.com/TagStudioDev/TagStudio/pull/648)
+- fix: enter/return adds top result tag by [@SkeleyM](https://github.com/SkeleyM) in [#651](https://github.com/TagStudioDev/TagStudio/pull/651)
+- fix: show correct unlinked files count by [@SkeleyM](https://github.com/SkeleyM) in [#653](https://github.com/TagStudioDev/TagStudio/pull/653)
+- feat: implement parent tag search by [@Computerdores](https://github.com/Computerdores) in [#673](https://github.com/TagStudioDev/TagStudio/pull/673)
+- fix: only close add tag menu with no search by [@SkeleyM](https://github.com/SkeleyM) in [#685](https://github.com/TagStudioDev/TagStudio/pull/685)
+- fix: drag and drop no longer resets by [@SkeleyM](https://github.com/SkeleyM) in [#710](https://github.com/TagStudioDev/TagStudio/pull/710)
+- feat(ui): port "create and add tag" to main branch by [@SkeleyM](https://github.com/SkeleyM) in [#711](https://github.com/TagStudioDev/TagStudio/pull/711)
+- fix: don't add default title field, use proper phrasing for adding files by [@CyanVoxel](https://github.com/CyanVoxel) in [#701](https://github.com/TagStudioDev/TagStudio/pull/701)
+- fix: preview panel + main window fixes and optimizations by [@CyanVoxel](https://github.com/CyanVoxel) in [#700](https://github.com/TagStudioDev/TagStudio/pull/700)
+- fix: sort tag results by [@mashed5894](https://github.com/mashed5894) in [#721](https://github.com/TagStudioDev/TagStudio/pull/721)
+- fix: restore opening last library on startup by [@SkeleyM](https://github.com/SkeleyM) in [#729](https://github.com/TagStudioDev/TagStudio/pull/729)
+- fix(ui): don't always create tag on enter by [@SkeleyM](https://github.com/SkeleyM) in [#731](https://github.com/TagStudioDev/TagStudio/pull/731)
+- fix: use tag aliases in tag search by [@CyanVoxel](https://github.com/CyanVoxel) in [#726](https://github.com/TagStudioDev/TagStudio/pull/726)
+- fix: keep initial id order in `get_entries_full()` by [@CyanVoxel](https://github.com/CyanVoxel) in [#736](https://github.com/TagStudioDev/TagStudio/pull/736)
+- fix: always catch db mismatch by [@CyanVoxel](https://github.com/CyanVoxel) in [#738](https://github.com/TagStudioDev/TagStudio/pull/738)
+- fix: relink unlinked entry to existing entry without sql error by [@mashed5894](https://github.com/mashed5894) in [#730](https://github.com/TagStudioDev/TagStudio/issues/730)
+- fix: refactor and fix bugs with missing_files.py by [@CyanVoxel](https://github.com/CyanVoxel) in [#739](https://github.com/TagStudioDev/TagStudio/pull/739)
+- fix: dragging files references correct entry IDs [@CyanVoxel](https://github.com/CyanVoxel) in [44ff17c](https://github.com/TagStudioDev/TagStudio/commit/44ff17c0b3f05570e356c112f005dbc14c7cc05d)
+- ui: port splash screen from Alpha-v9.4 by [@CyanVoxel](https://github.com/CyanVoxel) in [af760ee](https://github.com/TagStudioDev/TagStudio/commit/af760ee61a523c84bab0fb03a68d7465866d0e05)
+- fix: tags created from tag database now add aliases by [@CyanVoxel](https://github.com/CyanVoxel) in [2903dd2](https://github.com/TagStudioDev/TagStudio/commit/2903dd22c45c02498687073d075bb88886de6b62)
+- fix: check for tag name parity during JSON migration by [@CyanVoxel](https://github.com/CyanVoxel) in [#748](https://github.com/TagStudioDev/TagStudio/pull/748)
+- feat(ui): re-implement tag display names on sql by [@CyanVoxel](https://github.com/CyanVoxel) in [#747](https://github.com/TagStudioDev/TagStudio/pull/747)
+- fix(ui): restore Windows accent color on PySide 6.8.0.1 by [@CyanVoxel](https://github.com/CyanVoxel) in [#755](https://github.com/TagStudioDev/TagStudio/pull/755)
+- fix(ui): (mostly) fix right-click search option on tags by [@CyanVoxel](https://github.com/CyanVoxel) in [#756](https://github.com/TagStudioDev/TagStudio/pull/756)
+- feat: copy/paste fields and tags by [@mashed5894](https://github.com/mashed5894) in [#722](https://github.com/TagStudioDev/TagStudio/pull/722)
+- perf: optimize query methods and reduce preview panel updates by [@CyanVoxel](https://github.com/CyanVoxel) in [#794](https://github.com/TagStudioDev/TagStudio/pull/794)
+- feat: port file trashing ([#409](https://github.com/TagStudioDev/TagStudio/pull/409)) to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#792](https://github.com/TagStudioDev/TagStudio/pull/792)
+- fix: prevent future library versions from being opened by [@CyanVoxel](https://github.com/CyanVoxel) in [bcf3b2f](https://github.com/TagStudioDev/TagStudio/commit/bcf3b2f96bc8b876ca4b0c1d1882ce14a190f249)
 
 #### UI/UX
 
--   feat(ui): pre-select default tag name in `BuildTagPanel` by [@Cool-Game-Dev](https://github.com/Cool-Game-Dev) in [#592](https://github.com/TagStudioDev/TagStudio/pull/592)
--   feat(ui): keyboard navigation for editing tags by [@Computerdores](https://github.com/Computerdores) in [#407](https://github.com/TagStudioDev/TagStudio/pull/407)
--   feat(ui): use tag query as default new tag name by [@CyanVoxel](https://github.com/CyanVoxel) in [29c0dfd](https://github.com/TagStudioDev/TagStudio/commit/29c0dfdb2d88e8f473e27c7f1fe7ede6e5bd0feb)
--   feat(ui): shortcut to add tags to selected entries; change click behavior of tags to edit by [@CyanVoxel](https://github.com/CyanVoxel) in [#749](https://github.com/TagStudioDev/TagStudio/pull/749)
--   fix(ui): use consistent dark mode colors for all systems by [@CyanVoxel](https://github.com/CyanVoxel) in [#752](https://github.com/TagStudioDev/TagStudio/pull/752)
--   fix(ui): use camera white balance for raw images by [@CyanVoxel](https://github.com/CyanVoxel) in [6ee5304](https://github.com/TagStudioDev/TagStudio/commit/6ee5304b52f217af0f5df543fcb389649203d6b2)
--   Mixed field editing has been limited due to various bugs in both the JSON and SQL implementations. This will be re-implemented in a future release.
--   fix(ui): improve tagging ux by [@CyanVoxel](https://github.com/CyanVoxel) in [#633](https://github.com/TagStudioDev/TagStudio/pull/633)
--   fix(ui): hide library actions when no library is open by [@CyanVoxel](https://github.com/CyanVoxel) in [#787](https://github.com/TagStudioDev/TagStudio/pull/787)
--   refactor(ui): recycle tag list in TagSearchPanel by [@CyanVoxel](https://github.com/CyanVoxel) in [#788](https://github.com/TagStudioDev/TagStudio/pull/788)
-    -   feat(ui): add tag view limit dropdown
--   fix(ui): expand usage of esc and enter for modals by [@CyanVoxel](https://github.com/CyanVoxel) in [#793](https://github.com/TagStudioDev/TagStudio/pull/793)
+- feat(ui): pre-select default tag name in `BuildTagPanel` by [@Cool-Game-Dev](https://github.com/Cool-Game-Dev) in [#592](https://github.com/TagStudioDev/TagStudio/pull/592)
+- feat(ui): keyboard navigation for editing tags by [@Computerdores](https://github.com/Computerdores) in [#407](https://github.com/TagStudioDev/TagStudio/pull/407)
+- feat(ui): use tag query as default new tag name by [@CyanVoxel](https://github.com/CyanVoxel) in [29c0dfd](https://github.com/TagStudioDev/TagStudio/commit/29c0dfdb2d88e8f473e27c7f1fe7ede6e5bd0feb)
+- feat(ui): shortcut to add tags to selected entries; change click behavior of tags to edit by [@CyanVoxel](https://github.com/CyanVoxel) in [#749](https://github.com/TagStudioDev/TagStudio/pull/749)
+- fix(ui): use consistent dark mode colors for all systems by [@CyanVoxel](https://github.com/CyanVoxel) in [#752](https://github.com/TagStudioDev/TagStudio/pull/752)
+- fix(ui): use camera white balance for raw images by [@CyanVoxel](https://github.com/CyanVoxel) in [6ee5304](https://github.com/TagStudioDev/TagStudio/commit/6ee5304b52f217af0f5df543fcb389649203d6b2)
+- Mixed field editing has been limited due to various bugs in both the JSON and SQL implementations. This will be re-implemented in a future release.
+- fix(ui): improve tagging ux by [@CyanVoxel](https://github.com/CyanVoxel) in [#633](https://github.com/TagStudioDev/TagStudio/pull/633)
+- fix(ui): hide library actions when no library is open by [@CyanVoxel](https://github.com/CyanVoxel) in [#787](https://github.com/TagStudioDev/TagStudio/pull/787)
+- refactor(ui): recycle tag list in TagSearchPanel by [@CyanVoxel](https://github.com/CyanVoxel) in [#788](https://github.com/TagStudioDev/TagStudio/pull/788)
+    - feat(ui): add tag view limit dropdown
+- fix(ui): expand usage of esc and enter for modals by [@CyanVoxel](https://github.com/CyanVoxel) in [#793](https://github.com/TagStudioDev/TagStudio/pull/793)
 
 #### Performance
 
--   feat: improve performance of "Delete Missing Entries" by [@Toby222](https://github.com/Toby222) and [@Computerdores](https://github.com/Computerdores) in [#696](https://github.com/TagStudioDev/TagStudio/pull/696)
+- feat: improve performance of "Delete Missing Entries" by [@Toby222](https://github.com/Toby222) and [@Computerdores](https://github.com/Computerdores) in [#696](https://github.com/TagStudioDev/TagStudio/pull/696)
 
 #### Internal Changes
 
--   refactor: combine open launch args by [@UnusualEgg](https://github.com/UnusualEgg) in [#364](https://github.com/TagStudioDev/TagStudio/pull/364)
--   feat: add date_created, date_modified, and date_added columns to entries table by [@CyanVoxel](https://github.com/CyanVoxel) in [#740](https://github.com/TagStudioDev/TagStudio/pull/740)
+- refactor: combine open launch args by [@UnusualEgg](https://github.com/UnusualEgg) in [#364](https://github.com/TagStudioDev/TagStudio/pull/364)
+- feat: add date_created, date_modified, and date_added columns to entries table by [@CyanVoxel](https://github.com/CyanVoxel) in [#740](https://github.com/TagStudioDev/TagStudio/pull/740)
 
 ---
 
@@ -545,46 +546,46 @@ TagStudio now has official translation support! Head to the new settings panel a
 
 Translation hosting generously provided by [Weblate](https://weblate.org/en/). Check out our [project page](https://hosted.weblate.org/projects/tagstudio/) to help translate TagStudio! Thank you to everyone who's helped contribute to the translations so far!
 
--   translations: add string tokens for en.json by [@Bamowen](https://github.com/Bamowen) in [#507](https://github.com/TagStudioDev/TagStudio/pull/507)
--   feat: translations by [@Computerdores](https://github.com/Computerdores) in [#662](https://github.com/TagStudioDev/TagStudio/pull/662)
--   feat(ui): add language setting by [@CyanVoxel](https://github.com/CyanVoxel) in [#803](https://github.com/TagStudioDev/TagStudio/pull/803)
+- translations: add string tokens for en.json by [@Bamowen](https://github.com/Bamowen) in [#507](https://github.com/TagStudioDev/TagStudio/pull/507)
+- feat: translations by [@Computerdores](https://github.com/Computerdores) in [#662](https://github.com/TagStudioDev/TagStudio/pull/662)
+- feat(ui): add language setting by [@CyanVoxel](https://github.com/CyanVoxel) in [#803](https://github.com/TagStudioDev/TagStudio/pull/803)
 
 Initial Languages:
 
--   Chinese (Traditional) (68%)
-    -   [@brisu](https://github.com/brisu)
--   Dutch (35%)
-    -   [@Pheubel](https://github.com/Pheubel)
--   Filipino (15%)
-    -   [@searinminecraft](https://github.com/searinminecraft)
--   French (89%)
-    -   [@Bamowen](https://github.com/Bamowen), [@alessdangelo](https://github.com/alessdangelo), [@kitsumed](https://github.com/kitsumed), Obscaeris
--   German (73%)
-    -   [@Ryussei](https://github.com/Ryussei), [@Computerdores](https://github.com/Computerdores), Aaron M
--   Hungarian (89%)
-    -   [@smileyhead](https://github.com/smileyhead)
--   Norwegian Bokmål (16%)
-    -   [@comradekingu](https://github.com/comradekingu)
--   Polish (76%)
-    -   Anonymous
--   Portuguese (Brazil) (22%)
-    -   [@LoboMetalurgico](https://github.com/LoboMetalurgico), [@SpaceFox1](https://github.com/SpaceFox1)
--   Russian (22%)
-    -   [@The-Stolas](https://github.com/The-Stolas)
--   Spanish (46%)
-    -   [@gallegonovato](https://github.com/gallegonovato), [@Nginearing](https://github.com/Nginearing), [@noceno](https://github.com/noceno)
--   Swedish (24%)
-    -   [@adampawelec](https://github.com/adampawelec), [@mashed5894](https://github.com/mashed5894)
--   Tamil (22%)
-    -   [@VasigaranAndAngel](https://github.com/VasigaranAndAngel)
--   Toki Pona (32%)
-    -   [@goldstargloww](https://github.com/goldstargloww)
--   Turkish (22%)
-    -   [@Nyghl](https://github.com/Nyghl)
+- Chinese (Traditional) (68%)
+    - [@brisu](https://github.com/brisu)
+- Dutch (35%)
+    - [@Pheubel](https://github.com/Pheubel)
+- Filipino (15%)
+    - [@searinminecraft](https://github.com/searinminecraft)
+- French (89%)
+    - [@Bamowen](https://github.com/Bamowen), [@alessdangelo](https://github.com/alessdangelo), [@kitsumed](https://github.com/kitsumed), Obscaeris
+- German (73%)
+    - [@Ryussei](https://github.com/Ryussei), [@Computerdores](https://github.com/Computerdores), Aaron M
+- Hungarian (89%)
+    - [@smileyhead](https://github.com/smileyhead)
+- Norwegian Bokmål (16%)
+    - [@comradekingu](https://github.com/comradekingu)
+- Polish (76%)
+    - Anonymous
+- Portuguese (Brazil) (22%)
+    - [@LoboMetalurgico](https://github.com/LoboMetalurgico), [@SpaceFox1](https://github.com/SpaceFox1)
+- Russian (22%)
+    - [@The-Stolas](https://github.com/The-Stolas)
+- Spanish (46%)
+    - [@gallegonovato](https://github.com/gallegonovato), [@Nginearing](https://github.com/Nginearing), [@noceno](https://github.com/noceno)
+- Swedish (24%)
+    - [@adampawelec](https://github.com/adampawelec), [@mashed5894](https://github.com/mashed5894)
+- Tamil (22%)
+    - [@VasigaranAndAngel](https://github.com/VasigaranAndAngel)
+- Toki Pona (32%)
+    - [@goldstargloww](https://github.com/goldstargloww)
+- Turkish (22%)
+    - [@Nyghl](https://github.com/Nyghl)
 
 ### Fixed
 
--   feat(about): clickable links to docs/discord/etc in about modal by [@SkeleyM](https://github.com/SkeleyM) in [#799](https://github.com/TagStudioDev/TagStudio/pull/799)
+- feat(about): clickable links to docs/discord/etc in about modal by [@SkeleyM](https://github.com/SkeleyM) in [#799](https://github.com/TagStudioDev/TagStudio/pull/799)
 
 ### Internal Changes
 
@@ -600,40 +601,40 @@ This release increases the internal `DB_VERSION` to 8. Libraries created with th
 
 Added "Smartcase" and Globless Path Search
 
--   `path: temp`: Returns all paths that have "temp" **(Case insensitive)** somewhere in the name.
--   `path: Temp`: Returns all paths that have "Temp" **(Case sensitive)** somewhere in the name.
+- `path: temp`: Returns all paths that have "temp" **(Case insensitive)** somewhere in the name.
+- `path: Temp`: Returns all paths that have "Temp" **(Case sensitive)** somewhere in the name.
 
 Glob Patterns w/ Smartcase
 
--   `path: *temp*`: Returns all paths that have "temp" **(Case insensitive)** somewhere in the name.
--   `path: *Temp*`: Returns all paths that have "Temp" **(Case sensitive)** somewhere in the name.
--   `path: temp*`: Returns all paths that start with "temp" **(Case insensitive)** somewhere in the name.
--   `path: Temp*`: Returns all paths that start with "Temp" **(Case sensitive)** somewhere in the name.
--   `path: *temp`: Returns all paths that end with "temp" **(Case insensitive)** somewhere in the name.
--   `path: *TEmP`: Returns all paths that end with "TEmP" **(Case sensitive)** somewhere in the name.
+- `path: *temp*`: Returns all paths that have "temp" **(Case insensitive)** somewhere in the name.
+- `path: *Temp*`: Returns all paths that have "Temp" **(Case sensitive)** somewhere in the name.
+- `path: temp*`: Returns all paths that start with "temp" **(Case insensitive)** somewhere in the name.
+- `path: Temp*`: Returns all paths that start with "Temp" **(Case sensitive)** somewhere in the name.
+- `path: *temp`: Returns all paths that end with "temp" **(Case insensitive)** somewhere in the name.
+- `path: *TEmP`: Returns all paths that end with "TEmP" **(Case sensitive)** somewhere in the name.
 
 ##### [#788](https://github.com/TagStudioDev/TagStudio/pull/788) by [@CyanVoxel](https://github.com/CyanVoxel)
 
--   Added a "View Limit" dropdown to tag search boxes to limit the number of on-screen tags. Previously this limit was hardcoded to 100, but now options range from 25 to unlimited.  
-    <img width="350" src="https://github.com/user-attachments/assets/7f7da065-888d-4fe5-a4e7-f99447bcce98" />
+- Added a "View Limit" dropdown to tag search boxes to limit the number of on-screen tags. Previously this limit was hardcoded to 100, but now options range from 25 to unlimited.
+  <img width="350" src="https://github.com/user-attachments/assets/7f7da065-888d-4fe5-a4e7-f99447bcce98" />
 
 ### Changed
 
--   fix(ui): expand usage of esc and enter for modals by [@CyanVoxel](https://github.com/CyanVoxel) in [#793](https://github.com/TagStudioDev/TagStudio/pull/793)
--   perf: optimize query methods and reduce preview panel updates by [@CyanVoxel](https://github.com/CyanVoxel) in [#794](https://github.com/TagStudioDev/TagStudio/pull/794)
+- fix(ui): expand usage of esc and enter for modals by [@CyanVoxel](https://github.com/CyanVoxel) in [#793](https://github.com/TagStudioDev/TagStudio/pull/793)
+- perf: optimize query methods and reduce preview panel updates by [@CyanVoxel](https://github.com/CyanVoxel) in [#794](https://github.com/TagStudioDev/TagStudio/pull/794)
 
 ##### [#788](https://github.com/TagStudioDev/TagStudio/pull/788) by [@CyanVoxel](https://github.com/CyanVoxel)
 
--   Improved performance of tag search boxes, including the tag manager
+- Improved performance of tag search boxes, including the tag manager
 
 ### Fixed
 
--   fix(ui): hide library actions when no library is open by [@CyanVoxel](https://github.com/CyanVoxel) in [#787](https://github.com/TagStudioDev/TagStudio/pull/787)
--   feat: port file trashing ([#409](https://github.com/TagStudioDev/TagStudio/pull/409)) to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#792](https://github.com/TagStudioDev/TagStudio/pull/792)
+- fix(ui): hide library actions when no library is open by [@CyanVoxel](https://github.com/CyanVoxel) in [#787](https://github.com/TagStudioDev/TagStudio/pull/787)
+- feat: port file trashing ([#409](https://github.com/TagStudioDev/TagStudio/pull/409)) to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#792](https://github.com/TagStudioDev/TagStudio/pull/792)
 
 ### Docs
 
--   Added references to alternative POSIX shells, as well as pyenv to CONTRIBUTING.md by [@ChloeZamorano](https://github.com/ChloeZamorano) in [#791](https://github.com/TagStudioDev/TagStudio/pull/791)
+- Added references to alternative POSIX shells, as well as pyenv to CONTRIBUTING.md by [@ChloeZamorano](https://github.com/ChloeZamorano) in [#791](https://github.com/TagStudioDev/TagStudio/pull/791)
 
 ---
 
@@ -643,52 +644,52 @@ Glob Patterns w/ Smartcase
 
 ##### [#784](https://github.com/TagStudioDev/TagStudio/pull/784) by [@CyanVoxel](https://github.com/CyanVoxel)
 
--   Add Ctrl+M shortcut to open the "Tag Manager"
+- Add Ctrl+M shortcut to open the "Tag Manager"
 
 ### Fixed
 
--   fix: don't wrap field names too early by [@CyanVoxel](https://github.com/CyanVoxel) in [2215403](https://github.com/TagStudioDev/TagStudio/commit/2215403201e3b416a43ead0a322688180af6d71b) and [90a826d](https://github.com/TagStudioDev/TagStudio/commit/90a826d12804b3386a0b9003abb20f23f88ab3be)
--   fix: save all tag attributes from "Create & Add" modal by [@SkeleyM](https://github.com/SkeleyM) in [#762](https://github.com/TagStudioDev/TagStudio/pull/762)
--   fix: allow tag names with colons in search by [@SkeleyM](https://github.com/SkeleyM) in [#765](https://github.com/TagStudioDev/TagStudio/pull/765)
--   fix: catch `ParsingError` by [@CyanVoxel](https://github.com/CyanVoxel) in [#779](https://github.com/TagStudioDev/TagStudio/pull/779)
--   fix: patch incorrect description type & invalid disambiguation_id refs by [@CyanVoxel](https://github.com/CyanVoxel) in [#782](https://github.com/TagStudioDev/TagStudio/pull/782)
+- fix: don't wrap field names too early by [@CyanVoxel](https://github.com/CyanVoxel) in [2215403](https://github.com/TagStudioDev/TagStudio/commit/2215403201e3b416a43ead0a322688180af6d71b) and [90a826d](https://github.com/TagStudioDev/TagStudio/commit/90a826d12804b3386a0b9003abb20f23f88ab3be)
+- fix: save all tag attributes from "Create & Add" modal by [@SkeleyM](https://github.com/SkeleyM) in [#762](https://github.com/TagStudioDev/TagStudio/pull/762)
+- fix: allow tag names with colons in search by [@SkeleyM](https://github.com/SkeleyM) in [#765](https://github.com/TagStudioDev/TagStudio/pull/765)
+- fix: catch `ParsingError` by [@CyanVoxel](https://github.com/CyanVoxel) in [#779](https://github.com/TagStudioDev/TagStudio/pull/779)
+- fix: patch incorrect description type & invalid disambiguation_id refs by [@CyanVoxel](https://github.com/CyanVoxel) in [#782](https://github.com/TagStudioDev/TagStudio/pull/782)
 
 ##### [#784](https://github.com/TagStudioDev/TagStudio/pull/784) by [@CyanVoxel](https://github.com/CyanVoxel)
 
--   Reset tag search box and focus each time a tag search panel is opened
--   Include tag parents in tag search results (v9.4 parity)
--   Lowercase tag names now get properly sorted with uppercase ones
--   Don't include tag display names in "closeness" factor when searching
--   Escape "&" characters inside tag names so Qt doesn't treat them as mnemonics
--   Set minimum tag width
--   Fix "Add Tags" panel missing its window title when accessing from the keyboard shortcut
+- Reset tag search box and focus each time a tag search panel is opened
+- Include tag parents in tag search results (v9.4 parity)
+- Lowercase tag names now get properly sorted with uppercase ones
+- Don't include tag display names in "closeness" factor when searching
+- Escape "&" characters inside tag names so Qt doesn't treat them as mnemonics
+- Set minimum tag width
+- Fix "Add Tags" panel missing its window title when accessing from the keyboard shortcut
 
 ### Changed
 
 ##### [#784](https://github.com/TagStudioDev/TagStudio/pull/784) by [@CyanVoxel](https://github.com/CyanVoxel)
 
--   The "use for disambiguation" button has been moved to the right-hand side of parent tags in order to prevent accidental clicks involving the left-hand "remove tag" button
--   Add "Create & Add" button to the bottom of all non-whitespace searches, even if they return some tags
--   The awkward "+" button next to tags in the "Add Tags" panel has been removed in favor of clicking on tags themselves
--   Improved visual feedback for highlighting, keyboard focusing, and clicking tags
--   The clickable area of the "-" button on tags has been increased and has visual feedback when you hover and click it
--   You can now tab into the tag search list and add tags with a spacebar press (previously possible but very janky)
--   In tag search panels, pressing the Esc key will return your focus to the search bar and highlight your previous query. If the search box is already highlighted, pressing Esc will close the modal
--   In modals such as the "Add Tag" and "Edit Tag" panels, pressing Esc will cancel the operation and close the modal
+- The "use for disambiguation" button has been moved to the right-hand side of parent tags in order to prevent accidental clicks involving the left-hand "remove tag" button
+- Add "Create & Add" button to the bottom of all non-whitespace searches, even if they return some tags
+- The awkward "+" button next to tags in the "Add Tags" panel has been removed in favor of clicking on tags themselves
+- Improved visual feedback for highlighting, keyboard focusing, and clicking tags
+- The clickable area of the "-" button on tags has been increased and has visual feedback when you hover and click it
+- You can now tab into the tag search list and add tags with a spacebar press (previously possible but very janky)
+- In tag search panels, pressing the Esc key will return your focus to the search bar and highlight your previous query. If the search box is already highlighted, pressing Esc will close the modal
+- In modals such as the "Add Tag" and "Edit Tag" panels, pressing Esc will cancel the operation and close the modal
 
 ### Internal Changes
 
--   refactor: wrap migration_iterator lambda in a try/except block by [@CyanVoxel](https://github.com/CyanVoxel) in [#773](https://github.com/TagStudioDev/TagStudio/pull/773)
+- refactor: wrap migration_iterator lambda in a try/except block by [@CyanVoxel](https://github.com/CyanVoxel) in [#773](https://github.com/TagStudioDev/TagStudio/pull/773)
 
 ### Docs
 
--   docs: update field and library pages by [@CyanVoxel](https://github.com/CyanVoxel) in [f5ff4d7](https://github.com/TagStudioDev/TagStudio/commit/f5ff4d78c1ad53134e9c64698886aee68c0f1dc1)
--   docs: add information about "tag manager" by [@CyanVoxel](https://github.com/CyanVoxel) in [9bdbafa](https://github.com/TagStudioDev/TagStudio/commit/9bdbafa40c4274922f6533b5b5fcee9a4fe43030)
--   docs: add note about glob searching in the readme by [@CyanVoxel](https://github.com/CyanVoxel) in [6e402ac](https://github.com/TagStudioDev/TagStudio/commit/6e402ac34d2d60e71fbd36ad234fe3914d5eb8e0)
--   docs: add library_search page by [@CyanVoxel](https://github.com/CyanVoxel) in [5be7dfc](https://github.com/TagStudioDev/TagStudio/commit/5be7dfc314b21042c18b2f08893f2b452d12394a)
--   docs: docs: add more links to index.md by [@CyanVoxel](https://github.com/CyanVoxel) in [d795889](https://github.com/TagStudioDev/TagStudio/commit/d7958892b7762586837204d686a6a2a993e3c26e)
--   docs: fix typo for "category" in usage.md by [@pinheadtf2](https://github.com/pinheadtf2) in [#760](https://github.com/TagStudioDev/TagStudio/pull/760)
--   fix(docs): fix screenshot sometimes not rendering by [@SkeleyM](https://github.com/SkeleyM) in [#775](https://github.com/TagStudioDev/TagStudio/pull/775)
+- docs: update field and library pages by [@CyanVoxel](https://github.com/CyanVoxel) in [f5ff4d7](https://github.com/TagStudioDev/TagStudio/commit/f5ff4d78c1ad53134e9c64698886aee68c0f1dc1)
+- docs: add information about "tag manager" by [@CyanVoxel](https://github.com/CyanVoxel) in [9bdbafa](https://github.com/TagStudioDev/TagStudio/commit/9bdbafa40c4274922f6533b5b5fcee9a4fe43030)
+- docs: add note about glob searching in the readme by [@CyanVoxel](https://github.com/CyanVoxel) in [6e402ac](https://github.com/TagStudioDev/TagStudio/commit/6e402ac34d2d60e71fbd36ad234fe3914d5eb8e0)
+- docs: add library_search page by [@CyanVoxel](https://github.com/CyanVoxel) in [5be7dfc](https://github.com/TagStudioDev/TagStudio/commit/5be7dfc314b21042c18b2f08893f2b452d12394a)
+- docs: docs: add more links to index.md by [@CyanVoxel](https://github.com/CyanVoxel) in [d795889](https://github.com/TagStudioDev/TagStudio/commit/d7958892b7762586837204d686a6a2a993e3c26e)
+- docs: fix typo for "category" in usage.md by [@pinheadtf2](https://github.com/pinheadtf2) in [#760](https://github.com/TagStudioDev/TagStudio/pull/760)
+- fix(docs): fix screenshot sometimes not rendering by [@SkeleyM](https://github.com/SkeleyM) in [#775](https://github.com/TagStudioDev/TagStudio/pull/775)
 
 ---
 
@@ -700,88 +701,88 @@ Glob Patterns w/ Smartcase
 
 ##### Boolean Operators
 
--   feat: implement query language by [@Computerdores](https://github.com/Computerdores) in [#606](https://github.com/TagStudioDev/TagStudio/pull/606)
--   feat: optimize AND queries by [@Computerdores](https://github.com/Computerdores) in [#679](https://github.com/TagStudioDev/TagStudio/pull/679)
+- feat: implement query language by [@Computerdores](https://github.com/Computerdores) in [#606](https://github.com/TagStudioDev/TagStudio/pull/606)
+- feat: optimize AND queries by [@Computerdores](https://github.com/Computerdores) in [#679](https://github.com/TagStudioDev/TagStudio/pull/679)
 
 ##### Filetype, Mediatype, and Glob Path Searches
 
--   fix: remove wildcard requirement for tags by [@Tyrannicodin](https://github.com/Tyrannicodin) in [#481](https://github.com/TagStudioDev/TagStudio/pull/481)
--   feat: add filetype and mediatype searches by [@python357-1](https://github.com/python357-1) in [#575](https://github.com/TagStudioDev/TagStudio/pull/575)
--   feat: make path search use globs by [@python357-1](https://github.com/python357-1) in [#582](https://github.com/TagStudioDev/TagStudio/pull/582)
--   feat: implement search equivalence of "jpg" and "jpeg" filetypes by [@Computerdores](https://github.com/Computerdores) in [#649](https://github.com/TagStudioDev/TagStudio/pull/649)
+- fix: remove wildcard requirement for tags by [@Tyrannicodin](https://github.com/Tyrannicodin) in [#481](https://github.com/TagStudioDev/TagStudio/pull/481)
+- feat: add filetype and mediatype searches by [@python357-1](https://github.com/python357-1) in [#575](https://github.com/TagStudioDev/TagStudio/pull/575)
+- feat: make path search use globs by [@python357-1](https://github.com/python357-1) in [#582](https://github.com/TagStudioDev/TagStudio/pull/582)
+- feat: implement search equivalence of "jpg" and "jpeg" filetypes by [@Computerdores](https://github.com/Computerdores) in [#649](https://github.com/TagStudioDev/TagStudio/pull/649)
 
 ##### Sortable Results
 
--   feat: sort by "date added" in library by [@Computerdores](https://github.com/Computerdores) in [#674](https://github.com/TagStudioDev/TagStudio/pull/674)
+- feat: sort by "date added" in library by [@Computerdores](https://github.com/Computerdores) in [#674](https://github.com/TagStudioDev/TagStudio/pull/674)
 
 ##### Autocomplete
 
--   feat: add autocomplete for search engine by [@python357-1](https://github.com/python357-1) in [#586](https://github.com/TagStudioDev/TagStudio/pull/586)
+- feat: add autocomplete for search engine by [@python357-1](https://github.com/python357-1) in [#586](https://github.com/TagStudioDev/TagStudio/pull/586)
 
 #### Replaced "Tag Fields" with Tag Categories
 
 Instead of tags needing to be added to a tag field type such as "Meta Tags", "Content Tags", or just the "Tags" field, tags are now added directly to file entries with no intermediary step. While tag field types offered a way to further organize tags, it was cumbersome, inflexible, and simply not fully fleshed out. Tag Categories offer all of the previous (intentional) functionality while greatly increasing the ease of use and customization.
 
--   feat!: tag categories by [@CyanVoxel](https://github.com/CyanVoxel) in [#655](https://github.com/TagStudioDev/TagStudio/pull/655)
+- feat!: tag categories by [@CyanVoxel](https://github.com/CyanVoxel) in [#655](https://github.com/TagStudioDev/TagStudio/pull/655)
 
 #### Thumbnails and File Previews
 
 ##### New Thumbnail Support
 
--   feat: add svg thumbnail support (port [#442](https://github.com/TagStudioDev/TagStudio/pull/442)) by [@Tyrannicodin](https://github.com/Tyrannicodin) and [@CyanVoxel](https://github.com/CyanVoxel) in [#540](https://github.com/TagStudioDev/TagStudio/pull/540)
--   feat: add pdf thumbnail support (port [#378](https://github.com/TagStudioDev/TagStudio/pull/378)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#543](https://github.com/TagStudioDev/TagStudio/pull/543)
--   feat: add ePub thumbnail support (port [#387](https://github.com/TagStudioDev/TagStudio/pull/387)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#539](https://github.com/TagStudioDev/TagStudio/pull/539)
--   feat: add OpenDocument thumbnail support (port [#366](https://github.com/TagStudioDev/TagStudio/pull/366)) by [@Joshua-Beatty](https://github.com/Joshua-Beatty) and [@CyanVoxel](https://github.com/CyanVoxel) in [#545](https://github.com/TagStudioDev/TagStudio/pull/545)
--   feat: add JXL thumbnail and animated APNG + WEBP support (port [#344](https://github.com/TagStudioDev/TagStudio/pull/344) and partially port [#357](https://github.com/TagStudioDev/TagStudio/pull/357)) by [@BPplays](https://github.com/BPplays) and [@CyanVoxel](https://github.com/CyanVoxel) in [#549](https://github.com/TagStudioDev/TagStudio/pull/549)
-    -   fix: catch ImportError for pillow_jxl module by [@CyanVoxel](https://github.com/CyanVoxel) in [a2f9685](https://github.com/TagStudioDev/TagStudio/commit/a2f9685bc0d744ea6f5334c6d2926aad3f6d375a)
+- feat: add svg thumbnail support (port [#442](https://github.com/TagStudioDev/TagStudio/pull/442)) by [@Tyrannicodin](https://github.com/Tyrannicodin) and [@CyanVoxel](https://github.com/CyanVoxel) in [#540](https://github.com/TagStudioDev/TagStudio/pull/540)
+- feat: add pdf thumbnail support (port [#378](https://github.com/TagStudioDev/TagStudio/pull/378)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#543](https://github.com/TagStudioDev/TagStudio/pull/543)
+- feat: add ePub thumbnail support (port [#387](https://github.com/TagStudioDev/TagStudio/pull/387)) by [@Heiholf](https://github.com/Heiholf) and [@CyanVoxel](https://github.com/CyanVoxel) in [#539](https://github.com/TagStudioDev/TagStudio/pull/539)
+- feat: add OpenDocument thumbnail support (port [#366](https://github.com/TagStudioDev/TagStudio/pull/366)) by [@Joshua-Beatty](https://github.com/Joshua-Beatty) and [@CyanVoxel](https://github.com/CyanVoxel) in [#545](https://github.com/TagStudioDev/TagStudio/pull/545)
+- feat: add JXL thumbnail and animated APNG + WEBP support (port [#344](https://github.com/TagStudioDev/TagStudio/pull/344) and partially port [#357](https://github.com/TagStudioDev/TagStudio/pull/357)) by [@BPplays](https://github.com/BPplays) and [@CyanVoxel](https://github.com/CyanVoxel) in [#549](https://github.com/TagStudioDev/TagStudio/pull/549)
+    - fix: catch ImportError for pillow_jxl module by [@CyanVoxel](https://github.com/CyanVoxel) in [a2f9685](https://github.com/TagStudioDev/TagStudio/commit/a2f9685bc0d744ea6f5334c6d2926aad3f6d375a)
 
 ##### Audio Playback
 
--   feat: audio playback by [@csponge](https://github.com/csponge) in [#576](https://github.com/TagStudioDev/TagStudio/pull/576)
-    -   feat(ui): add audio volume slider by [@SkeleyM](https://github.com/SkeleyM) in [#691](https://github.com/TagStudioDev/TagStudio/pull/691)
+- feat: audio playback by [@csponge](https://github.com/csponge) in [#576](https://github.com/TagStudioDev/TagStudio/pull/576)
+    - feat(ui): add audio volume slider by [@SkeleyM](https://github.com/SkeleyM) in [#691](https://github.com/TagStudioDev/TagStudio/pull/691)
 
 ##### Thumbnail Caching
 
--   feat(ui): add thumbnail caching by [@CyanVoxel](https://github.com/CyanVoxel) in [#694](https://github.com/TagStudioDev/TagStudio/pull/694)
+- feat(ui): add thumbnail caching by [@CyanVoxel](https://github.com/CyanVoxel) in [#694](https://github.com/TagStudioDev/TagStudio/pull/694)
 
 #### Tags
 
 ##### Delete Tags _(Finally!)_
 
--   feat: remove and create tags from tag database panel by [@DandyDev01](https://github.com/DandyDev01) in [#569](https://github.com/TagStudioDev/TagStudio/pull/569)
+- feat: remove and create tags from tag database panel by [@DandyDev01](https://github.com/DandyDev01) in [#569](https://github.com/TagStudioDev/TagStudio/pull/569)
 
 ##### New Tag Colors + UI
 
--   feat: expanded tag color system by [@CyanVoxel](https://github.com/CyanVoxel) in [#709](https://github.com/TagStudioDev/TagStudio/pull/709)
--   fix(ui): use correct pink tag color by [@CyanVoxel](https://github.com/CyanVoxel) in [431efe4](https://github.com/TagStudioDev/TagStudio/commit/431efe4fe93213141c763e59ca9887215766fd42)
--   fix(ui): use consistent tag outline colors by [@CyanVoxel](https://github.com/CyanVoxel) in [020a73d](https://github.com/TagStudioDev/TagStudio/commit/020a73d095c74283d6c80426d3c3db8874409952)
+- feat: expanded tag color system by [@CyanVoxel](https://github.com/CyanVoxel) in [#709](https://github.com/TagStudioDev/TagStudio/pull/709)
+- fix(ui): use correct pink tag color by [@CyanVoxel](https://github.com/CyanVoxel) in [431efe4](https://github.com/TagStudioDev/TagStudio/commit/431efe4fe93213141c763e59ca9887215766fd42)
+- fix(ui): use consistent tag outline colors by [@CyanVoxel](https://github.com/CyanVoxel) in [020a73d](https://github.com/TagStudioDev/TagStudio/commit/020a73d095c74283d6c80426d3c3db8874409952)
 
 ##### New Tag Alias UI
 
--   fix: preview panel aliases not staying up to date with database by [@DandyDev01](https://github.com/DandyDev01) in [#641](https://github.com/TagStudioDev/TagStudio/pull/641)
--   fix: subtags/parent tags & aliases update the UI for building a tag by [@DandyDev01](https://github.com/DandyDev01) in [#534](https://github.com/TagStudioDev/TagStudio/pull/534)
+- fix: preview panel aliases not staying up to date with database by [@DandyDev01](https://github.com/DandyDev01) in [#641](https://github.com/TagStudioDev/TagStudio/pull/641)
+- fix: subtags/parent tags & aliases update the UI for building a tag by [@DandyDev01](https://github.com/DandyDev01) in [#534](https://github.com/TagStudioDev/TagStudio/pull/534)
 
 #### Miscellaneous
 
--   feat: about section by [@mashed5894](https://github.com/mashed5894) in [#712](https://github.com/TagStudioDev/TagStudio/pull/712)
--   feat(ui): add configurable splash screens by [@CyanVoxel](https://github.com/CyanVoxel) in [#703](https://github.com/TagStudioDev/TagStudio/pull/703)
--   feat(ui): show filenames in thumbnail grid by [@CyanVoxel](https://github.com/CyanVoxel) in [#633](https://github.com/TagStudioDev/TagStudio/pull/633)
+- feat: about section by [@mashed5894](https://github.com/mashed5894) in [#712](https://github.com/TagStudioDev/TagStudio/pull/712)
+- feat(ui): add configurable splash screens by [@CyanVoxel](https://github.com/CyanVoxel) in [#703](https://github.com/TagStudioDev/TagStudio/pull/703)
+- feat(ui): show filenames in thumbnail grid by [@CyanVoxel](https://github.com/CyanVoxel) in [#633](https://github.com/TagStudioDev/TagStudio/pull/633)
 
 ### Fixed
 
--   fix(ui): display all tags in panel during empty search by [@samuellieberman](https://github.com/samuellieberman) in [#328](https://github.com/TagStudioDev/TagStudio/pull/328)
--   fix: avoid `KeyError` in `add_folders_to_tree()` (fix [#346](https://github.com/TagStudioDev/TagStudio/issues/346)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#347](https://github.com/TagStudioDev/TagStudio/pull/347)
--   fix: error on closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#484](https://github.com/TagStudioDev/TagStudio/pull/484)
--   fix: resolution info [#550](https://github.com/TagStudioDev/TagStudio/issues/550) by [@Roc25](https://github.com/Roc25) in [#551](https://github.com/TagStudioDev/TagStudio/pull/551)
--   fix: remove queued thumnail jobs when closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#583](https://github.com/TagStudioDev/TagStudio/pull/583)
--   fix: use absolute ffprobe path on macos (Fix [#511](https://github.com/TagStudioDev/TagStudio/issues/511)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#629](https://github.com/TagStudioDev/TagStudio/pull/629)
--   fix(ui): prevent duplicate parent tags in UI by [@SkeleyM](https://github.com/SkeleyM) in [#665](https://github.com/TagStudioDev/TagStudio/pull/665)
--   fix: fix -o flag not working if path has whitespace around it by [@python357-1](https://github.com/python357-1) in [#670](https://github.com/TagStudioDev/TagStudio/pull/670)
--   fix: better file opening compatibility with non-ascii filenames by [@SkeleyM](https://github.com/SkeleyM) in [#667](https://github.com/TagStudioDev/TagStudio/pull/667)
--   fix: restore environment before launching external programs by [@mashed5894](https://github.com/mashed5894) in [#707](https://github.com/TagStudioDev/TagStudio/pull/707)
--   fix: have pydub use known ffmpeg + ffprobe locations by [@CyanVoxel](https://github.com/CyanVoxel) in [#724](https://github.com/TagStudioDev/TagStudio/pull/724)
--   fix: add ".DS_Store" to `GLOBAL_IGNORE_SET` by [@CyanVoxel](https://github.com/CyanVoxel) in [b72a2f2](https://github.com/TagStudioDev/TagStudio/commit/b72a2f233141db4db6aa6be8796b626ebd3f0756)
--   fix: don't add ".\_" files to libraries by [@CyanVoxel](https://github.com/CyanVoxel) in [eb1f634](https://github.com/TagStudioDev/TagStudio/commit/eb1f634d386cd8a5ecee1e6ff6a0b7d8811550fa)
+- fix(ui): display all tags in panel during empty search by [@samuellieberman](https://github.com/samuellieberman) in [#328](https://github.com/TagStudioDev/TagStudio/pull/328)
+- fix: avoid `KeyError` in `add_folders_to_tree()` (fix [#346](https://github.com/TagStudioDev/TagStudio/issues/346)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#347](https://github.com/TagStudioDev/TagStudio/pull/347)
+- fix: error on closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#484](https://github.com/TagStudioDev/TagStudio/pull/484)
+- fix: resolution info [#550](https://github.com/TagStudioDev/TagStudio/issues/550) by [@Roc25](https://github.com/Roc25) in [#551](https://github.com/TagStudioDev/TagStudio/pull/551)
+- fix: remove queued thumnail jobs when closing library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#583](https://github.com/TagStudioDev/TagStudio/pull/583)
+- fix: use absolute ffprobe path on macos (Fix [#511](https://github.com/TagStudioDev/TagStudio/issues/511)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#629](https://github.com/TagStudioDev/TagStudio/pull/629)
+- fix(ui): prevent duplicate parent tags in UI by [@SkeleyM](https://github.com/SkeleyM) in [#665](https://github.com/TagStudioDev/TagStudio/pull/665)
+- fix: fix -o flag not working if path has whitespace around it by [@python357-1](https://github.com/python357-1) in [#670](https://github.com/TagStudioDev/TagStudio/pull/670)
+- fix: better file opening compatibility with non-ascii filenames by [@SkeleyM](https://github.com/SkeleyM) in [#667](https://github.com/TagStudioDev/TagStudio/pull/667)
+- fix: restore environment before launching external programs by [@mashed5894](https://github.com/mashed5894) in [#707](https://github.com/TagStudioDev/TagStudio/pull/707)
+- fix: have pydub use known ffmpeg + ffprobe locations by [@CyanVoxel](https://github.com/CyanVoxel) in [#724](https://github.com/TagStudioDev/TagStudio/pull/724)
+- fix: add ".DS_Store" to `GLOBAL_IGNORE_SET` by [@CyanVoxel](https://github.com/CyanVoxel) in [b72a2f2](https://github.com/TagStudioDev/TagStudio/commit/b72a2f233141db4db6aa6be8796b626ebd3f0756)
+- fix: don't add ".\_" files to libraries by [@CyanVoxel](https://github.com/CyanVoxel) in [eb1f634](https://github.com/TagStudioDev/TagStudio/commit/eb1f634d386cd8a5ecee1e6ff6a0b7d8811550fa)
 
 ### Changed
 
@@ -789,66 +790,66 @@ Instead of tags needing to be added to a tag field type such as "Meta Tags", "Co
 
 This was the main focus of this update, and where the majority of development time and resources have been spent since v9.4. These changes include everything that was done to migrate from the JSON format to SQLite starting from the initial SQLite PR, while re-implementing every feature from v9.4 as the initial SQLite PR was based on v9.3.x at the time.
 
--   refactor!: use SQLite and SQLAlchemy for database backend by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#332](https://github.com/TagStudioDev/TagStudio/pull/332)
--   feat: make search results more ergonomic by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#498](https://github.com/TagStudioDev/TagStudio/pull/498)
--   feat: store `Entry` suffix separately by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#503](https://github.com/TagStudioDev/TagStudio/pull/503)
--   feat: port thumbnail ([#390](https://github.com/TagStudioDev/TagStudio/pull/390)) and related features to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#522](https://github.com/TagStudioDev/TagStudio/pull/522)
--   fix: don't check db version with new library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#536](https://github.com/TagStudioDev/TagStudio/pull/536)
--   fix(ui): update ui when removing fields by [@DandyDev01](https://github.com/DandyDev01) in [#560](https://github.com/TagStudioDev/TagStudio/pull/560)
--   feat(parity): backend for aliases and parent tags by [@DandyDev01](https://github.com/DandyDev01) in [#596](https://github.com/TagStudioDev/TagStudio/pull/596)
--   fix: "open in explorer" opens correct folder by [@KirilBourakov](https://github.com/KirilBourakov) in [#603](https://github.com/TagStudioDev/TagStudio/pull/603)
--   fix: ui/ux parity fixes for thumbnails and files by [@CyanVoxel](https://github.com/CyanVoxel) in [#608](https://github.com/TagStudioDev/TagStudio/pull/608)
--   feat(parity): migrate json libraries to sqlite by [@CyanVoxel](https://github.com/CyanVoxel) in [#604](https://github.com/TagStudioDev/TagStudio/pull/604)
--   fix: clear all setting values when opening a library by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#622](https://github.com/TagStudioDev/TagStudio/pull/622)
--   fix: remove/rework windows path tests by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#625](https://github.com/TagStudioDev/TagStudio/pull/625)
--   fix: add check to see if library is loaded in filter_items by [@Roc25](https://github.com/Roc25) in [#547](https://github.com/TagStudioDev/TagStudio/pull/547)
--   fix: multiple macro errors by [@Computerdores](https://github.com/Computerdores) in [#612](https://github.com/TagStudioDev/TagStudio/pull/612)
--   fix: don't allow blank tag alias values in db by [@CyanVoxel](https://github.com/CyanVoxel) in [#628](https://github.com/TagStudioDev/TagStudio/pull/628)
--   feat: Reimplement drag drop files on sql migration by [@seakrueger](https://github.com/seakrueger) in [#528](https://github.com/TagStudioDev/TagStudio/pull/528)
--   fix: stop sqlite db from being updated while running tests by [@python357-1](https://github.com/python357-1) in [#648](https://github.com/TagStudioDev/TagStudio/pull/648)
--   fix: enter/return adds top result tag by [@SkeleyM](https://github.com/SkeleyM) in [#651](https://github.com/TagStudioDev/TagStudio/pull/651)
--   fix: show correct unlinked files count by [@SkeleyM](https://github.com/SkeleyM) in [#653](https://github.com/TagStudioDev/TagStudio/pull/653)
--   feat: implement parent tag search by [@Computerdores](https://github.com/Computerdores) in [#673](https://github.com/TagStudioDev/TagStudio/pull/673)
--   fix: only close add tag menu with no search by [@SkeleyM](https://github.com/SkeleyM) in [#685](https://github.com/TagStudioDev/TagStudio/pull/685)
--   fix: drag and drop no longer resets by [@SkeleyM](https://github.com/SkeleyM) in [#710](https://github.com/TagStudioDev/TagStudio/pull/710)
--   feat(ui): port "create and add tag" to main branch by [@SkeleyM](https://github.com/SkeleyM) in [#711](https://github.com/TagStudioDev/TagStudio/pull/711)
--   fix: don't add default title field, use proper phrasing for adding files by [@CyanVoxel](https://github.com/CyanVoxel) in [#701](https://github.com/TagStudioDev/TagStudio/pull/701)
--   fix: preview panel + main window fixes and optimizations by [@CyanVoxel](https://github.com/CyanVoxel) in [#700](https://github.com/TagStudioDev/TagStudio/pull/700)
--   fix: sort tag results by [@mashed5894](https://github.com/mashed5894) in [#721](https://github.com/TagStudioDev/TagStudio/pull/721)
--   fix: restore opening last library on startup by [@SkeleyM](https://github.com/SkeleyM) in [#729](https://github.com/TagStudioDev/TagStudio/pull/729)
--   fix(ui): don't always create tag on enter by [@SkeleyM](https://github.com/SkeleyM) in [#731](https://github.com/TagStudioDev/TagStudio/pull/731)
--   fix: use tag aliases in tag search by [@CyanVoxel](https://github.com/CyanVoxel) in [#726](https://github.com/TagStudioDev/TagStudio/pull/726)
--   fix: keep initial id order in `get_entries_full()` by [@CyanVoxel](https://github.com/CyanVoxel) in [#736](https://github.com/TagStudioDev/TagStudio/pull/736)
--   fix: always catch db mismatch by [@CyanVoxel](https://github.com/CyanVoxel) in [#738](https://github.com/TagStudioDev/TagStudio/pull/738)
--   fix: relink unlinked entry to existing entry without sql error by [@mashed5894](https://github.com/mashed5894) in [#730](https://github.com/TagStudioDev/TagStudio/issues/730)
--   fix: refactor and fix bugs with missing_files.py by [@CyanVoxel](https://github.com/CyanVoxel) in [#739](https://github.com/TagStudioDev/TagStudio/pull/739)
--   fix: dragging files references correct entry IDs [@CyanVoxel](https://github.com/CyanVoxel) in [44ff17c](https://github.com/TagStudioDev/TagStudio/commit/44ff17c0b3f05570e356c112f005dbc14c7cc05d)
--   ui: port splash screen from Alpha-v9.4 by [@CyanVoxel](https://github.com/CyanVoxel) in [af760ee](https://github.com/TagStudioDev/TagStudio/commit/af760ee61a523c84bab0fb03a68d7465866d0e05)
--   fix: tags created from tag database now add aliases by [@CyanVoxel](https://github.com/CyanVoxel) in [2903dd2](https://github.com/TagStudioDev/TagStudio/commit/2903dd22c45c02498687073d075bb88886de6b62)
--   fix: check for tag name parity during JSON migration by [@CyanVoxel](https://github.com/CyanVoxel) in [#748](https://github.com/TagStudioDev/TagStudio/pull/748)
--   feat(ui): re-implement tag display names on sql by [@CyanVoxel](https://github.com/CyanVoxel) in [#747](https://github.com/TagStudioDev/TagStudio/pull/747)
--   fix(ui): restore Windows accent color on PySide 6.8.0.1 by [@CyanVoxel](https://github.com/CyanVoxel) in [#755](https://github.com/TagStudioDev/TagStudio/pull/755)
--   fix(ui): (mostly) fix right-click search option on tags by [@CyanVoxel](https://github.com/CyanVoxel) in [#756](https://github.com/TagStudioDev/TagStudio/pull/756)
--   feat: copy/paste fields and tags by [@mashed5894](https://github.com/mashed5894) in [#722](https://github.com/TagStudioDev/TagStudio/pull/722)
+- refactor!: use SQLite and SQLAlchemy for database backend by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#332](https://github.com/TagStudioDev/TagStudio/pull/332)
+- feat: make search results more ergonomic by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#498](https://github.com/TagStudioDev/TagStudio/pull/498)
+- feat: store `Entry` suffix separately by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#503](https://github.com/TagStudioDev/TagStudio/pull/503)
+- feat: port thumbnail ([#390](https://github.com/TagStudioDev/TagStudio/pull/390)) and related features to v9.5 by [@CyanVoxel](https://github.com/CyanVoxel) in [#522](https://github.com/TagStudioDev/TagStudio/pull/522)
+- fix: don't check db version with new library by [@yedpodtrzitko](https://github.com/yedpodtrzitko) in [#536](https://github.com/TagStudioDev/TagStudio/pull/536)
+- fix(ui): update ui when removing fields by [@DandyDev01](https://github.com/DandyDev01) in [#560](https://github.com/TagStudioDev/TagStudio/pull/560)
+- feat(parity): backend for aliases and parent tags by [@DandyDev01](https://github.com/DandyDev01) in [#596](https://github.com/TagStudioDev/TagStudio/pull/596)
+- fix: "open in explorer" opens correct folder by [@KirilBourakov](https://github.com/KirilBourakov) in [#603](https://github.com/TagStudioDev/TagStudio/pull/603)
+- fix: ui/ux parity fixes for thumbnails and files by [@CyanVoxel](https://github.com/CyanVoxel) in [#608](https://github.com/TagStudioDev/TagStudio/pull/608)
+- feat(parity): migrate json libraries to sqlite by [@CyanVoxel](https://github.com/CyanVoxel) in [#604](https://github.com/TagStudioDev/TagStudio/pull/604)
+- fix: clear all setting values when opening a library by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#622](https://github.com/TagStudioDev/TagStudio/pull/622)
+- fix: remove/rework windows path tests by [@VasigaranAndAngel](https://github.com/VasigaranAndAngel) in [#625](https://github.com/TagStudioDev/TagStudio/pull/625)
+- fix: add check to see if library is loaded in filter_items by [@Roc25](https://github.com/Roc25) in [#547](https://github.com/TagStudioDev/TagStudio/pull/547)
+- fix: multiple macro errors by [@Computerdores](https://github.com/Computerdores) in [#612](https://github.com/TagStudioDev/TagStudio/pull/612)
+- fix: don't allow blank tag alias values in db by [@CyanVoxel](https://github.com/CyanVoxel) in [#628](https://github.com/TagStudioDev/TagStudio/pull/628)
+- feat: Reimplement drag drop files on sql migration by [@seakrueger](https://github.com/seakrueger) in [#528](https://github.com/TagStudioDev/TagStudio/pull/528)
+- fix: stop sqlite db from being updated while running tests by [@python357-1](https://github.com/python357-1) in [#648](https://github.com/TagStudioDev/TagStudio/pull/648)
+- fix: enter/return adds top result tag by [@SkeleyM](https://github.com/SkeleyM) in [#651](https://github.com/TagStudioDev/TagStudio/pull/651)
+- fix: show correct unlinked files count by [@SkeleyM](https://github.com/SkeleyM) in [#653](https://github.com/TagStudioDev/TagStudio/pull/653)
+- feat: implement parent tag search by [@Computerdores](https://github.com/Computerdores) in [#673](https://github.com/TagStudioDev/TagStudio/pull/673)
+- fix: only close add tag menu with no search by [@SkeleyM](https://github.com/SkeleyM) in [#685](https://github.com/TagStudioDev/TagStudio/pull/685)
+- fix: drag and drop no longer resets by [@SkeleyM](https://github.com/SkeleyM) in [#710](https://github.com/TagStudioDev/TagStudio/pull/710)
+- feat(ui): port "create and add tag" to main branch by [@SkeleyM](https://github.com/SkeleyM) in [#711](https://github.com/TagStudioDev/TagStudio/pull/711)
+- fix: don't add default title field, use proper phrasing for adding files by [@CyanVoxel](https://github.com/CyanVoxel) in [#701](https://github.com/TagStudioDev/TagStudio/pull/701)
+- fix: preview panel + main window fixes and optimizations by [@CyanVoxel](https://github.com/CyanVoxel) in [#700](https://github.com/TagStudioDev/TagStudio/pull/700)
+- fix: sort tag results by [@mashed5894](https://github.com/mashed5894) in [#721](https://github.com/TagStudioDev/TagStudio/pull/721)
+- fix: restore opening last library on startup by [@SkeleyM](https://github.com/SkeleyM) in [#729](https://github.com/TagStudioDev/TagStudio/pull/729)
+- fix(ui): don't always create tag on enter by [@SkeleyM](https://github.com/SkeleyM) in [#731](https://github.com/TagStudioDev/TagStudio/pull/731)
+- fix: use tag aliases in tag search by [@CyanVoxel](https://github.com/CyanVoxel) in [#726](https://github.com/TagStudioDev/TagStudio/pull/726)
+- fix: keep initial id order in `get_entries_full()` by [@CyanVoxel](https://github.com/CyanVoxel) in [#736](https://github.com/TagStudioDev/TagStudio/pull/736)
+- fix: always catch db mismatch by [@CyanVoxel](https://github.com/CyanVoxel) in [#738](https://github.com/TagStudioDev/TagStudio/pull/738)
+- fix: relink unlinked entry to existing entry without sql error by [@mashed5894](https://github.com/mashed5894) in [#730](https://github.com/TagStudioDev/TagStudio/issues/730)
+- fix: refactor and fix bugs with missing_files.py by [@CyanVoxel](https://github.com/CyanVoxel) in [#739](https://github.com/TagStudioDev/TagStudio/pull/739)
+- fix: dragging files references correct entry IDs [@CyanVoxel](https://github.com/CyanVoxel) in [44ff17c](https://github.com/TagStudioDev/TagStudio/commit/44ff17c0b3f05570e356c112f005dbc14c7cc05d)
+- ui: port splash screen from Alpha-v9.4 by [@CyanVoxel](https://github.com/CyanVoxel) in [af760ee](https://github.com/TagStudioDev/TagStudio/commit/af760ee61a523c84bab0fb03a68d7465866d0e05)
+- fix: tags created from tag database now add aliases by [@CyanVoxel](https://github.com/CyanVoxel) in [2903dd2](https://github.com/TagStudioDev/TagStudio/commit/2903dd22c45c02498687073d075bb88886de6b62)
+- fix: check for tag name parity during JSON migration by [@CyanVoxel](https://github.com/CyanVoxel) in [#748](https://github.com/TagStudioDev/TagStudio/pull/748)
+- feat(ui): re-implement tag display names on sql by [@CyanVoxel](https://github.com/CyanVoxel) in [#747](https://github.com/TagStudioDev/TagStudio/pull/747)
+- fix(ui): restore Windows accent color on PySide 6.8.0.1 by [@CyanVoxel](https://github.com/CyanVoxel) in [#755](https://github.com/TagStudioDev/TagStudio/pull/755)
+- fix(ui): (mostly) fix right-click search option on tags by [@CyanVoxel](https://github.com/CyanVoxel) in [#756](https://github.com/TagStudioDev/TagStudio/pull/756)
+- feat: copy/paste fields and tags by [@mashed5894](https://github.com/mashed5894) in [#722](https://github.com/TagStudioDev/TagStudio/pull/722)
 
 #### UI/UX
 
--   feat(ui): pre-select default tag name in `BuildTagPanel` by [@Cool-Game-Dev](https://github.com/Cool-Game-Dev) in [#592](https://github.com/TagStudioDev/TagStudio/pull/592)
--   feat(ui): keyboard navigation for editing tags by [@Computerdores](https://github.com/Computerdores) in [#407](https://github.com/TagStudioDev/TagStudio/pull/407)
--   feat(ui): use tag query as default new tag name by [@CyanVoxel](https://github.com/CyanVoxel) in [29c0dfd](https://github.com/TagStudioDev/TagStudio/commit/29c0dfdb2d88e8f473e27c7f1fe7ede6e5bd0feb)
--   feat(ui): shortcut to add tags to selected entries; change click behavior of tags to edit by [@CyanVoxel](https://github.com/CyanVoxel) in [#749](https://github.com/TagStudioDev/TagStudio/pull/749)
--   fix(ui): use consistent dark mode colors for all systems by [@CyanVoxel](https://github.com/CyanVoxel) in [#752](https://github.com/TagStudioDev/TagStudio/pull/752)
--   fix(ui): use camera white balance for raw images by [@CyanVoxel](https://github.com/CyanVoxel) in [6ee5304](https://github.com/TagStudioDev/TagStudio/commit/6ee5304b52f217af0f5df543fcb389649203d6b2)
--   Mixed field editing has been limited due to various bugs in both the JSON and SQL implementations. This will be re-implemented in a future release.
+- feat(ui): pre-select default tag name in `BuildTagPanel` by [@Cool-Game-Dev](https://github.com/Cool-Game-Dev) in [#592](https://github.com/TagStudioDev/TagStudio/pull/592)
+- feat(ui): keyboard navigation for editing tags by [@Computerdores](https://github.com/Computerdores) in [#407](https://github.com/TagStudioDev/TagStudio/pull/407)
+- feat(ui): use tag query as default new tag name by [@CyanVoxel](https://github.com/CyanVoxel) in [29c0dfd](https://github.com/TagStudioDev/TagStudio/commit/29c0dfdb2d88e8f473e27c7f1fe7ede6e5bd0feb)
+- feat(ui): shortcut to add tags to selected entries; change click behavior of tags to edit by [@CyanVoxel](https://github.com/CyanVoxel) in [#749](https://github.com/TagStudioDev/TagStudio/pull/749)
+- fix(ui): use consistent dark mode colors for all systems by [@CyanVoxel](https://github.com/CyanVoxel) in [#752](https://github.com/TagStudioDev/TagStudio/pull/752)
+- fix(ui): use camera white balance for raw images by [@CyanVoxel](https://github.com/CyanVoxel) in [6ee5304](https://github.com/TagStudioDev/TagStudio/commit/6ee5304b52f217af0f5df543fcb389649203d6b2)
+- Mixed field editing has been limited due to various bugs in both the JSON and SQL implementations. This will be re-implemented in a future release.
 
 #### Performance
 
--   feat: improve performance of "Delete Missing Entries" by [@Toby222](https://github.com/Toby222) and [@Computerdores](https://github.com/Computerdores) in [#696](https://github.com/TagStudioDev/TagStudio/pull/696)
+- feat: improve performance of "Delete Missing Entries" by [@Toby222](https://github.com/Toby222) and [@Computerdores](https://github.com/Computerdores) in [#696](https://github.com/TagStudioDev/TagStudio/pull/696)
 
 #### Internal Changes
 
--   refactor: combine open launch args by [@UnusualEgg](https://github.com/UnusualEgg) in [#364](https://github.com/TagStudioDev/TagStudio/pull/364)
--   feat: add date_created, date_modified, and date_added columns to entries table by [@CyanVoxel](https://github.com/CyanVoxel) in [#740](https://github.com/TagStudioDev/TagStudio/pull/740)
+- refactor: combine open launch args by [@UnusualEgg](https://github.com/UnusualEgg) in [#364](https://github.com/TagStudioDev/TagStudio/pull/364)
+- feat: add date_created, date_modified, and date_added columns to entries table by [@CyanVoxel](https://github.com/CyanVoxel) in [#740](https://github.com/TagStudioDev/TagStudio/pull/740)
 
 ---
 
@@ -856,7 +857,7 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Added/Fixed
 
--   Create auto-backup of library for use in save failures (Fix [#343](https://github.com/TagStudioDev/TagStudio/issues/343)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#554](https://github.com/TagStudioDev/TagStudio/pull/554)
+- Create auto-backup of library for use in save failures (Fix [#343](https://github.com/TagStudioDev/TagStudio/issues/343)) by [@CyanVoxel](https://github.com/CyanVoxel) in [#554](https://github.com/TagStudioDev/TagStudio/pull/554)
 
 ---
 
@@ -864,18 +865,18 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Added
 
--   Warn user if FFmpeg is not installed
--   Support for `.raf` and `.orf` raw image thumbnails and previews
+- Warn user if FFmpeg is not installed
+- Support for `.raf` and `.orf` raw image thumbnails and previews
 
 ### Fixed
 
--   Use `birthtime` for file creation time on Mac & Windows
--   Use audio icon fallback when FFmpeg is not detected
--   Retain search query upon directory refresh
+- Use `birthtime` for file creation time on Mac & Windows
+- Use audio icon fallback when FFmpeg is not detected
+- Retain search query upon directory refresh
 
 ### Changed
 
--   Significantly improve file re-scanning performance
+- Significantly improve file re-scanning performance
 
 ---
 
@@ -883,64 +884,64 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Added
 
--   Copy and paste fields
--   Add multiple fields at once
--   Drag and drop files in/out of the program
-    -   Files can be shared by dragging them from the thumbnail grid to other programs
-    -   Files can be added to library folder by dragging them into the program
--   Manage Python virtual environment in Nix flake
--   Ability to create tag when adding tags
--   Blender preview thumbnail support
--   File deletion/trashing
-    -   Added right-click option on thumbnails and preview panel to delete files
-    -   Added Edit Menu option for deleting files
-    -   Added <kbd>Delete</kbd> key shortcut for deleting files
--   Font preview thumbnail support
-    -   Short "Aa" previews for thumbnails
-    -   Full alphabet preview for the preview pane
--   Sort tags by alphabetical/color
--   File explorer action follows OS naming
--   Preview Source Engine files
--   Expanded thumbnail and preview features
-    -   Add album cover art thumbnails
-    -   Add audio waveform thumbnails for audio files without embedded cover art
-    -   Add new default file thumbnails, both for generic and specific file types
-    -   Change the unlinked file icon to better convey its meaning
-    -   Add dropdown for different thumbnail sizes
--   Show File Creation and Modified dates; Restyle file path label
+- Copy and paste fields
+- Add multiple fields at once
+- Drag and drop files in/out of the program
+    - Files can be shared by dragging them from the thumbnail grid to other programs
+    - Files can be added to library folder by dragging them into the program
+- Manage Python virtual environment in Nix flake
+- Ability to create tag when adding tags
+- Blender preview thumbnail support
+- File deletion/trashing
+    - Added right-click option on thumbnails and preview panel to delete files
+    - Added Edit Menu option for deleting files
+    - Added <kbd>Delete</kbd> key shortcut for deleting files
+- Font preview thumbnail support
+    - Short "Aa" previews for thumbnails
+    - Full alphabet preview for the preview pane
+- Sort tags by alphabetical/color
+- File explorer action follows OS naming
+- Preview Source Engine files
+- Expanded thumbnail and preview features
+    - Add album cover art thumbnails
+    - Add audio waveform thumbnails for audio files without embedded cover art
+    - Add new default file thumbnails, both for generic and specific file types
+    - Change the unlinked file icon to better convey its meaning
+    - Add dropdown for different thumbnail sizes
+- Show File Creation and Modified dates; Restyle file path label
 
 ### Fixed
 
--   Backslashes in f-string on file dupe widget
--   Tags not shown when none searched
--   Avoid error from eagerly grabbing data values
--   Correct behavior for tag search options
--   Load Gallery-DL sidecar files correctly
--   Correct duplicate file matching
--   GPU hardware acceleration in Nix flake
--   Suppress command prompt windows for FFmpeg in builds
+- Backslashes in f-string on file dupe widget
+- Tags not shown when none searched
+- Avoid error from eagerly grabbing data values
+- Correct behavior for tag search options
+- Load Gallery-DL sidecar files correctly
+- Correct duplicate file matching
+- GPU hardware acceleration in Nix flake
+- Suppress command prompt windows for FFmpeg in builds
 
 ### Internal Changes
 
--   Move type constants to media classes
--   Combine open launch arguments
--   Revamp Nix flake with devenv/direnv in cb4798b
--   Remove impurity of Nix flake when used with direnv in bc38e56
+- Move type constants to media classes
+- Combine open launch arguments
+- Revamp Nix flake with devenv/direnv in cb4798b
+- Remove impurity of Nix flake when used with direnv in bc38e56
 
 ## 9.3.2 <small>[July 18th, 2024]</small>
 
 ### Fixed
 
--   Fix signal log warning
--   Fix "Folders to Tags" feature
--   Fix search ignoring case of extension list
+- Fix signal log warning
+- Fix "Folders to Tags" feature
+- Fix search ignoring case of extension list
 
 ### Internal Changes
 
--   Add tests into CI by
--   Create testing library files ad-hoc
--   Refactoring: centralize field IDs
--   Update to pyside6 version 6.7.1
+- Add tests into CI by
+- Create testing library files ad-hoc
+- Refactoring: centralize field IDs
+- Update to pyside6 version 6.7.1
 
 ---
 
@@ -948,10 +949,10 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Fixed
 
--   Separately pin QT nixpkg version
--   Bugfix for #252, don't attempt to read video file if invalid or 0 frames long
--   Toggle Mouse Event Transparency on ItemThumbs
--   Refactor `video_player.py`
+- Separately pin QT nixpkg version
+- Bugfix for #252, don't attempt to read video file if invalid or 0 frames long
+- Toggle Mouse Event Transparency on ItemThumbs
+- Refactor `video_player.py`
 
 ---
 
@@ -959,31 +960,31 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Added
 
--   Added playback previews for video files
--   Added Boolean "and/or" search mode selection
--   Added ability to scan and fix duplicate entries (not to be confused with duplicate files) from the "Fix Unlinked Entries" menu
--   Added “Select All” (<kbd>Ctrl</kbd>+<kbd>A</kbd> / <kbd>⌘ Command</kbd>+<kbd>A</kbd>) hotkey for the library grid view
--   Added "Clear Selection" hotkey (<kbd>Esc</kbd>) for the library grid view
--   Added the ability to invert the file extension inclusion list into an exclusion list
--   Added default landing page when no library is open
+- Added playback previews for video files
+- Added Boolean "and/or" search mode selection
+- Added ability to scan and fix duplicate entries (not to be confused with duplicate files) from the "Fix Unlinked Entries" menu
+- Added “Select All” (<kbd>Ctrl</kbd>+<kbd>A</kbd> / <kbd>⌘ Command</kbd>+<kbd>A</kbd>) hotkey for the library grid view
+- Added "Clear Selection" hotkey (<kbd>Esc</kbd>) for the library grid view
+- Added the ability to invert the file extension inclusion list into an exclusion list
+- Added default landing page when no library is open
 
 ### Fixed
 
--   TagStudio will no longer attempt to or allow you to reopen a library from a missing location
--   Fixed `PermissionError` when attempting to access files with a higher permission level upon scanning the library directory
--   Fixed RAW image previews sometimes not loadingand
--   Fixed most non-UTF-8 encoded text files from not being able to be previewed
--   Fixed "Refresh Directories"/"Fix Unlinked Entries" creating duplicate entries
--   Other miscellaneous fixes
+- TagStudio will no longer attempt to or allow you to reopen a library from a missing location
+- Fixed `PermissionError` when attempting to access files with a higher permission level upon scanning the library directory
+- Fixed RAW image previews sometimes not loadingand
+- Fixed most non-UTF-8 encoded text files from not being able to be previewed
+- Fixed "Refresh Directories"/"Fix Unlinked Entries" creating duplicate entries
+- Other miscellaneous fixes
 
 ### Changed
 
--   Renamed "Subtags" to "Parent Tags" to help better describe their function
--   Increased number of tags shown by default in the "Add Tag" modal from 29 to 100
--   Documentation is now split into individual linked files and updated to include future features
--   Replaced use of `os.path` with `pathlib`
--   `.cr2` files are now included in the list of RAW image file types
--   Minimum supported macOS version raised to 12.0
+- Renamed "Subtags" to "Parent Tags" to help better describe their function
+- Increased number of tags shown by default in the "Add Tag" modal from 29 to 100
+- Documentation is now split into individual linked files and updated to include future features
+- Replaced use of `os.path` with `pathlib`
+- `.cr2` files are now included in the list of RAW image file types
+- Minimum supported macOS version raised to 12.0
 
 ---
 
@@ -991,17 +992,17 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Added
 
--   Basic thumbnail/preview support for RAW images (currently `.raw`, `.dng`, `.rw2`, `.nef`, `.arw`, `.crw`, `.cr3`)
-    -   NOTE: These previews are currently slow to load given the nature of rendering them. In the future once thumbnail caching is added, this process should only happen once.
--   Thumbnail/preview support for HEIF images
+- Basic thumbnail/preview support for RAW images (currently `.raw`, `.dng`, `.rw2`, `.nef`, `.arw`, `.crw`, `.cr3`)
+    - NOTE: These previews are currently slow to load given the nature of rendering them. In the future once thumbnail caching is added, this process should only happen once.
+- Thumbnail/preview support for HEIF images
 
 ### Fixed
 
--   Fixed sidebar not expanding horizontally
--   Fixed "Recent Library" list not updating when creating a new library
--   Fixed palletized images not loading with alpha channels
--   Low resolution images (such as pixel art) now render with crisp edges in thumbnails and previews
--   Fixed visual bug where the edit icon would show for incorrect fields
+- Fixed sidebar not expanding horizontally
+- Fixed "Recent Library" list not updating when creating a new library
+- Fixed palletized images not loading with alpha channels
+- Low resolution images (such as pixel art) now render with crisp edges in thumbnails and previews
+- Fixed visual bug where the edit icon would show for incorrect fields
 
 ---
 
@@ -1009,51 +1010,51 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Added
 
--   Full macOS and Linux support
--   Ability to apply tags to multiple selections at once
--   Right-click context menu for opening files or their locations
--   Support for all filetypes inside of the library
--   Configurable filetype blacklist
--   Option to automatically open last used library on startup
--   Tool to convert folder structure to tag tree
--   SIGTERM handling in console window
--   Keyboard shortcuts for basic functions
--   Basic support for plaintext thumbnails
--   Default icon for files with no thumbnail support
--   Menu action to close library
--   All tags now show in the "Add Tag" panel by default
--   Modal view to view and manage all library tags
--   Build scripts for Windows and macOS
--   Help menu option to visit the GitHub repository
--   Toggleable "Recent Libraries" list in the entry side panel
+- Full macOS and Linux support
+- Ability to apply tags to multiple selections at once
+- Right-click context menu for opening files or their locations
+- Support for all filetypes inside of the library
+- Configurable filetype blacklist
+- Option to automatically open last used library on startup
+- Tool to convert folder structure to tag tree
+- SIGTERM handling in console window
+- Keyboard shortcuts for basic functions
+- Basic support for plaintext thumbnails
+- Default icon for files with no thumbnail support
+- Menu action to close library
+- All tags now show in the "Add Tag" panel by default
+- Modal view to view and manage all library tags
+- Build scripts for Windows and macOS
+- Help menu option to visit the GitHub repository
+- Toggleable "Recent Libraries" list in the entry side panel
 
 ### Fixed
 
--   Fixed errors when performing actions with no library open
--   Fixed bug where built-in tags were duplicated upon saving
--   QThreads are now properly terminated on application exit
--   Images with rotational EXIF data are now properly displayed
--   Fixed "truncated" images causing errors
--   Fixed images with large resolutions causing errors
+- Fixed errors when performing actions with no library open
+- Fixed bug where built-in tags were duplicated upon saving
+- QThreads are now properly terminated on application exit
+- Images with rotational EXIF data are now properly displayed
+- Fixed "truncated" images causing errors
+- Fixed images with large resolutions causing errors
 
 ### Changed
 
--   Updated minimum Python version to 3.12
--   Various UI improvements
-    -   Improved legibility of the Light Theme (still a WIP)
-    -   Updated Dark Theme
-    -   Added hand cursor to several clickable elements
--   Fixed network paths not being able to load
--   Various code cleanup and refactoring
--   New application icons
+- Updated minimum Python version to 3.12
+- Various UI improvements
+    - Improved legibility of the Light Theme (still a WIP)
+    - Updated Dark Theme
+    - Added hand cursor to several clickable elements
+- Fixed network paths not being able to load
+- Various code cleanup and refactoring
+- New application icons
 
 ### Known Issues
 
--   Using and editing multiple entry fields of the same type may result in incorrect field(s) being updated
--   Adding Favorite or Archived tags via the thumbnail badges may apply the tag(s) to incorrect fields
--   Searching for tag names with spaces does not currently function as intended
-    -   A temporary workaround it to omit spaces in tag names when searching
--   Sorting fields using the "Sort Fields" macro may result in edit icons being shown for incorrect fields
+- Using and editing multiple entry fields of the same type may result in incorrect field(s) being updated
+- Adding Favorite or Archived tags via the thumbnail badges may apply the tag(s) to incorrect fields
+- Searching for tag names with spaces does not currently function as intended
+    - A temporary workaround it to omit spaces in tag names when searching
+- Sorting fields using the "Sort Fields" macro may result in edit icons being shown for incorrect fields
 
 ---
 
@@ -1061,4 +1062,4 @@ This was the main focus of this update, and where the majority of development ti
 
 ### Added
 
--   Initial public release
+- Initial public release

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,6 +1,7 @@
 ---
 icon: material/palette
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,7 @@
 ---
 icon: material/file-plus
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -10,11 +11,11 @@ Thank you so much for showing interest in contributing to TagStudio! Here are a 
 
 ## Getting Started
 
--   Check the [Feature Roadmap](roadmap.md) page to see what priority features there are, the [FAQ](https://github.com/TagStudioDev/TagStudio/blob/main/README.md#faq), as well as the project's [Issues](https://github.com/TagStudioDev/TagStudio/issues) and [Pull Requests](https://github.com/TagStudioDev/TagStudio/pulls).
--   If you'd like to add a feature that isn't on the feature roadmap or doesn't have an open issue, **PLEASE create a feature request** issue for it discussing your intentions so any feedback or important information can be given by the team first.
-    -   We don't want you wasting time developing a feature or making a change that can't/won't be added for any reason ranging from pre-existing refactors to design philosophy differences.
--   **Please don't** create pull requests that consist of large refactors, _especially_ without discussing them with us first. These end up doing more harm than good for the project by continuously delaying progress and disrupting everyone else's work.
--   If you wish to discuss TagStudio further, feel free to join the [Discord Server](https://discord.com/invite/hRNnVKhF2G)!
+- Check the [Feature Roadmap](roadmap.md) page to see what priority features there are, the [FAQ](https://github.com/TagStudioDev/TagStudio/blob/main/README.md#faq), as well as the project's [Issues](https://github.com/TagStudioDev/TagStudio/issues) and [Pull Requests](https://github.com/TagStudioDev/TagStudio/pulls).
+- If you'd like to add a feature that isn't on the feature roadmap or doesn't have an open issue, **PLEASE create a feature request** issue for it discussing your intentions so any feedback or important information can be given by the team first.
+    - We don't want you wasting time developing a feature or making a change that can't/won't be added for any reason ranging from pre-existing refactors to design philosophy differences.
+- **Please don't** create pull requests that consist of large refactors, _especially_ without discussing them with us first. These end up doing more harm than good for the project by continuously delaying progress and disrupting everyone else's work.
+- If you wish to discuss TagStudio further, feel free to join the [Discord Server](https://discord.com/invite/hRNnVKhF2G)!
 
 <!-- prettier-ignore -->
 !!! note
@@ -22,20 +23,20 @@ Thank you so much for showing interest in contributing to TagStudio! Here are a 
 
 ### Contribution Checklist
 
--   I've read the [Feature Roadmap](roadmap.md) page
--   I've read the [FAQ](https://github.com/TagStudioDev/TagStudio/blob/main/README.md#faq)
--   I've checked the project's [Issues](https://github.com/TagStudioDev/TagStudio/issues) and [Pull Requests](https://github.com/TagStudioDev/TagStudio/pulls)
--   **I've created a new issue for my feature/fix _before_ starting work on it**, or have at least notified others in the relevant existing issue(s) of my intention to work on it
--   I've set up my development environment including Ruff, Mypy, and PyTest
--   I've read the CONTRIBUTING.md/Contributing page on the documentation site as well as the and/or [Style Guide](style.md)
--   **_I mean it, I've found or created an issue for my feature/fix!_**
+- I've read the [Feature Roadmap](roadmap.md) page
+- I've read the [FAQ](https://github.com/TagStudioDev/TagStudio/blob/main/README.md#faq)
+- I've checked the project's [Issues](https://github.com/TagStudioDev/TagStudio/issues) and [Pull Requests](https://github.com/TagStudioDev/TagStudio/pulls)
+- **I've created a new issue for my feature/fix _before_ starting work on it**, or have at least notified others in the relevant existing issue(s) of my intention to work on it
+- I've set up my development environment including Ruff, Mypy, and PyTest
+- I've read the CONTRIBUTING.md/Contributing page on the documentation site as well as the and/or [Style Guide](style.md)
+- **_I mean it, I've found or created an issue for my feature/fix!_**
 
 <!-- prettier-ignore -->
 !!! failure "Unacceptable Code"
     The following types of code will NOT be accepted to the project:
 
-    -   Code that is not yours or does not have a compatible license with TagStudio's [own one](../LICENSE)
-    -   Code that you do not understand and/or cannot explain
+    - Code that is not yours or does not have a compatible license with TagStudio's [own one](../LICENSE)
+    - Code that you do not understand and/or cannot explain
 
 ## Creating a Development Environment
 
@@ -80,9 +81,9 @@ A Python linter and code formatter. Ruff uses the `pyproject.toml` as its config
 
 Inside the root repository directory:
 
--   Lint code with `ruff check`
-    -   Some linting suggestions can be automatically formatted with `ruff check --fix`
--   Format code with `ruff format`
+- Lint code with `ruff check`
+    - Some linting suggestions can be automatically formatted with `ruff check --fix`
+- Format code with `ruff format`
 
 Ruff should automatically discover the configuration options inside the [pyproject.toml](https://github.com/TagStudioDev/TagStudio/blob/main/pyproject.toml) file. For more information, see the [ruff configuration discovery docs](https://docs.astral.sh/ruff/configuration/#config-file-discovery).
 
@@ -94,16 +95,16 @@ Mypy is a static type checker for Python. It sure has a lot to say sometimes, bu
 
 #### Running Locally
 
--   **(First time only)** Run the following:
-    -   `mkdir -p .mypy_cache`
-    -   `mypy --install-types --non-interactive`
--   You can now check code by running `mypy --config-file pyproject.toml .` in the repository root. _(Don't forget the "." at the end!)_
+- **(First time only)** Run the following:
+    - `mkdir -p .mypy_cache`
+    - `mypy --install-types --non-interactive`
+- You can now check code by running `mypy --config-file pyproject.toml .` in the repository root. _(Don't forget the "." at the end!)_
 
 Mypy is also available as a VS Code [extension](https://marketplace.visualstudio.com/items?itemName=matangover.mypy), PyCharm [plugin](https://plugins.jetbrains.com/plugin/11086-mypy), and [more](https://plugins.jetbrains.com/plugin/11086-mypy).
 
 ### PyTest
 
--   Run all tests by running `pytest tests/` in the repository root.
+- Run all tests by running `pytest tests/` in the repository root.
 
 ## Code Style
 
@@ -111,22 +112,22 @@ See the [Style Guide](style.md)
 
 ### Modules & Implementations
 
--   **Do not** modify legacy library code in the `src/core/library/json/` directory
--   Avoid direct calls to `os`
-    -   Use `Pathlib` library instead of `os.path`
-    -   Use `platform.system()` instead of `os.name` and `sys.platform`
--   Don't prepend local imports with `tagstudio`, stick to `src`
--   Use the `logger` system instead of `print` statements
--   Avoid nested f-strings
--   Use HTML-like tags inside Qt widgets over stylesheets where possible
+- **Do not** modify legacy library code in the `src/core/library/json/` directory
+- Avoid direct calls to `os`
+    - Use `Pathlib` library instead of `os.path`
+    - Use `platform.system()` instead of `os.name` and `sys.platform`
+- Don't prepend local imports with `tagstudio`, stick to `src`
+- Use the `logger` system instead of `print` statements
+- Avoid nested f-strings
+- Use HTML-like tags inside Qt widgets over stylesheets where possible
 
 ### Commit and Pull Request Style
 
--   Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) as a guideline for commit messages. This allows us to easily generate changelogs for releases.
-    -   See some [examples](https://www.conventionalcommits.org/en/v1.0.0/#examples) of what this looks like in practice.
--   Use clear and concise commit messages. If your commit does too much, either consider breaking it up into smaller commits or providing extra detail in the commit description.
--   Pull requests should have an adequate title and description which clearly outline your intentions and changes/additions. Feel free to provide screenshots, GIFs, or videos, especially for UI changes.
--   Pull requests should ideally be limited to **a single** feature or fix.
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) as a guideline for commit messages. This allows us to easily generate changelogs for releases.
+    - See some [examples](https://www.conventionalcommits.org/en/v1.0.0/#examples) of what this looks like in practice.
+- Use clear and concise commit messages. If your commit does too much, either consider breaking it up into smaller commits or providing extra detail in the commit description.
+- Pull requests should have an adequate title and description which clearly outline your intentions and changes/additions. Feel free to provide screenshots, GIFs, or videos, especially for UI changes.
+- Pull requests should ideally be limited to **a single** feature or fix.
 
 <!-- prettier-ignore -->
 !!! important
@@ -138,24 +139,24 @@ See the [Style Guide](style.md)
 
 ### Runtime Requirements
 
--   Final code must function on supported versions of Windows, macOS, and Linux:
-    -   Windows: 10, 11
-    -   macOS: 13.0+
-    -   Linux: _Varies_
--   Final code must **_NOT:_**
-    -   Contain superfluous or unnecessary logging statements
-    -   Cause unreasonable slowdowns to the program outside of a progress-indicated task
-    -   Cause undesirable visual glitches or artifacts on screen
+- Final code must function on supported versions of Windows, macOS, and Linux:
+    - Windows: 10, 11
+    - macOS: 13.0+
+    - Linux: _Varies_
+- Final code must **_NOT:_**
+    - Contain superfluous or unnecessary logging statements
+    - Cause unreasonable slowdowns to the program outside of a progress-indicated task
+    - Cause undesirable visual glitches or artifacts on screen
 
 ## Documentation Guidelines
 
 Documentation contributions include anything inside of the `docs/` folder, as well as the `README.md` and `CONTRIBUTING.md` files. Documentation inside the `docs/` folder is built and hosted on our static documentation site, [docs.tagstud.io](https://docs.tagstud.io/).
 
--   Use "[dash-case / kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case)" for file and folder names
--   Follow the folder structure pattern
--   Don't add images or other media with excessively large file sizes
--   Provide alt text for all embedded media
--   Use "[Title Case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)" for title capitalization
+- Use "[dash-case / kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case)" for file and folder names
+- Follow the folder structure pattern
+- Don't add images or other media with excessively large file sizes
+- Provide alt text for all embedded media
+- Use "[Title Case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)" for title capitalization
 
 ## Translation Guidelines
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,6 +1,7 @@
 ---
 icon: material/code-braces
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -87,10 +88,9 @@ If you choose to manually set up a virtual environment and install dependencies 
     ```
 
 2.  Activate your environment:
-
-    -   Windows w/Powershell: `.venv\Scripts\Activate.ps1`
-    -   Windows w/Command Prompt: `.venv\Scripts\activate.bat`
-    -   Linux/macOS: `source .venv/bin/activate`
+    - Windows w/Powershell: `.venv\Scripts\Activate.ps1`
+    - Windows w/Command Prompt: `.venv\Scripts\activate.bat`
+    - Linux/macOS: `source .venv/bin/activate`
 
     <!-- prettier-ignore -->
     !!! info "Supported Shells"

--- a/docs/entries.md
+++ b/docs/entries.md
@@ -1,6 +1,7 @@
 ---
 icon: material/file
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -24,33 +25,33 @@ To fix file entries that have become unlinked, select the "Fix Unlinked Entries"
 
 ## Internal Structure
 
--   `id` (`INTEGER`/`int`, `UNIQUE`, `NOT NULL`, `PRIMARY KEY`)
-    -   The ID for the file entry.
-    -   Used for guaranteed unique references.
--   `folder` (`INTEGER`/`int`, `NOT NULL`, `FOREIGN KEY`)
-    -   _Not currently used, may be removed._
--   `path` (`VARCHAR`/`Path`, `UNIQUE`, `NOT NULL`)
-    -   The filename and filepath relative to the root of the library folder.
-    -   (E.g. for library "Folder", path = "any_subfolders/filename.txt")
--   `suffix` (`VARCHAR`/`str`, `NOT NULL`)
-    -   The filename suffix with no leading dot.
-    -   Used for quicker file extension checks.
--   `date_created` (`DATETIME`/`Datetime`)
-    -   _Not currently used, will be implemented in an upcoming update._
-    -   The creation date of the file (not the entry).
-    -   Generated from `st_birthtime` on Windows and Mac, and `st_ctime` on Linux.
--   `date_modified` (`DATETIME`/`Datetime`)
-    -   _Not currently used, will be implemented in an upcoming update._
-    -   The latest modification date of the file (not the entry).
-    -   Generated from `st_mtime`.
--   `date_added` (`DATETIME`/`Datetime`)
-    -   The date the file entry was added to the TagStudio library.
+- `id` (`INTEGER`/`int`, `UNIQUE`, `NOT NULL`, `PRIMARY KEY`)
+    - The ID for the file entry.
+    - Used for guaranteed unique references.
+- `folder` (`INTEGER`/`int`, `NOT NULL`, `FOREIGN KEY`)
+    - _Not currently used, may be removed._
+- `path` (`VARCHAR`/`Path`, `UNIQUE`, `NOT NULL`)
+    - The filename and filepath relative to the root of the library folder.
+    - (E.g. for library "Folder", path = "any_subfolders/filename.txt")
+- `suffix` (`VARCHAR`/`str`, `NOT NULL`)
+    - The filename suffix with no leading dot.
+    - Used for quicker file extension checks.
+- `date_created` (`DATETIME`/`Datetime`)
+    - _Not currently used, will be implemented in an upcoming update._
+    - The creation date of the file (not the entry).
+    - Generated from `st_birthtime` on Windows and Mac, and `st_ctime` on Linux.
+- `date_modified` (`DATETIME`/`Datetime`)
+    - _Not currently used, will be implemented in an upcoming update._
+    - The latest modification date of the file (not the entry).
+    - Generated from `st_mtime`.
+- `date_added` (`DATETIME`/`Datetime`)
+    - The date the file entry was added to the TagStudio library.
 
 ### Table Relationships
 
--   `tag_entries`
-    -   A relationship between `entry_id` to `tag_id`s from the `tags` table.
--   `text_fields`
-    -   (TODO: determine the relationship for `entry_id`)
--   `datetime_fields`
-    -   (TODO: determine the relationship for `entry_id`)
+- `tag_entries`
+    - A relationship between `entry_id` to `tag_id`s from the `tags` table.
+- `text_fields`
+    - (TODO: determine the relationship for `entry_id`)
+- `datetime_fields`
+    - (TODO: determine the relationship for `entry_id`)

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1,6 +1,7 @@
 ---
 icon: material/text-box
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -14,16 +15,16 @@ Fields are additional types of metadata that you can attach to [file entries](./
 
 A string of text, displayed as a single line.
 
--   e.g: Title, Author, Artist, URL, etc.
+- e.g: Title, Author, Artist, URL, etc.
 
 ### Text Box
 
 A long string of text displayed as a box of text.
 
--   e.g: Description, Notes, etc.
+- e.g: Description, Notes, etc.
 
 ### Datetime
 
 A date and time value.
 
--   e.g: Date Published, Date Taken, etc.
+- e.g: Date Published, Date Taken, etc.

--- a/docs/help/ffmpeg.md
+++ b/docs/help/ffmpeg.md
@@ -1,6 +1,7 @@
 ---
 icon: material/movie-open-cog
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -25,7 +26,6 @@ To Install:
 1. Download 7z or zip file and extract it (right click > Extract All)
 2. Move extracted contents to a unique folder (i.e; `c:\ffmpeg` or `c:\Program Files\ffmpeg`)
 3. Add FFmpeg to your system PATH
-
     1. In Windows, search for or go to "Edit the system environment variables" under the Control Panel
     2. Under "User Variables", select "Path" then edit
     3. Click new and add `<Your folder>\bin` (e.g; `c:\ffmpeg\bin` or `c:\Program Files\ffmpeg\bin`)

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -2,6 +2,7 @@
 title: Ignoring Files
 icon: material/file-document-remove
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -64,7 +65,7 @@ When scanning your library directories, the `.ts_ignore` file is read by either 
 
 A `#` symbol at the start of a line indicates that this line is a comment, and match no items. Blank lines are used to enhance readability and also match no items.
 
--   Can be escaped by putting a backslash ("`\`") in front of the `#` symbol.
+- Can be escaped by putting a backslash ("`\`") in front of the `#` symbol.
 
 <!-- prettier-ignore-start -->
 === "Example comment"
@@ -106,9 +107,9 @@ A `#` symbol at the start of a line indicates that this line is a comment, and m
 
 The forward slash "`/`" is used as the directory separator. Separators may occur at the beginning, middle or end of the `.ts_ignore` search pattern.
 
--   If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular `.TagStudio` library folder itself. Otherwise the pattern may also match at any level below the `.TagStudio` folder level.
+- If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular `.TagStudio` library folder itself. Otherwise the pattern may also match at any level below the `.TagStudio` folder level.
 
--   If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files and directories.
+- If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files and directories.
 
 <!-- prettier-ignore-start -->
 === "Example folder pattern"
@@ -129,8 +130,8 @@ The forward slash "`/`" is used as the directory separator. Separators may occur
 
 A `!` prefix before a pattern negates the pattern, allowing any files matched matched by previous patterns to be un-matched.
 
--   Any matching file excluded by a previous pattern will become included again.
--   **It is not possible to re-include a file if a parent directory of that file is excluded.**
+- Any matching file excluded by a previous pattern will become included again.
+- **It is not possible to re-include a file if a parent directory of that file is excluded.**
 
 <!-- prettier-ignore-start -->
 === "Example negation"
@@ -204,10 +205,10 @@ The character "`?`" matches any one character except "`/`".
 
 Two consecutive asterisks ("`**`") in patterns matched against full pathname may have special meaning:
 
--   A leading "`**`" followed by a slash means matches in all directories.
--   A trailing "`/**`" matches everything inside.
--   A slash followed by two consecutive asterisks then a slash ("`/**/`") matches zero or more directories.
--   Other consecutive asterisks are considered regular asterisks and will match according to the previous rules.
+- A leading "`**`" followed by a slash means matches in all directories.
+- A trailing "`/**`" matches everything inside.
+- A slash followed by two consecutive asterisks then a slash ("`/**/`") matches zero or more directories.
+- Other consecutive asterisks are considered regular asterisks and will match according to the previous rules.
 
 <!-- prettier-ignore-start -->
 === "Leading **"

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ hide:
     - toc
     - navigation
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -38,7 +39,7 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-file-multiple:{ .lg .middle } **[All Files](entries.md) Welcome**
+- :material-file-multiple:{ .lg .middle } **[All Files](entries.md) Welcome**
 
     ***
 
@@ -46,27 +47,25 @@ hide:
 
     [:material-arrow-right: See Full Preview Support](preview-support.md)
 
--   :material-tag-text:{ .lg .middle } **Create [Tags](tags.md) Your Way**
+- :material-tag-text:{ .lg .middle } **Create [Tags](tags.md) Your Way**
 
     ***
+    - :material-format-font: No character restrictions
+    - :material-form-textbox: Add aliases/alternate names
+    - :material-palette: Customize colors and styles
+    - :material-tag-multiple: Tags can be tagged with other tags!
+    - :material-star-four-points: And more!
 
-    -   :material-format-font: No character restrictions
-    -   :material-form-textbox: Add aliases/alternate names
-    -   :material-palette: Customize colors and styles
-    -   :material-tag-multiple: Tags can be tagged with other tags!
-    -   :material-star-four-points: And more!
-
--   :material-magnify:{ .lg .middle } **Powerful [Search](search.md)**
+- :material-magnify:{ .lg .middle } **Powerful [Search](search.md)**
 
     ***
+    - Full [Boolean operator](search.md) support
+    - Filenames, paths, and extensions with [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) syntax
+    - General media types (e.g. "Photo", "Video", "Document")
+    - Special searches (e.g. "Untagged")
+    - "[Smartcase](search.md#case-sensitivity)" case sensitivity
 
-    -   Full [Boolean operator](search.md) support
-    -   Filenames, paths, and extensions with [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) syntax
-    -   General media types (e.g. "Photo", "Video", "Document")
-    -   Special searches (e.g. "Untagged")
-    -   "[Smartcase](search.md#case-sensitivity)" case sensitivity
-
--   :material-text-box:{ .lg .middle } **Text and Date [Fields](fields.md)**
+- :material-text-box:{ .lg .middle } **Text and Date [Fields](fields.md)**
 
     ***
 
@@ -80,7 +79,7 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-scale-balance:{ .lg .middle } **Open Source**
+- :material-scale-balance:{ .lg .middle } **Open Source**
 
     ***
 
@@ -90,7 +89,7 @@ hide:
 
     [:material-arrow-right: Roadmap to MIT Core Library License](roadmap.md#core-library-api)
 
--   :material-database:{ .lg .middle } **Central Save File**
+- :material-database:{ .lg .middle } **Central Save File**
 
     ***
 
@@ -108,6 +107,6 @@ TagStudio aims to create an **open** and **robust** format for file tagging that
 
 <div class="grid cards" markdown>
 
--   :material-map-check:{ .lg .middle } See the [**Roadmap**](roadmap.md) for future features and updates
+- :material-map-check:{ .lg .middle } See the [**Roadmap**](roadmap.md) for future features and updates
 
 </div>

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,7 @@
 ---
 icon: material/download
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -64,22 +65,21 @@ TagStudio can now be launched via the `tagstudio` command in your terminal.
 
 Some external dependencies are required for TagStudio to execute. Below is a table of known packages that will be necessary.
 
-<!-- prettier-ignore -->
-| Package | Reason |
-|--------------- | --------------- |
-| [dbus](https://repology.org/project/dbus) | required for Qt; opening desktop applications |
-| [ffmpeg](https://repology.org/project/ffmpeg) | audio/video playback |
-| libstdc++ | required for Qt |
-| [libva](https://repology.org/project/libva) | hardware rendering with [VAAPI](https://www.freedesktop.org/wiki/Software/vaapi) |
-| [libvdpau](https://repology.org/project/libvdpau) | hardware rendering with [VDPAU](https://www.freedesktop.org/wiki/Software/VDPAU) |
-| [libx11](https://repology.org/project/libx11) | required for Qt |
-| libxcb-cursor OR [xcb-util-cursor](https://repology.org/project/xcb-util-cursor) | required for Qt |
-| [libxkbcommon](https://repology.org/project/libxkbcommon) | required for Qt |
-| [libxrandr](https://repology.org/project/libxrandr) | hardware rendering |
-| [pipewire](https://repology.org/project/pipewire) | PipeWire audio support |
-| [qt](https://repology.org/project/qt) | required |
-| [qt-multimedia](https://repology.org/project/qt) | required |
-| [qt-wayland](https://repology.org/project/qt) | Wayland support |
+| Package                                                                          | Reason                                                                           |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [dbus](https://repology.org/project/dbus)                                        | required for Qt; opening desktop applications                                    |
+| [ffmpeg](https://repology.org/project/ffmpeg)                                    | audio/video playback                                                             |
+| libstdc++                                                                        | required for Qt                                                                  |
+| [libva](https://repology.org/project/libva)                                      | hardware rendering with [VAAPI](https://www.freedesktop.org/wiki/Software/vaapi) |
+| [libvdpau](https://repology.org/project/libvdpau)                                | hardware rendering with [VDPAU](https://www.freedesktop.org/wiki/Software/VDPAU) |
+| [libx11](https://repology.org/project/libx11)                                    | required for Qt                                                                  |
+| libxcb-cursor OR [xcb-util-cursor](https://repology.org/project/xcb-util-cursor) | required for Qt                                                                  |
+| [libxkbcommon](https://repology.org/project/libxkbcommon)                        | required for Qt                                                                  |
+| [libxrandr](https://repology.org/project/libxrandr)                              | hardware rendering                                                               |
+| [pipewire](https://repology.org/project/pipewire)                                | PipeWire audio support                                                           |
+| [qt](https://repology.org/project/qt)                                            | required                                                                         |
+| [qt-multimedia](https://repology.org/project/qt)                                 | required                                                                         |
+| [qt-wayland](https://repology.org/project/qt)                                    | Wayland support                                                                  |
 
 ### :material-nix: Nix(OS)
 
@@ -225,15 +225,15 @@ For audio/video thumbnails and playback you'll need [FFmpeg](https://ffmpeg.org/
 
 To generate thumbnails for RAR-based files (like `.cbr`) you'll need an extractor capable of handling them.
 
--   :material-penguin: On Linux you'll need to install either `unrar` (likely in you distro's non-free repository) or `unrar-free` from your package manager.
+- :material-penguin: On Linux you'll need to install either `unrar` (likely in you distro's non-free repository) or `unrar-free` from your package manager.
 
--   :fontawesome-brands-apple: On macOS `unrar` can be installed through Homebrew's [`rar`](https://formulae.brew.sh/cask/rar) formula.
+- :fontawesome-brands-apple: On macOS `unrar` can be installed through Homebrew's [`rar`](https://formulae.brew.sh/cask/rar) formula.
 
     <!-- prettier-ignore -->
     !!! warning ":fontawesome-brands-apple: macOS "Privacy & Security" Popup"
         On macOS, you may be met with a message similar to  "**"unrar" Not Opened. Apple could not verify "unrar" is free of malware that may harm your Mac or compromise your privacy**" If you encounter this, then you'll need to go to the "Settings" app, navigate to "Privacy & Security", and scroll down to a section that says "**"unrar" was blocked from use because it is not from an identified developer.**" Click the "Open Anyway" button to allow unrar to be used.
 
--   :fontawesome-brands-windows: On Windows you'll need to install either [`WinRAR`](https://www.rarlab.com/download.htm) or [`7-zip`](https://www.7-zip.org/) and add their folder to you `PATH`.
+- :fontawesome-brands-windows: On Windows you'll need to install either [`WinRAR`](https://www.rarlab.com/download.htm) or [`7-zip`](https://www.7-zip.org/) and add their folder to you `PATH`.
 
     <!-- prettier-ignore -->
     !!! tip "WinRAR License"

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,6 +1,7 @@
 ---
 icon: material/database
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 

--- a/docs/library-changes.md
+++ b/docs/library-changes.md
@@ -1,6 +1,7 @@
 ---
 icon: material/database-edit
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -1,6 +1,7 @@
 ---
 icon: material/script-text
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 

--- a/docs/preview-support.md
+++ b/docs/preview-support.md
@@ -1,6 +1,7 @@
 ---
 icon: material/image-check
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -81,7 +82,7 @@ Audio thumbnails will default to embedded cover art (if any) and fallback to gen
 Preview support for office documents or well-known project file formats varies by the format and whether or not embedded thumbnails are available to be read from. OpenDocument-based files are typically supported.
 
 | Filetype                             | Extensions            | Preview Type                                                               |
-|--------------------------------------| --------------------- | -------------------------------------------------------------------------- |
+| ------------------------------------ | --------------------- | -------------------------------------------------------------------------- |
 | Blender                              | `.blend`, `.blend<#>` | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
 | Clip Studio Paint                    | `.clip`               | Embedded thumbnail                                                         |
 | Keynote (Apple iWork)                | `.key`                | Embedded thumbnail                                                         |
@@ -103,7 +104,7 @@ Preview support for office documents or well-known project file formats varies b
 Archive thumbnails will display the first image from the archive within the Preview Panel.
 
 | Filetype | Extensions     |
-|----------|----------------|
+| -------- | -------------- |
 | 7-Zip    | `.7z`, `.s7z`  |
 | RAR      | `.rar`         |
 | Tar      | `.tar`, `.tgz` |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,7 @@
 ---
 icon: material/map-check
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -16,9 +17,9 @@ Planned features and changes are assigned **priority levels** to signify how imp
 
 <!-- prettier-ignore -->
 !!! info "Priority Level Icons"
-    -   :material-chevron-triple-up:{ .priority-high title="High Priority" } **High Priority** - Core features
-    -   :material-chevron-double-up:{ .priority-med title="Medium Priority" } **Medium Priority** - Important, but not necessary
-    -   :material-chevron-up:{ .priority-low title="Low Priority" } **Low Priority** - Just nice to have
+    - :material-chevron-triple-up:{ .priority-high title="High Priority" } **High Priority** - Core features
+    - :material-chevron-double-up:{ .priority-med title="Medium Priority" } **Medium Priority** - Important, but not necessary
+    - :material-chevron-up:{ .priority-low title="Low Priority" } **Low Priority** - Just nice to have
 
 ## Version Estimates
 
@@ -41,29 +42,29 @@ Must be finalized or deemed "feature complete" before other core features are de
 !!! note
     See the "[Library](#library)" section for features related to the library database rather than the underlying schema.
 
--   [x] A SQLite-based library save file format **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
--   [ ] Cached File Properties Table :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [x] Date Entry Added to Library :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Date File Created :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Date File Modified :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Date Photo Taken :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Media Duration :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Media Dimensions :material-chevron-double-up:{ .priority-med title="Medium Priority" }
-    -   [ ] Word Count :material-chevron-up:{ .priority-low title="Low Priority" }
+- [x] A SQLite-based library save file format **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+- [ ] Cached File Properties Table :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [x] Date Entry Added to Library :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Date File Created :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Date File Modified :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Date Photo Taken :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Media Duration :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Media Dimensions :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+    - [ ] Word Count :material-chevron-up:{ .priority-low title="Low Priority" }
 
 ### :material-database-cog: Core Library + API
 
 A separated, UI agnostic core library that would be used to interface with the TagStudio library format. Would host an API for communication from outside the program. This would be licensed under the more permissive [MIT](https://en.wikipedia.org/wiki/MIT_License) license to foster wider adoption compared to the TagStudio application source code.
 
--   [ ] Core Library :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
--   [ ] Core Library API :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
--   [ ] MIT License :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
+- [ ] Core Library :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
+- [ ] Core Library API :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
+- [ ] MIT License :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
 
 ### :material-clipboard-text: Format Specification
 
 A detailed written specification for the TagStudio tag and/or library format. Intended for used by third-parties to build alternative cores or protocols that can remain interoperable.
 
--   [ ] Format Specification Established :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
+- [ ] Format Specification Established :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
 
 ---
 
@@ -71,74 +72,74 @@ A detailed written specification for the TagStudio tag and/or library format. In
 
 ### :material-button-cursor: UI/UX
 
--   [x] Library Grid View
-    -   [ ] Explore Filesystem in Grid View :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Infinite Scrolling (No Pagination) :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [ ] Library List View :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Explore Filesystem in List View :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [ ] Lightbox View :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   Similar to List View in concept, but displays one large preview that can cycle back/forth between entries.
-    -   [ ] Smaller thumbnails of immediate adjacent entries below :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [x] Library Statistics Screen **[[v9.5.4](changelog.md#954-september-1st-2025)]**
--   [x] Unified Library Health/Cleanup Screen **[[v9.5.4](changelog.md#954-september-1st-2025)]**
-    -   [x] Fix Unlinked Entries
-    -   [x] Fix Duplicate Files
-    -   [x] ~~Fix Duplicate Entries~~
-    -   [x] Remove Ignored Entries **[[v9.5.4](changelog.md#954-september-1st-2025)]**
-    -   [x] Delete Old Backups **[[v9.5.4](changelog.md#954-september-1st-2025)]**
-    -   [x] Delete Legacy JSON File **[[v9.5.4](changelog.md#954-september-1st-2025)]**
--   [x] Translations
--   [ ] Search Bar Rework :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
-    -   [ ] Improved Tag Autocomplete :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Tags appear as widgets in search bar :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [x] Unified Media Player
-    -   [x] Auto-Hiding Player Controls
-    -   [x] Play/Pause
-    -   [x] Loop
-    -   [x] Toggle Autoplay
-    -   [x] Volume Control
-    -   [x] Toggle Mute
-    -   [x] Timeline scrubber
-    -   [ ] Fullscreen :material-chevron-double-up:{ .priority-med title="Medium Priority" }
-    -   [ ] Fine-Tuned UI/UX :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6]**
--   [ ] 3D Model Thumbnails/Previews :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] STL File Support
-    -   [ ] OBJ File Support
--   [ ] Plaintext Thumbnails/Previews :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [x] Basic Support
-    -   [ ] Full File Preview :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Syntax Highlighting :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [ ] Toggleable Persistent Tagging Panel :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Top Tags
-    -   [ ] Recent Tags
-    -   [ ] Tag Search
-    -   [ ] Pinned Tags
--   [ ] New Tabbed Tag Building UI to Support New Tag Features :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Custom Thumbnail Overrides :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [ ] Media Duration Labels :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Word/Line Count Labels :material-chevron-up:{ .priority-low title="Low Priority" }
--   [ ] Custom Tag Badges :material-chevron-up:{ .priority-low title="Low Priority" }
-    -   Would serve as an addition/alternative to the Favorite and Archived badges.
+- [x] Library Grid View
+    - [ ] Explore Filesystem in Grid View :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Infinite Scrolling (No Pagination) :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [ ] Library List View :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Explore Filesystem in List View :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [ ] Lightbox View :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - Similar to List View in concept, but displays one large preview that can cycle back/forth between entries.
+    - [ ] Smaller thumbnails of immediate adjacent entries below :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [x] Library Statistics Screen **[[v9.5.4](changelog.md#954-september-1st-2025)]**
+- [x] Unified Library Health/Cleanup Screen **[[v9.5.4](changelog.md#954-september-1st-2025)]**
+    - [x] Fix Unlinked Entries
+    - [x] Fix Duplicate Files
+    - [x] ~~Fix Duplicate Entries~~
+    - [x] Remove Ignored Entries **[[v9.5.4](changelog.md#954-september-1st-2025)]**
+    - [x] Delete Old Backups **[[v9.5.4](changelog.md#954-september-1st-2025)]**
+    - [x] Delete Legacy JSON File **[[v9.5.4](changelog.md#954-september-1st-2025)]**
+- [x] Translations
+- [ ] Search Bar Rework :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
+    - [ ] Improved Tag Autocomplete :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Tags appear as widgets in search bar :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [x] Unified Media Player
+    - [x] Auto-Hiding Player Controls
+    - [x] Play/Pause
+    - [x] Loop
+    - [x] Toggle Autoplay
+    - [x] Volume Control
+    - [x] Toggle Mute
+    - [x] Timeline scrubber
+    - [ ] Fullscreen :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+    - [ ] Fine-Tuned UI/UX :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6]**
+- [ ] 3D Model Thumbnails/Previews :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] STL File Support
+    - [ ] OBJ File Support
+- [ ] Plaintext Thumbnails/Previews :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [x] Basic Support
+    - [ ] Full File Preview :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Syntax Highlighting :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [ ] Toggleable Persistent Tagging Panel :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Top Tags
+    - [ ] Recent Tags
+    - [ ] Tag Search
+    - [ ] Pinned Tags
+- [ ] New Tabbed Tag Building UI to Support New Tag Features :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Custom Thumbnail Overrides :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [ ] Media Duration Labels :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Word/Line Count Labels :material-chevron-up:{ .priority-low title="Low Priority" }
+- [ ] Custom Tag Badges :material-chevron-up:{ .priority-low title="Low Priority" }
+    - Would serve as an addition/alternative to the Favorite and Archived badges.
 
 ### :material-cog: Settings
 
--   [x] Application Settings
-    -   [x] Stored in System User Folder/Designated Folder
-    -   [x] Language
-    -   [x] Date and Time Format
-    -   [x] Theme
-    -   [x] Thumbnail Generation **[[v9.5.4](changelog.md#954-september-1st-2025)]**
--   [x] Configurable Page Size
--   [ ] Library Settings :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Stored in `.TagStudio` folder :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [ ] Toggle File Extension Label :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [ ] Toggle Duration Label :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [x] Application Settings
+    - [x] Stored in System User Folder/Designated Folder
+    - [x] Language
+    - [x] Date and Time Format
+    - [x] Theme
+    - [x] Thumbnail Generation **[[v9.5.4](changelog.md#954-september-1st-2025)]**
+- [x] Configurable Page Size
+- [ ] Library Settings :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Stored in `.TagStudio` folder :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [ ] Toggle File Extension Label :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [ ] Toggle Duration Label :material-chevron-double-up:{ .priority-med title="Medium Priority" }
 
 ### :material-puzzle: Plugin Support
 
 Some form of official plugin support for TagStudio, likely with its own API that may connect to or encapsulate part of the the [core library API](#core-library-api).
 
--   [ ] Plugin Support :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
+- [ ] Plugin Support :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
 
 ---
 
@@ -146,140 +147,140 @@ Some form of official plugin support for TagStudio, likely with its own API that
 
 ### :material-wrench: Library Mechanics
 
--   [x] Per-Library Tags
--   [ ] Global Tags :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [ ] Multiple Root Directories :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] Ability to store TagStudio library folder separate from library files :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Automatic Entry Relinking :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
-    -   [ ] Detect Renames :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Detect Moves :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Detect Deletions :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Performant :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [ ] Background File Scanning :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
--   [x] Thumbnail Caching **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-    -   [ ] Audio Waveform Caching :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.7.x]**
+- [x] Per-Library Tags
+- [ ] Global Tags :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [ ] Multiple Root Directories :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] Ability to store TagStudio library folder separate from library files :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Automatic Entry Relinking :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
+    - [ ] Detect Renames :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Detect Moves :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Detect Deletions :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Performant :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [ ] Background File Scanning :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
+- [x] Thumbnail Caching **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+    - [ ] Audio Waveform Caching :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.7.x]**
 
 ### :material-grid: [Entries](entries.md)
 
 Library representations of files or file-like objects.
 
--   [x] File Entries **[v1.0.0]**
--   [ ] Folder Entries :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [ ] URL Entries / Bookmarks :material-chevron-up:{ .priority-low title="Low Priority" }
--   [x] Fields
-    -   [x] Text Lines
-    -   [x] Text Boxes
-    -   [x] Datetimes **[[v9.5.4](changelog.md#954-september-1st-2025)]**
-    -   [ ] User-Titled Fields :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-        -   [ ] Removal of Deprecated Fields :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Entry Groups :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
-    -   [ ] Non-exclusive; Entries can be in multiple groups :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Ability to number entries within group :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Ability to set sorting method for group :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Ability to set custom thumbnail for group :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Group is treated as entry with tags and metadata :material-chevron-double-up:{ .priority-med title="Medium Priority" }
-    -   [ ] Nested groups :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [x] File Entries **[v1.0.0]**
+- [ ] Folder Entries :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [ ] URL Entries / Bookmarks :material-chevron-up:{ .priority-low title="Low Priority" }
+- [x] Fields
+    - [x] Text Lines
+    - [x] Text Boxes
+    - [x] Datetimes **[[v9.5.4](changelog.md#954-september-1st-2025)]**
+    - [ ] User-Titled Fields :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+        - [ ] Removal of Deprecated Fields :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Entry Groups :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.7.x]**
+    - [ ] Non-exclusive; Entries can be in multiple groups :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Ability to number entries within group :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Ability to set sorting method for group :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Ability to set custom thumbnail for group :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Group is treated as entry with tags and metadata :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+    - [ ] Nested groups :material-chevron-double-up:{ .priority-med title="Medium Priority" }
 
 ### :material-tag-text: [Tags](tags.md)
 
 Discrete library objects representing [attributes](<https://en.wikipedia.org/wiki/Property_(philosophy)>). Can be applied to library [entries](entries.md), or applied to other tags to build traversable relationships.
 
--   [x] Tag Name **[v8.0.0]**
--   [x] Tag Shorthand Name **[v8.0.0]**
--   [x] Tag Aliases List **[v8.0.0]**
--   [x] Tag Color **[v8.0.0]**
--   [ ] Tag Description :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.6.x]**
--   [x] Tag Colors
-    -   [x] Built-in Color Palette **[v8.0.0]**
-    -   [x] User-Defined Colors **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-    -   [x] Primary and Secondary Colors **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
--   [ ] Tag Icons :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] Small Icons :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] Large Icons for Profiles :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.6.x]**
-    -   [ ] Built-in Icon Packs (i.e. Boxicons) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] User-Defined Icons :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [x] [Category Property](tags.md#is-category) **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-    -   [x] Property available for tags that allow the tag and any inheriting from it to be displayed separately in the preview panel under a title
-    -   [ ] Fine-tuned exclusion from categories :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Hidden Property :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] Built-in "Archived" tag has this property by default :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] Checkbox near search bar to show hidden tags in search :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Tag Relationships
-    -   [x] [Parent Tags](tags.md#parent-tags) ([Inheritance](<https://en.wikipedia.org/wiki/Inheritance_(object-oriented_programming)>) Relationship) **[v9.0.0]**
-    -   [ ] [Component Tags](tags.md#component-tags) ([Composition](https://en.wikipedia.org/wiki/Object_composition) Relationship) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Multiple Language Support :material-chevron-up:{ .priority-low title="Low Priority" } **[v9.9.x]**
--   [ ] Tag Overrides :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [ ] Tag Merging :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [x] Tag Name **[v8.0.0]**
+- [x] Tag Shorthand Name **[v8.0.0]**
+- [x] Tag Aliases List **[v8.0.0]**
+- [x] Tag Color **[v8.0.0]**
+- [ ] Tag Description :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.6.x]**
+- [x] Tag Colors
+    - [x] Built-in Color Palette **[v8.0.0]**
+    - [x] User-Defined Colors **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+    - [x] Primary and Secondary Colors **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+- [ ] Tag Icons :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] Small Icons :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] Large Icons for Profiles :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.6.x]**
+    - [ ] Built-in Icon Packs (i.e. Boxicons) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] User-Defined Icons :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [x] [Category Property](tags.md#is-category) **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+    - [x] Property available for tags that allow the tag and any inheriting from it to be displayed separately in the preview panel under a title
+    - [ ] Fine-tuned exclusion from categories :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Hidden Property :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] Built-in "Archived" tag has this property by default :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] Checkbox near search bar to show hidden tags in search :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Tag Relationships
+    - [x] [Parent Tags](tags.md#parent-tags) ([Inheritance](<https://en.wikipedia.org/wiki/Inheritance_(object-oriented_programming)>) Relationship) **[v9.0.0]**
+    - [ ] [Component Tags](tags.md#component-tags) ([Composition](https://en.wikipedia.org/wiki/Object_composition) Relationship) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Multiple Language Support :material-chevron-up:{ .priority-low title="Low Priority" } **[v9.9.x]**
+- [ ] Tag Overrides :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [ ] Tag Merging :material-chevron-double-up:{ .priority-med title="Medium Priority" }
 
 ### :material-magnify: [Search](search.md)
 
--   [x] Tag Search **[v8.0.0]**
--   [x] Filename Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-    -   [x] Glob Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
--   [x] Filetype Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-    -   [x] Search by Extension (e.g. ".jpg", ".png") **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-        -   [x] Optional consolidation of extension synonyms (i.e. ".jpg" can equal ".jpeg") **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-    -   [x] Search by media type (e.g. "image", "video", "document") **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
--   [ ] Field Content Search :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [x] [Boolean Operators](search.md) **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
-    -   [x] `AND` Operator
-    -   [x] `OR` Operator
-    -   [x] `NOT` Operator
-    -   [x] Parenthesis Grouping
-    -   [x] Character Escaping
--   [ ] `HAS` Operator (for [Component Tags](tags.md#component-tags)) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
--   [ ] Conditional Search :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.7.x]**
-    -   [ ] Compare Dates :material-chevron-double-up:{ .priority-med title="Medium Priority" }
-    -   [ ] Compare Durations :material-chevron-double-up:{ .priority-med title="Medium Priority" }
-    -   [ ] Compare File Sizes :material-chevron-double-up:{ .priority-med title="Medium Priority" }
-    -   [ ] Compare Dimensions :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [x] Smartcase Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
--   [ ] Search Result Sorting
-    -   [x] Sort by Filename **[[v9.5.2](changelog.md#952-march-31st-2025)]**
-    -   [x] Sort by Date Entry Added to Library **[[v9.5.2](changelog.md#952-march-31st-2025)]**
-    -   [ ] Sort by File Creation Date :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] Sort by File Modification Date :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [ ] Sort by File Modification Date :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Sort by Date Taken (Photos) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
-    -   [x] Random/Shuffle Sort
--   [ ] OCR Search :material-chevron-up:{ .priority-low title="Low Priority" }
--   [ ] Fuzzy Search :material-chevron-up:{ .priority-low title="Low Priority" }
+- [x] Tag Search **[v8.0.0]**
+- [x] Filename Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+    - [x] Glob Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+- [x] Filetype Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+    - [x] Search by Extension (e.g. ".jpg", ".png") **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+        - [x] Optional consolidation of extension synonyms (i.e. ".jpg" can equal ".jpeg") **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+    - [x] Search by media type (e.g. "image", "video", "document") **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+- [ ] Field Content Search :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [x] [Boolean Operators](search.md) **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+    - [x] `AND` Operator
+    - [x] `OR` Operator
+    - [x] `NOT` Operator
+    - [x] Parenthesis Grouping
+    - [x] Character Escaping
+- [ ] `HAS` Operator (for [Component Tags](tags.md#component-tags)) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+- [ ] Conditional Search :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.7.x]**
+    - [ ] Compare Dates :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+    - [ ] Compare Durations :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+    - [ ] Compare File Sizes :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+    - [ ] Compare Dimensions :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [x] Smartcase Search **[[v9.5.0](changelog.md#950-march-3rd-2025)]**
+- [ ] Search Result Sorting
+    - [x] Sort by Filename **[[v9.5.2](changelog.md#952-march-31st-2025)]**
+    - [x] Sort by Date Entry Added to Library **[[v9.5.2](changelog.md#952-march-31st-2025)]**
+    - [ ] Sort by File Creation Date :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] Sort by File Modification Date :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [ ] Sort by File Modification Date :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Sort by Date Taken (Photos) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.6.x]**
+    - [x] Random/Shuffle Sort
+- [ ] OCR Search :material-chevron-up:{ .priority-low title="Low Priority" }
+- [ ] Fuzzy Search :material-chevron-up:{ .priority-low title="Low Priority" }
 
 ### :material-file-cog: [Macros](macros.md)
 
--   [ ] Standard, Human Readable Format (TOML) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
--   [ ] Versioning System :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
--   [ ] Triggers **[v9.5.x]**
-    -   [ ] On File Added :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] On Library Refresh :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] [...]
--   [ ] Actions **[v9.5.x]**
-    -   [ ] Add Tag(s) :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Add Field(s) :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Set Field Content :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] [...]
+- [ ] Standard, Human Readable Format (TOML) :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
+- [ ] Versioning System :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
+- [ ] Triggers **[v9.5.x]**
+    - [ ] On File Added :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] On Library Refresh :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] [...]
+- [ ] Actions **[v9.5.x]**
+    - [ ] Add Tag(s) :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Add Field(s) :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Set Field Content :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] [...]
 
 ### :material-table-arrow-right: Sharable Data
 
 Sharable TagStudio library data in the form of data packs (tags, colors, etc.) or other formats.
 Packs are intended as an easy way to import and export specific data between libraries and users, while export-only formats are intended to be imported by other programs.
 
--   [ ] Color Packs :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
-    -   [ ] Importable
-    -   [ ] Exportable
-    -   [x] UUIDs + Namespaces :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [x] Standard, Human Readable Format (TOML) :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Versioning System :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [ ] Tag Packs :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.9.x]**
-    -   [ ] Importable :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Exportable :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] UUIDs + Namespaces :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Standard, Human Readable Format (TOML) :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Versioning System :material-chevron-double-up:{ .priority-med title="Medium Priority" }
--   [ ] Macro Sharing :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
-    -   [ ] Importable :material-chevron-triple-up:{ .priority-high title="High Priority" }
-    -   [ ] Exportable :material-chevron-triple-up:{ .priority-high title="High Priority" }
--   [ ] Sharable Entry Data :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.9.x]**
-    -   _Specifics of this are yet to be determined_
--   [ ] Export Library to Human Readable Format :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
-    -   Intended to give users more flexible options with their data if they wish to migrate away from TagStudio
+- [ ] Color Packs :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
+    - [ ] Importable
+    - [ ] Exportable
+    - [x] UUIDs + Namespaces :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [x] Standard, Human Readable Format (TOML) :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Versioning System :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [ ] Tag Packs :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.9.x]**
+    - [ ] Importable :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Exportable :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] UUIDs + Namespaces :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Standard, Human Readable Format (TOML) :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Versioning System :material-chevron-double-up:{ .priority-med title="Medium Priority" }
+- [ ] Macro Sharing :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v9.5.x]**
+    - [ ] Importable :material-chevron-triple-up:{ .priority-high title="High Priority" }
+    - [ ] Exportable :material-chevron-triple-up:{ .priority-high title="High Priority" }
+- [ ] Sharable Entry Data :material-chevron-double-up:{ .priority-med title="Medium Priority" } **[v9.9.x]**
+    - _Specifics of this are yet to be determined_
+- [ ] Export Library to Human Readable Format :material-chevron-triple-up:{ .priority-high title="High Priority" } **[v10.0.0]**
+    - Intended to give users more flexible options with their data if they wish to migrate away from TagStudio

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,6 +1,7 @@
 ---
 icon: material/magnify
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -50,13 +51,13 @@ Sometimes search queries have ambiguous characters and need to be "escaped". Thi
 
 #### Valid Escaped Tag Searches
 
--   "Tag Name With Spaces"
--   Tag_Name_With_Spaces
+- "Tag Name With Spaces"
+- Tag_Name_With_Spaces
 
 #### Invalid Escaped Tag Searches
 
--   Tag Name With Spaces
-    -   Reason: Ambiguity between a tag named "Tag Name With Spaces" and four individual tags called "Tag", "Name", "With", "Spaces".
+- Tag Name With Spaces
+    - Reason: Ambiguity between a tag named "Tag Name With Spaces" and four individual tags called "Tag", "Name", "With", "Spaces".
 
 ## Tags
 
@@ -86,31 +87,31 @@ Optionally, you may use [glob](<https://en.wikipedia.org/wiki/Glob_(programming)
 
 Given a file "Artwork/Piece.jpg", the following searches will return results for it:
 
--   `path: artwork/piece.jpg`
--   `path: Artwork/Piece.jpg`
--   `path: piece.jpg`
--   `path: Piece.jpg`
--   `path: artwork`
--   `path: rtwor`
--   `path: ece.jpg`
--   `path: iec`
--   `path: artwork/*`
--   `path: Artwork/*`
--   `path: *piece.jpg*`
--   `path: *Piece.jpg*`
--   `path: *artwork*`
--   `path: *Artwork*`
--   `path: *rtwor*`
--   `path: *ece.jpg*`
--   `path: *iec*`
--   `path: *.jpg`
+- `path: artwork/piece.jpg`
+- `path: Artwork/Piece.jpg`
+- `path: piece.jpg`
+- `path: Piece.jpg`
+- `path: artwork`
+- `path: rtwor`
+- `path: ece.jpg`
+- `path: iec`
+- `path: artwork/*`
+- `path: Artwork/*`
+- `path: *piece.jpg*`
+- `path: *Piece.jpg*`
+- `path: *artwork*`
+- `path: *Artwork*`
+- `path: *rtwor*`
+- `path: *ece.jpg*`
+- `path: *iec*`
+- `path: *.jpg`
 
 While the following searches will **NOT:**
 
--   `path: ARTWORK/Piece.jpg` _(Reason: Mismatched case)_
--   `path: *aRtWoRk/Piece*` _(Reason: Mismatched case)_
--   `path: PieCe.jpg` _(Reason: Mismatched case)_
--   `path: *PieCe.jpg*` _(Reason: Mismatched case)_
+- `path: ARTWORK/Piece.jpg` _(Reason: Mismatched case)_
+- `path: *aRtWoRk/Piece*` _(Reason: Mismatched case)_
+- `path: PieCe.jpg` _(Reason: Mismatched case)_
+- `path: *PieCe.jpg*` _(Reason: Mismatched case)_
 
 ## Special Searches
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,6 +1,7 @@
 ---
 icon: material/sign-text
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -10,20 +11,21 @@ icon: material/sign-text
 
 Most of the style guidelines can be checked, fixed, and enforced via Ruff. Older code may not be adhering to all of these guidelines, in which case _"do as I say, not as I do"..._
 
--   Do your best to write clear, concise, and modular code.
-    -   This should include making methods private by default (e.g. `__method()`)
-    -   Methods should only be protected (e.g. `_method()`) or public (e.g. `method()`) when needed and warranted
--   Keep a maximum column width of no more than **100** characters.
--   Code comments should be used to help describe sections of code that can't speak for themselves.
--   Use [Google style](https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings) docstrings for any classes and functions you add.
-    -   If you're modifying an existing function that does _not_ have docstrings, you don't _have_ to add docstrings to it... but it would be pretty cool if you did ;)
--   Imports should be ordered alphabetically.
--   Lists of values should be ordered using their [natural sort order](https://en.wikipedia.org/wiki/Natural_sort_order).
-    -   Some files have their methods ordered alphabetically as well (i.e. [`thumb_renderer`](https://github.com/TagStudioDev/TagStudio/blob/main/src/tagstudio/qt/widgets/thumb_renderer.py)). If you're working in a file and notice this, please try and keep to the pattern.
--   When writing text for window titles or form titles, use "[Title Case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)" capitalization. Your IDE may have a command to format this for you automatically, although some may incorrectly capitalize short prepositions. In a pinch you can use a website such as [capitalizemytitle.com](https://capitalizemytitle.com/) to check.
--   If it wasn't mentioned above, then stick to [**PEP-8**](https://peps.python.org/pep-0008/)!
+- Do your best to write clear, concise, and modular code.
+    - This should include making methods private by default (e.g. `__method()`)
+    - Methods should only be protected (e.g. `_method()`) or public (e.g. `method()`) when needed and warranted
+- Keep a maximum column width of no more than **100** characters.
+- Code comments should be used to help describe sections of code that can't speak for themselves.
+- Use [Google style](https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings) docstrings for any classes and functions you add.
+    - If you're modifying an existing function that does _not_ have docstrings, you don't _have_ to add docstrings to it... but it would be pretty cool if you did ;)
+- Imports should be ordered alphabetically.
+- Lists of values should be ordered using their [natural sort order](https://en.wikipedia.org/wiki/Natural_sort_order).
+    - Some files have their methods ordered alphabetically as well (i.e. [`thumb_renderer`](https://github.com/TagStudioDev/TagStudio/blob/main/src/tagstudio/qt/widgets/thumb_renderer.py)). If you're working in a file and notice this, please try and keep to the pattern.
+- When writing text for window titles or form titles, use "[Title Case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)" capitalization. Your IDE may have a command to format this for you automatically, although some may incorrectly capitalize short prepositions. In a pinch you can use a website such as [capitalizemytitle.com](https://capitalizemytitle.com/) to check.
+- If it wasn't mentioned above, then stick to [**PEP-8**](https://peps.python.org/pep-0008/)!
 
 ### Formatter Configs
+
 TagStudio provides an [EditorConfig](https://editorconfig.org/#example-file) file ([`.editorconfig`](../.editorconfig)) along with a [Prettier](https://prettier.io/) config file ([`.prettierrc.toml`](../.prettierrc.toml)) for formatting files other than .py files (Markdown, JSON, YAML, HTML, CSS, etc.). If editing these types of files it's recommended that you use a formatter that supports EditorConfig or has its settings matched to the EditorConfig and Prettier configs. Lastly, please pay attention to the `prettier-ignore` flags in present in some files if you are not using Prettier, as formatting these sections will break formatting used elsewhere such as the [MkDocs site](https://docs.tagstud.io/).
 
 ## Qt
@@ -85,14 +87,14 @@ class MyCoolWidget(MyCoolWidgetView):
 
 Observe the following key aspects of this example:
 
--   The Controller is just called `MyCoolWidget` instead of `MyCoolWidgetController` as it will be directly used by other code
--   The UI elements are in private variables
-    -   This enforces that the controller shouldn't directly access UI elements
-    -   Instead the view should provide a protected API (e.g. `_get_color()`) for things like setting/getting the value of a dropdown, etc.
-    -   Instead of `_get_color()` there could also be a `_color` method marked with `@property`
--   The callback methods are already defined as protected methods with NotImplementedErrors
-    -   Defines the interface the callbacks
-    -   Enforces that UI events be handled
+- The Controller is just called `MyCoolWidget` instead of `MyCoolWidgetController` as it will be directly used by other code
+- The UI elements are in private variables
+    - This enforces that the controller shouldn't directly access UI elements
+    - Instead the view should provide a protected API (e.g. `_get_color()`) for things like setting/getting the value of a dropdown, etc.
+    - Instead of `_get_color()` there could also be a `_color` method marked with `@property`
+- The callback methods are already defined as protected methods with NotImplementedErrors
+    - Defines the interface the callbacks
+    - Enforces that UI events be handled
 
 <!-- prettier-ignore -->
 !!! tip

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -62,11 +62,7 @@
 
 /* Mobile Nav Header */
 .md-nav__source {
-    background: linear-gradient(
-        60deg,
-        rgb(205, 78, 255) 0%,
-        rgb(116, 123, 255) 100%
-    );
+    background: linear-gradient(60deg, rgb(205, 78, 255) 0%, rgb(116, 123, 255) 100%);
     border-style: solid;
     border-width: 0 0 2px 0;
     border-color: #ffffff33;

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,6 +1,7 @@
 ---
 icon: material/tag-text
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -12,9 +13,9 @@ Tags are discrete objects that represent some attribute. This could be a person,
 
 TagStudio tags do not share the same naming limitations of many other tagging solutions. The key standouts of tag names in TagStudio are:
 
--   Tag names do **NOT** have to be unique
--   Tag names are **NOT** limited to specific characters
--   Tags can have **aliases**, a.k.a. alternate names to go by
+- Tag names do **NOT** have to be unique
+- Tag names are **NOT** limited to specific characters
+- Tags can have **aliases**, a.k.a. alternate names to go by
 
 ### Name
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,7 @@
 ---
 icon: material/mouse
 ---
+
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: GPL-3.0-only -->
 
@@ -36,14 +37,14 @@ Hover over the field and click the pencil icon. From there, add or edit text in 
 
 Create a new tag by accessing the "New Tag" option from the Edit menu or by pressing <kbd>Ctrl</kbd>+<kbd>T</kbd>. In the tag creation panel, enter a tag name, optional shorthand name, optional tag aliases, optional parent tags, and an optional color.
 
--   The tag **name** is the base name of the tag. **_This does NOT have to be unique!_**
--   The tag **shorthand** is a special type of alias that displays in situations where screen space is more valuable, notably with name disambiguation.
--   **Aliases** are alternate names for a tag. These let you search for terms other than the exact tag name in order to find the tag again.
--   **Parent Tags** are tags in which this tag can substitute for in searches. In other words, tags under this section are parents of this tag.
-    -   Parent tags with the disambiguation check next to them will be used to help disambiguate tag names that may not be unique.
-    -   For example: If you had a tag for "Freddy Fazbear", you might add "Five Nights at Freddy's" as one of the parent tags. If the disambiguation box is checked next to "Five Nights at Freddy's" parent tag, then the tag "Freddy Fazbear" will display as "Freddy Fazbear (Five Nights at Freddy's)". Furthermore, if the "Five Nights at Freddy's" tag has a shorthand like "FNAF", then the "Freddy Fazbear" tag will display as "Freddy Fazbear (FNAF)".
--   The **color** option lets you select an optional color palette to use for your tag.
--   The **"Is Category"** property lets you treat this tag as a category under which itself and any child tags inheriting from it will be sorted by inside the preview panel.
+- The tag **name** is the base name of the tag. **_This does NOT have to be unique!_**
+- The tag **shorthand** is a special type of alias that displays in situations where screen space is more valuable, notably with name disambiguation.
+- **Aliases** are alternate names for a tag. These let you search for terms other than the exact tag name in order to find the tag again.
+- **Parent Tags** are tags in which this tag can substitute for in searches. In other words, tags under this section are parents of this tag.
+    - Parent tags with the disambiguation check next to them will be used to help disambiguate tag names that may not be unique.
+    - For example: If you had a tag for "Freddy Fazbear", you might add "Five Nights at Freddy's" as one of the parent tags. If the disambiguation box is checked next to "Five Nights at Freddy's" parent tag, then the tag "Freddy Fazbear" will display as "Freddy Fazbear (Five Nights at Freddy's)". Furthermore, if the "Five Nights at Freddy's" tag has a shorthand like "FNAF", then the "Freddy Fazbear" tag will display as "Freddy Fazbear (FNAF)".
+- The **color** option lets you select an optional color palette to use for your tag.
+- The **"Is Category"** property lets you treat this tag as a category under which itself and any child tags inheriting from it will be sorted by inside the preview panel.
 
 ### Tag Manager
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: (c) TagStudio Contributors
 # SPDX-License-Identifier: GPL-3.0-only
 
-
 # yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
 
 # MkDocs: https://www.mkdocs.org/
@@ -37,9 +36,9 @@ nav:
       - install.md
       - usage.md
       - Developing:
-        - developing.md
-        - contributing.md
-        - style.md
+          - developing.md
+          - contributing.md
+          - style.md
       - Help:
           - help/ffmpeg.md
   - Using Libraries:
@@ -50,7 +49,7 @@ nav:
       - ignore.md
       - macros.md
       - Fields:
-        - fields.md
+          - fields.md
       - Tags:
           - tags.md
           - colors.md
@@ -58,7 +57,7 @@ nav:
       - changelog.md
       - roadmap.md
       - Schema History:
-        - library-changes.md
+          - library-changes.md
 
 theme:
   name: material
@@ -108,7 +107,6 @@ theme:
       upcoming: material/flask-outline
 
 markdown_extensions:
-
   # Python Markdown
   - abbr
   - admonition
@@ -152,8 +150,8 @@ markdown_extensions:
 plugins:
   - search
   - tags
-  - social:  # social embed cards
-      enabled: !ENV [CI, false]  # enabled only when running in CI (eg GitHub Actions)
+  - social: # social embed cards
+      enabled: !ENV [CI, false] # enabled only when running in CI (eg GitHub Actions)
   - redirects:
       redirect_maps:
         "develop.md": "developing.md"

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -2,14 +2,22 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: MIT -->
 
+
 <!-- Determine classes -->
-{% set class = "md-header" %} {% if "navigation.tabs.sticky" in features %} {% set class = class ~ "
-md-header--shadow md-header--lifted" %} {% elif "navigation.tabs" not in features %} {% set class =
-class ~ " md-header--shadow" %} {% endif %}
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
 
 <!-- Header -->
 <header class="{{ class }}" data-md-component="header">
-  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+  <nav
+    class="md-header__inner md-grid"
+    aria-label="{{ lang.t('header') }}"
+  >
+
     <!-- Link to home -->
     <a
       href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
@@ -23,8 +31,8 @@ class ~ " md-header--shadow" %} {% endif %}
 
     <!-- Button to open drawer -->
     <label class="md-header__button md-icon" for="__drawer">
-      {% set icon = config.theme.icon.menu or "material/menu" %} {% include ".icons/" ~ icon ~
-      ".svg" %}
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
     </label>
 
     <!-- Header title -->
@@ -32,12 +40,15 @@ class ~ " md-header--shadow" %} {% endif %}
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            <a style="font-weight: 900">Tag</a><a style="font-weight: 500"><i>Studio</i></a>
+            <a style="font-weight: 900;">Tag</a><a style="font-weight: 500;"><i>Studio</i></a>
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
           <span class="md-ellipsis">
-            {% if page.meta and page.meta.title %} {{ page.meta.title }} {% else %} {{ page.title }}
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
             {% endif %}
           </span>
         </div>
@@ -45,37 +56,50 @@ class ~ " md-header--shadow" %} {% endif %}
     </div>
 
     <!-- Color palette toggle -->
-    {% if config.theme.palette %} {% if not config.theme.palette is mapping %} {% include
-    "partials/palette.html" %} {% endif %} {% endif %}
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
 
     <!-- User preference: color palette -->
-    {% if not config.theme.palette is mapping %} {% include "partials/javascripts/palette.html" %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
     {% endif %}
 
     <!-- Site language selector -->
-    {% if config.extra.alternate %} {% include "partials/alternate.html" %} {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
 
     <!-- Button to open search modal -->
-    {% if "material/search" in config.plugins %} {% set search = config.plugins["material/search"] |
-    attr("config") %}
+    {% if "material/search" in config.plugins %}
+      {% set search = config.plugins["material/search"] | attr("config") %}
 
-    <!-- Check if search is actually enabled - see https://t.ly/DT_0V -->
-    {% if search.enabled %}
-    <label class="md-header__button md-icon" for="__search">
-      {% set icon = config.theme.icon.search or "material/magnify" %} {% include ".icons/" ~ icon ~
-      ".svg" %}
-    </label>
+      <!-- Check if search is actually enabled - see https://t.ly/DT_0V -->
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
 
-    <!-- Search interface -->
-    {% include "partials/search.html" %} {% endif %} {% endif %}
+        <!-- Search interface -->
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
 
     <!-- Repository information -->
     {% if config.repo_url %}
-    <div class="md-header__source">{% include "partials/source.html" %}</div>
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
     {% endif %}
   </nav>
 
   <!-- Navigation tabs (sticky) -->
-  {% if "navigation.tabs.sticky" in features %} {% if "navigation.tabs" in features %} {% include
-  "partials/tabs.html" %} {% endif %} {% endif %}
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
 </header>

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -2,22 +2,14 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: MIT -->
 
-
 <!-- Determine classes -->
-{% set class = "md-header" %}
-{% if "navigation.tabs.sticky" in features %}
-  {% set class = class ~ " md-header--shadow md-header--lifted" %}
-{% elif "navigation.tabs" not in features %}
-  {% set class = class ~ " md-header--shadow" %}
-{% endif %}
+{% set class = "md-header" %} {% if "navigation.tabs.sticky" in features %} {% set class = class ~ "
+md-header--shadow md-header--lifted" %} {% elif "navigation.tabs" not in features %} {% set class =
+class ~ " md-header--shadow" %} {% endif %}
 
 <!-- Header -->
 <header class="{{ class }}" data-md-component="header">
-  <nav
-    class="md-header__inner md-grid"
-    aria-label="{{ lang.t('header') }}"
-  >
-
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
     <!-- Link to home -->
     <a
       href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
@@ -31,8 +23,8 @@
 
     <!-- Button to open drawer -->
     <label class="md-header__button md-icon" for="__drawer">
-      {% set icon = config.theme.icon.menu or "material/menu" %}
-      {% include ".icons/" ~ icon ~ ".svg" %}
+      {% set icon = config.theme.icon.menu or "material/menu" %} {% include ".icons/" ~ icon ~
+      ".svg" %}
     </label>
 
     <!-- Header title -->
@@ -40,15 +32,12 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            <a style="font-weight: 900;">Tag</a><a style="font-weight: 500;"><i>Studio</i></a>
+            <a style="font-weight: 900">Tag</a><a style="font-weight: 500"><i>Studio</i></a>
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
           <span class="md-ellipsis">
-            {% if page.meta and page.meta.title %}
-              {{ page.meta.title }}
-            {% else %}
-              {{ page.title }}
+            {% if page.meta and page.meta.title %} {{ page.meta.title }} {% else %} {{ page.title }}
             {% endif %}
           </span>
         </div>
@@ -56,50 +45,37 @@
     </div>
 
     <!-- Color palette toggle -->
-    {% if config.theme.palette %}
-      {% if not config.theme.palette is mapping %}
-        {% include "partials/palette.html" %}
-      {% endif %}
-    {% endif %}
+    {% if config.theme.palette %} {% if not config.theme.palette is mapping %} {% include
+    "partials/palette.html" %} {% endif %} {% endif %}
 
     <!-- User preference: color palette -->
-    {% if not config.theme.palette is mapping %}
-      {% include "partials/javascripts/palette.html" %}
+    {% if not config.theme.palette is mapping %} {% include "partials/javascripts/palette.html" %}
     {% endif %}
 
     <!-- Site language selector -->
-    {% if config.extra.alternate %}
-      {% include "partials/alternate.html" %}
-    {% endif %}
+    {% if config.extra.alternate %} {% include "partials/alternate.html" %} {% endif %}
 
     <!-- Button to open search modal -->
-    {% if "material/search" in config.plugins %}
-      {% set search = config.plugins["material/search"] | attr("config") %}
+    {% if "material/search" in config.plugins %} {% set search = config.plugins["material/search"] |
+    attr("config") %}
 
-      <!-- Check if search is actually enabled - see https://t.ly/DT_0V -->
-      {% if search.enabled %}
-        <label class="md-header__button md-icon" for="__search">
-          {% set icon = config.theme.icon.search or "material/magnify" %}
-          {% include ".icons/" ~ icon ~ ".svg" %}
-        </label>
+    <!-- Check if search is actually enabled - see https://t.ly/DT_0V -->
+    {% if search.enabled %}
+    <label class="md-header__button md-icon" for="__search">
+      {% set icon = config.theme.icon.search or "material/magnify" %} {% include ".icons/" ~ icon ~
+      ".svg" %}
+    </label>
 
-        <!-- Search interface -->
-        {% include "partials/search.html" %}
-      {% endif %}
-    {% endif %}
+    <!-- Search interface -->
+    {% include "partials/search.html" %} {% endif %} {% endif %}
 
     <!-- Repository information -->
     {% if config.repo_url %}
-      <div class="md-header__source">
-        {% include "partials/source.html" %}
-      </div>
+    <div class="md-header__source">{% include "partials/source.html" %}</div>
     {% endif %}
   </nav>
 
   <!-- Navigation tabs (sticky) -->
-  {% if "navigation.tabs.sticky" in features %}
-    {% if "navigation.tabs" in features %}
-      {% include "partials/tabs.html" %}
-    {% endif %}
-  {% endif %}
+  {% if "navigation.tabs.sticky" in features %} {% if "navigation.tabs" in features %} {% include
+  "partials/tabs.html" %} {% endif %} {% endif %}
 </header>

--- a/overrides/partials/nav.html
+++ b/overrides/partials/nav.html
@@ -2,25 +2,15 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: MIT -->
 
-
 {% import "partials/nav-item.html" as item with context %}
 
 <!-- Determine classes -->
-{% set class = "md-nav md-nav--primary" %}
-{% if "navigation.tabs" in features %}
-  {% set class = class ~ " md-nav--lifted" %}
-{% endif %}
-{% if "toc.integrate" in features %}
-  {% set class = class ~ " md-nav--integrated" %}
-{% endif %}
+{% set class = "md-nav md-nav--primary" %} {% if "navigation.tabs" in features %} {% set class =
+class ~ " md-nav--lifted" %} {% endif %} {% if "toc.integrate" in features %} {% set class = class ~
+" md-nav--integrated" %} {% endif %}
 
 <!-- Navigation -->
-<nav
-  class="{{ class }}"
-  aria-label="{{ lang.t('nav') }}"
-  data-md-level="0"
->
-
+<nav class="{{ class }}" aria-label="{{ lang.t('nav') }}" data-md-level="0">
   <!-- Site title -->
   <!-- <label class="md-nav__title" for="__drawer">
     <a
@@ -37,16 +27,12 @@
 
   <!-- Repository information -->
   {% if config.repo_url %}
-    <div class="md-nav__source">
-      {% include "partials/source.html" %}
-    </div>
+  <div class="md-nav__source">{% include "partials/source.html" %}</div>
   {% endif %}
 
   <!-- Navigation list -->
   <ul class="md-nav__list" data-md-scrollfix>
-    {% for nav_item in nav %}
-      {% set path = "__nav_" ~ loop.index %}
-      {{ item.render(nav_item, path, 1) }}
-    {% endfor %}
+    {% for nav_item in nav %} {% set path = "__nav_" ~ loop.index %} {{ item.render(nav_item, path,
+    1) }} {% endfor %}
   </ul>
 </nav>

--- a/overrides/partials/nav.html
+++ b/overrides/partials/nav.html
@@ -2,15 +2,25 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: MIT -->
 
+
 {% import "partials/nav-item.html" as item with context %}
 
 <!-- Determine classes -->
-{% set class = "md-nav md-nav--primary" %} {% if "navigation.tabs" in features %} {% set class =
-class ~ " md-nav--lifted" %} {% endif %} {% if "toc.integrate" in features %} {% set class = class ~
-" md-nav--integrated" %} {% endif %}
+{% set class = "md-nav md-nav--primary" %}
+{% if "navigation.tabs" in features %}
+  {% set class = class ~ " md-nav--lifted" %}
+{% endif %}
+{% if "toc.integrate" in features %}
+  {% set class = class ~ " md-nav--integrated" %}
+{% endif %}
 
 <!-- Navigation -->
-<nav class="{{ class }}" aria-label="{{ lang.t('nav') }}" data-md-level="0">
+<nav
+  class="{{ class }}"
+  aria-label="{{ lang.t('nav') }}"
+  data-md-level="0"
+>
+
   <!-- Site title -->
   <!-- <label class="md-nav__title" for="__drawer">
     <a
@@ -27,12 +37,16 @@ class ~ " md-nav--lifted" %} {% endif %} {% if "toc.integrate" in features %} {%
 
   <!-- Repository information -->
   {% if config.repo_url %}
-  <div class="md-nav__source">{% include "partials/source.html" %}</div>
+    <div class="md-nav__source">
+      {% include "partials/source.html" %}
+    </div>
   {% endif %}
 
   <!-- Navigation list -->
   <ul class="md-nav__list" data-md-scrollfix>
-    {% for nav_item in nav %} {% set path = "__nav_" ~ loop.index %} {{ item.render(nav_item, path,
-    1) }} {% endfor %}
+    {% for nav_item in nav %}
+      {% set path = "__nav_" ~ loop.index %}
+      {{ item.render(nav_item, path, 1) }}
+    {% endfor %}
   </ul>
 </nav>

--- a/overrides/partials/toc-item.html
+++ b/overrides/partials/toc-item.html
@@ -2,25 +2,19 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: MIT -->
 
-
 <!-- Table of contents item -->
 <li class="md-nav__item">
-    <a href="{{ toc_item.url }}" class="md-nav__link">
-      <span class="md-ellipsis">
-        {{ toc_item.title }}
-      </span>
-    </a>
+  <a href="{{ toc_item.url }}" class="md-nav__link">
+    <span class="md-ellipsis"> {{ toc_item.title }} </span>
+  </a>
 
-    <!-- Table of contents list -->
-    {% if toc_item.children %}
-      <nav class="md-nav" aria-label="{{ toc_item.title | striptags | e }}">
-        <ul class="md-nav__list">
-          {% for toc_item in toc_item.children %}
-          {% if not page.meta.toc_depth or toc_item.level <= page.meta.toc_depth %}
-            {% include "partials/toc-item.html" %}
-          {% endif %}
-          {% endfor %}
-        </ul>
-      </nav>
-    {% endif %}
-  </li>
+  <!-- Table of contents list -->
+  {% if toc_item.children %}
+  <nav class="md-nav" aria-label="{{ toc_item.title | striptags | e }}">
+    <ul class="md-nav__list">
+      {% for toc_item in toc_item.children %} {% if not page.meta.toc_depth or toc_item.level <=
+      page.meta.toc_depth %} {% include "partials/toc-item.html" %} {% endif %} {% endfor %}
+    </ul>
+  </nav>
+  {% endif %}
+</li>

--- a/overrides/partials/toc-item.html
+++ b/overrides/partials/toc-item.html
@@ -2,19 +2,25 @@
 <!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
 <!-- SPDX-License-Identifier: MIT -->
 
+
 <!-- Table of contents item -->
 <li class="md-nav__item">
-  <a href="{{ toc_item.url }}" class="md-nav__link">
-    <span class="md-ellipsis"> {{ toc_item.title }} </span>
-  </a>
+    <a href="{{ toc_item.url }}" class="md-nav__link">
+      <span class="md-ellipsis">
+        {{ toc_item.title }}
+      </span>
+    </a>
 
-  <!-- Table of contents list -->
-  {% if toc_item.children %}
-  <nav class="md-nav" aria-label="{{ toc_item.title | striptags | e }}">
-    <ul class="md-nav__list">
-      {% for toc_item in toc_item.children %} {% if not page.meta.toc_depth or toc_item.level <=
-      page.meta.toc_depth %} {% include "partials/toc-item.html" %} {% endif %} {% endfor %}
-    </ul>
-  </nav>
-  {% endif %}
-</li>
+    <!-- Table of contents list -->
+    {% if toc_item.children %}
+      <nav class="md-nav" aria-label="{{ toc_item.title | striptags | e }}">
+        <ul class="md-nav__list">
+          {% for toc_item in toc_item.children %}
+          {% if not page.meta.toc_depth or toc_item.level <= page.meta.toc_depth %}
+            {% include "partials/toc-item.html" %}
+          {% endif %}
+          {% endfor %}
+        </ul>
+      </nav>
+    {% endif %}
+  </li>

--- a/tests/fixtures/sidecar_newgrounds.json
+++ b/tests/fixtures/sidecar_newgrounds.json
@@ -1,8 +1,5 @@
 {
-    "tags": [
-        "ng_tag",
-        "ng_tag2"
-    ],
+    "tags": ["ng_tag", "ng_tag2"],
     "date": "2024-01-02",
     "description": "NG description",
     "user": "NG artist",


### PR DESCRIPTION
### Summary

Followup to #1362 that applies the formalized formatting rules across all applicable files.
The most drastic change is the way that lists are formatted, however I'm not sure if that's because of the new rules specifically or because my formatter appears to have been wonky the past few months.

After this PR is pulled, I'll add the commit number to the `.git-blame-ignore-revs` file.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [x] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [x] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    -   [x] MkDocs Site inspection
    <!-- If other important criteria was tested for, please add it here -->