### PR TITLE
fix: fall back when ripgrep refresh fails

### DIFF
--- a/src/tagstudio/core/library/refresh.py
+++ b/src/tagstudio/core/library/refresh.py
@@ -91,26 +91,28 @@ class RefreshTracker:
             with open(compiled_ignore_path, "w") as pattern_file:
                 pattern_file.write("\n".join(ignore_patterns))
 
-            result = silent_run(
-                " ".join(
+            try:
+                result = silent_run(
                     [
-                        "rg",
+                        rg_path,
                         "--files",
                         "--follow",
                         "--hidden",
                         "--ignore-file",
-                        f'"{str(compiled_ignore_path)}"',
-                    ]
-                ),
-                cwd=library_dir,
-                capture_output=True,
-                shell=True,
-                encoding="UTF-8",
-            )
-            compiled_ignore_path.unlink()
+                        str(compiled_ignore_path),
+                    ],
+                    cwd=library_dir,
+                    capture_output=True,
+                    encoding="UTF-8",
+                )
+            finally:
+                compiled_ignore_path.unlink()
 
             if result.stderr:
                 logger.error(result.stderr)
+
+            if result.returncode != 0:
+                return None
 
             return result.stdout.splitlines()  # pyright: ignore [reportReturnType]
 

--- a/tests/macros/test_refresh_dir.py
+++ b/tests/macros/test_refresh_dir.py
@@ -3,6 +3,7 @@
 
 
 from pathlib import Path
+from subprocess import CompletedProcess
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -48,3 +49,24 @@ def test_refresh_multi_byte_filenames(library: Library):
     assert Path("em–dash.txt") in registry.files_not_in_library
     assert Path("apostrophe’.txt") in registry.files_not_in_library
     assert Path("umlaute äöü.txt") in registry.files_not_in_library
+
+
+@pytest.mark.parametrize("library", [TemporaryDirectory()], indirect=True)
+def test_refresh_falls_back_when_ripgrep_fails(library: Library, monkeypatch: pytest.MonkeyPatch):
+    library_dir = unwrap(library.library_dir)
+    registry = RefreshTracker(library=library)
+    library.included_files.clear()
+    (library_dir / ".TagStudio").mkdir()
+    (library_dir / "new-file.txt").touch()
+
+    monkeypatch.setattr("tagstudio.core.library.refresh.shutil.which", lambda _: "rg")
+    monkeypatch.setattr(
+        "tagstudio.core.library.refresh.silent_run",
+        lambda *args, **kwargs: CompletedProcess(
+            args=args, returncode=1, stdout="", stderr="rg failed"
+        ),
+    )
+
+    list(registry.refresh_dir(library_dir))
+
+    assert Path("new-file.txt") in registry.files_not_in_library


### PR DESCRIPTION
### Summary

Fixes #1338 by making directory refresh call the detected `rg` executable directly and fall back to the internal scanner if ripgrep exits unsuccessfully.

The previous shell-string invocation could fail to use the detected ripgrep path correctly. This switches to an argument-list subprocess call, cleans up the generated ignore file in a `finally` block, and adds regression coverage for the ripgrep-failure fallback path.

### Tasks Completed

- Platforms Tested:
    - [x] Windows x86 - GitHub Actions pytest passed; not manually desktop-tested
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM - targeted local test/lint
    - [x] Linux x86 - GitHub Actions pytest passed
    - [ ] Linux ARM
- Tested For:
    - [x] Basic functionality - targeted refresh fallback regression test
    - [ ] PyInstaller executable
      - Local: `uv run --extra pytest python -m pytest tests/macros/test_refresh_dir.py -q`
      - Local: `uv run --extra ruff ruff check src/tagstudio/core/library/refresh.py tests/macros/test_refresh_dir.py`
      - CI: Ruff, Pyright, REUSE, pytest Linux, pytest Windows, coverage all passed.
      - I did not manually reproduce the original Windows desktop setup with ripgrep installed.
