### PR TITLE
fix: render duplicate mirror modal values correctly

### DIFF
--- a/src/tagstudio/qt/mixed/mirror_entries_modal.py
+++ b/src/tagstudio/qt/mixed/mirror_entries_modal.py
@@ -67,13 +67,15 @@ class MirrorEntriesModal(QWidget):
         )
 
         self.model.clear()
-        for i in self.tracker.groups:
-            self.model.appendRow(QStandardItem(str(i)))
+        for entries in self.tracker.groups:
+            item = QStandardItem("\n".join(str(entry.path) for entry in entries))
+            item.setEditable(False)
+            self.model.appendRow(item)
 
     def mirror_entries(self):
         def displayed_text(x):
             return Translations.format(
-                "entries.mirror.label", idx=x + 1, count=self.tracker.groups_count
+                "entries.mirror.label", idx=x + 1, total=self.tracker.groups_count
             )
 
         pw = ProgressWidget(

--- a/tests/qt/test_mirror_entries_modal.py
+++ b/tests/qt/test_mirror_entries_modal.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
+from pathlib import Path
 from unittest.mock import Mock
 
 from pytestqt.qtbot import QtBot
@@ -9,6 +10,7 @@ from pytestqt.qtbot import QtBot
 from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.registries.dupe_files_registry import DupeFilesRegistry
 from tagstudio.qt.mixed.mirror_entries_modal import MirrorEntriesModal
+from tagstudio.qt.translations import Translations
 
 
 def _registry_with_groups(library: Library) -> DupeFilesRegistry:
@@ -24,7 +26,7 @@ def test_refresh_list_shows_entry_paths(qtbot: QtBot, library: Library) -> None:
     modal.refresh_list()
 
     item_text = modal.model.item(0).text()
-    assert item_text == "foo.txt\none/two/bar.md"
+    assert item_text == f"foo.txt\n{Path('one/two/bar.md')}"
     assert "Entry" not in item_text
 
 
@@ -51,4 +53,4 @@ def test_mirror_entries_progress_label_uses_group_count(
 
     modal.mirror_entries()
 
-    assert labels == ["Mirroring 1/1 Entries..."]
+    assert labels == [Translations.format("entries.mirror.label", idx=1, total=1)]

--- a/tests/qt/test_mirror_entries_modal.py
+++ b/tests/qt/test_mirror_entries_modal.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) TagStudio Contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+
+from unittest.mock import Mock
+
+from pytestqt.qtbot import QtBot
+
+from tagstudio.core.library.alchemy.library import Library
+from tagstudio.core.library.alchemy.registries.dupe_files_registry import DupeFilesRegistry
+from tagstudio.qt.mixed.mirror_entries_modal import MirrorEntriesModal
+
+
+def _registry_with_groups(library: Library) -> DupeFilesRegistry:
+    registry = DupeFilesRegistry(library=library)
+    registry.groups = [list(library.get_entries_full([1, 2]))]
+    return registry
+
+
+def test_refresh_list_shows_entry_paths(qtbot: QtBot, library: Library) -> None:
+    modal = MirrorEntriesModal(Mock(), _registry_with_groups(library))
+    qtbot.addWidget(modal)
+
+    modal.refresh_list()
+
+    item_text = modal.model.item(0).text()
+    assert item_text == "foo.txt\none/two/bar.md"
+    assert "Entry" not in item_text
+
+
+def test_mirror_entries_progress_label_uses_group_count(
+    qtbot: QtBot, library: Library, monkeypatch
+) -> None:
+    labels: list[str] = []
+
+    class FakeProgressWidget:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        def setWindowTitle(self, title: str) -> None:  # noqa: N802
+            pass
+
+        def from_iterable_function(self, function, update_label_callback, *done_callbacks) -> None:
+            labels.append(update_label_callback(0))
+
+    monkeypatch.setattr(
+        "tagstudio.qt.mixed.mirror_entries_modal.ProgressWidget", FakeProgressWidget
+    )
+    modal = MirrorEntriesModal(Mock(selected=[]), _registry_with_groups(library))
+    qtbot.addWidget(modal)
+
+    modal.mirror_entries()
+
+    assert labels == ["Mirroring 1/1 Entries..."]


### PR DESCRIPTION
### Summary

Draft / waiting on latest CI.

Fixes #1331 by making the duplicate-entry mirror confirmation and progress text render stable, user-readable values.

The modal now lists duplicate entry paths instead of raw object representations, and the progress label receives the expected `total` value for translation formatting. The regression tests were updated to be portable across Windows path separators and translated CI locales.

### Tasks Completed

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM - targeted local test/lint
    - [ ] Linux x86
    - [ ] Linux ARM
      - GitHub Actions for the latest push are awaiting maintainer approval on the fork. Earlier CI failures were due to non-portable test expectations; the latest commit updates those tests.
- Tested For:
    - [x] Basic functionality - targeted duplicate mirror modal regression tests
    - [ ] PyInstaller executable
      - Local: `uv run --extra pytest python -m pytest tests/qt/test_mirror_entries_modal.py tests/macros/test_dupe_files.py -q`
      - Local: `uv run --extra ruff ruff check src/tagstudio/qt/mixed/mirror_entries_modal.py tests/qt/test_mirror_entries_modal.py`
      - Missing before marking ready again: latest GitHub Actions run or maintainer acceptance of the local targeted coverage.
