### PR TITLE
feat: allow all raster images to be used as archive thumbnails.

### DIFF
--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -949,9 +949,10 @@ class ThumbRenderer(QObject):
         if cover is not None:
             pages = [f for f in archive.namelist() if f != "ComicInfo.xml"]
             page_name = pages[int(unwrap(cover.get("Image")))]
-            if page_name.endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg")):
+            ext = ThumbRenderer.__suffix(page_name)
+            if MediaCategories.IMAGE_RASTER_TYPES.contains(ext):
                 image_data = archive.read(page_name)
-                im = Image.open(BytesIO(image_data))
+                im = ThumbRenderer.__load_raster_image(BytesIO(image_data))
 
         return im
 
@@ -1006,9 +1007,10 @@ class ThumbRenderer(QObject):
             Image: The first renderable image in the archive.
         """
         for file_name in archive.namelist():
-            if file_name.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg")):
+            ext = ThumbRenderer.__suffix(file_name)
+            if MediaCategories.IMAGE_RASTER_TYPES.contains(ext):
                 image_data = archive.read(file_name)
-                return Image.open(BytesIO(image_data))
+                return ThumbRenderer.__load_raster_image(BytesIO(image_data))
 
         return None
 
@@ -1172,14 +1174,8 @@ class ThumbRenderer(QObject):
         """
         im: Image.Image | None = None
         try:
-            im = Image.open(filepath)
-            if im.mode != "RGB" and im.mode != "RGBA":
-                im = im.convert(mode="RGBA")
-            if im.mode == "RGBA":
-                new_bg = Image.new("RGB", im.size, color="#1e1e1e")
-                new_bg.paste(im, mask=im.getchannel(3))
-                im = new_bg
-            im = unwrap(ImageOps.exif_transpose(im))
+            with filepath.open("rb") as file:
+                im = ThumbRenderer.__load_raster_image(BytesIO(file.read()))
         except (
             FileNotFoundError,
             UnidentifiedImageError,
@@ -1534,6 +1530,43 @@ class ThumbRenderer(QObject):
             logger.error("Couldn't render thumbnail", filepath=filepath, error=type(e).__name__)
 
         return im
+
+    @staticmethod
+    def __suffix(archive_path: str) -> str:
+        """Read the files' extension.
+
+        See pathlib.Path.suffix.
+
+        Args:
+            archive_path (str): The path of the file in the archive.
+
+        Returns:
+            str: The file extension.
+        """
+        i = archive_path.rfind(".")
+        if 0 < i < len(archive_path) - 1:
+            return archive_path[i:]
+        else:
+            return ""
+
+    @staticmethod
+    def __load_raster_image(image_data: BytesIO) -> Image.Image:
+        """Load a raster image and add a background if it's transparent.
+
+        Args:
+            image_data (BytesIO): The binary image data.
+
+        Returns:
+            Image.Image: The loaded raster image, with a background if needed.
+        """
+        im: Image.Image = Image.open(image_data)
+        if im.mode != "RGB" and im.mode != "RGBA":
+            im = im.convert(mode="RGBA")
+        if im.mode == "RGBA":
+            new_bg = Image.new("RGB", im.size, color="#1e1e1e")
+            new_bg.paste(im, mask=im.getchannel(3))
+            im = new_bg
+        return unwrap(ImageOps.exif_transpose(im))
 
     def render(
         self,


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
<!-- SPDX-License-Identifier: GPL-3.0-only -->

### Summary

Allow all (except `.exr`) raster images to be used as thumbnails for archive-based files.

Fixes https://github.com/TagStudioDev/TagStudio/issues/1364

I've left out `exr` images since they have to be handled separately from the other raster images and I suspect that they would be pretty rare in archives and especially in comic books.
If I'm wrong or if you think they're worth having I can add them.

#### Before
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/2e6beed4-2f64-4322-b9d1-1320be431a4b" />

#### After
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/f18aeb8c-236b-461c-8695-7a859866a607" />

#### Files used for testing
[samples.zip](https://github.com/user-attachments/files/27763020/samples.zip)

All shown files zipped because of upload limitations
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
