### PR TITLE
fix: match against the correct path in the ignore registry

### DIFF
--- a/src/tagstudio/core/library/alchemy/registries/ignored_registry.py
+++ b/src/tagstudio/core/library/alchemy/registries/ignored_registry.py
@@ -4,14 +4,12 @@
 
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from pathlib import Path
 
 import structlog
 
 from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.models import Entry
 from tagstudio.core.library.ignore import Ignore
-from tagstudio.core.utils.types import unwrap
 
 logger = structlog.get_logger(__name__)
 
@@ -35,13 +33,12 @@ class IgnoredRegistry:
         logger.info("[IgnoredRegistry] Refreshing ignored entries...")
 
         self.ignored_entries = []
-        library_dir: Path = unwrap(self.lib.library_dir)
 
         for i, entry in enumerate(self.lib.all_entries()):
             if not Ignore.compiled_patterns:
                 # If the compiled_patterns has malfunctioned, don't consider that a false positive
                 yield i
-            elif Ignore.compiled_patterns.match(library_dir / entry.path):
+            elif Ignore.compiled_patterns.match(entry.path):
                 self.ignored_entries.append(entry)
             yield i
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
<!-- SPDX-License-Identifier: GPL-3.0-only -->

### Summary

Fixes the "Ignore Entries" tool not correctly finding ignored entries.

This issue was caused by it matching against the path `{library_dir}/{entry_path}`, instead of just the entry path like is matched against elsewhere.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
