### PR TITLE
fix: prioritize exact tag shorthand matches

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -1273,11 +1273,20 @@ class Library:
                     )
                 )
 
-            tags = list(session.execute(query))
+            tags = [(tag_id, tag_name) for tag_id, tag_name in session.execute(query)]
 
             if name:
+                shorthand_query = select(Tag.id, Tag.shorthand).where(
+                    and_(Tag.shorthand.is_not(None), Tag.shorthand.icontains(name))
+                )
+                tags.extend(
+                    (tag_id, shorthand)
+                    for tag_id, shorthand in session.execute(shorthand_query)
+                    if shorthand is not None
+                )
+
                 query = select(TagAlias.tag_id, TagAlias.name).where(TagAlias.name.icontains(name))
-                tags.extend(session.execute(query))
+                tags.extend((tag_id, alias_name) for tag_id, alias_name in session.execute(query))
 
             tags.sort(key=lambda t: sort_key(t[1]))
             # Use order from Tag.name or TagAlias.name depending on which comes first for each tag.

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -135,6 +135,21 @@ def test_tag_search(library: Library):
     assert library.search_tags(tag.name * 2) == ([], [])
 
 
+def test_tag_search_exact_shorthand_takes_priority(generate_tag: Callable[..., Tag]):
+    with TemporaryDirectory() as tmp_dir_name:
+        library = Library()
+        status = library.open_library(Path(tmp_dir_name), in_memory=True)
+        assert status.success
+
+        blue = unwrap(library.add_tag(generate_tag("blue", shorthand="u")))
+        black = unwrap(library.add_tag(generate_tag("black", shorthand="b")))
+
+        direct_tags, _ = library.search_tags("b")
+
+        assert blue.id != black.id
+        assert direct_tags[0].id == black.id
+
+
 def test_get_entry(library: Library, entry_min: Entry):
     result = unwrap(library.get_entry_full(unwrap(entry_min.id)))
     assert len(result.tags) == 1


### PR DESCRIPTION
### Summary

Fixes #1381 by ranking exact tag shorthand matches ahead of longer tag-name prefix matches in tag search results.

This changes `Library.search_tags()` so shorthand text is considered when sorting match quality, and adds a regression test for the reported `blue` / `black` case where query `b` should rank the tag with shorthand `b` first.

### Tasks Completed

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM - targeted local test/lint
    - [ ] Linux x86
    - [ ] Linux ARM
      - GitHub Actions also passed pytest on Linux and Windows for this PR.
- Tested For:
    - [x] Basic functionality - targeted search ranking regression test
    - [ ] PyInstaller executable
      - Local: `.venv/bin/python -m pytest tests/test_library.py -q`
      - Local: `.venv/bin/ruff check src/tagstudio/core/library/alchemy/library.py tests/test_library.py`
      - CI: Ruff, Pyright, REUSE, pytest Linux, pytest Windows, coverage all passed.
