### PR TITLE
fix: support WebP thumbnails inside ZIP archives

### DIFF
--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -949,7 +949,9 @@ class ThumbRenderer(QObject):
         if cover is not None:
             pages = [f for f in archive.namelist() if f != "ComicInfo.xml"]
             page_name = pages[int(unwrap(cover.get("Image")))]
-            if page_name.endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg")):
+            if page_name.lower().endswith(
+                (".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", ".webp")
+            ):
                 image_data = archive.read(page_name)
                 im = Image.open(BytesIO(image_data))
 
@@ -1006,7 +1008,9 @@ class ThumbRenderer(QObject):
             Image: The first renderable image in the archive.
         """
         for file_name in archive.namelist():
-            if file_name.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg")):
+            if file_name.lower().endswith(
+                (".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", ".webp")
+            ):
                 image_data = archive.read(file_name)
                 return Image.open(BytesIO(image_data))
 

--- a/tests/qt/test_thumb_renderer.py
+++ b/tests/qt/test_thumb_renderer.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (c) TagStudio Contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile
+
+from PIL import Image
+
+from tagstudio.qt.previews.renderer import ThumbRenderer
+
+
+def _write_webp_archive(archive_path: Path) -> None:
+    image_data = BytesIO()
+    Image.new("RGB", (2, 2), "red").save(image_data, format="WEBP")
+
+    with ZipFile(archive_path, "w") as archive:
+        archive.writestr("cover.webp", image_data.getvalue())
+
+
+def test_archive_thumb_extracts_webp_image(tmp_path: Path):
+    archive_path = tmp_path / "webp_only.zip"
+    _write_webp_archive(archive_path)
+
+    thumbnail = ThumbRenderer._archive_thumb(archive_path, ".zip")
+
+    assert thumbnail is not None
+    assert thumbnail.size == (2, 2)
+
+
+def test_epub_cover_extracts_webp_image_from_cbz(tmp_path: Path):
+    archive_path = tmp_path / "webp_only.cbz"
+    _write_webp_archive(archive_path)
+
+    thumbnail = ThumbRenderer._epub_cover(archive_path, ".cbz")
+
+    assert thumbnail is not None
+    assert thumbnail.size == (2, 2)


### PR DESCRIPTION
### Summary

Fixes #1364 by allowing WebP images inside ZIP/CBZ archives to be used as thumbnails.

This adds `.webp` to the archive thumbnail image extension checks, makes the ComicInfo cover extension check case-insensitive, and adds ZIP/CBZ WebP regression tests.

### Tasks Completed

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM - targeted local test/lint
    - [ ] Linux x86
    - [ ] Linux ARM
      - GitHub Actions also passed pytest on Linux and Windows for this PR.
- Tested For:
    - [x] Basic functionality - targeted archive thumbnail regression tests
    - [ ] PyInstaller executable
      - Local: `uv run --extra pytest pytest tests/qt/test_thumb_renderer.py -q`
      - Local: `uv run --extra ruff ruff check src/tagstudio/qt/previews/renderer.py tests/qt/test_thumb_renderer.py`
      - Local: `uv run --extra ruff ruff format --check src/tagstudio/qt/previews/renderer.py tests/qt/test_thumb_renderer.py`
      - CI: Ruff, Pyright, REUSE, pytest Linux, pytest Windows, coverage all passed.
