### PR TITLE
chore(ci): bump ruff to 0.15.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pytest = [
     "pytest-qt==4.4.0",
     "syrupy==5.1.0",
 ]
-ruff = ["ruff==0.11.8"]
+ruff = ["ruff==0.15.17"]
 
 [project.gui-scripts]
 tagstudio = "tagstudio.main:main"

--- a/src/tagstudio/core/enums.py
+++ b/src/tagstudio/core/enums.py
@@ -5,14 +5,14 @@
 import enum
 
 
-class SettingItems(str, enum.Enum):
+class SettingItems(enum.StrEnum):
     """List of setting item names."""
 
     LAST_LIBRARY = "last_library"
     LIBS_LIST = "libs_list"
 
 
-class ShowFilepathOption(int, enum.Enum):
+class ShowFilepathOption(enum.IntEnum):
     """Values representing the options for the "show_filenames" setting."""
 
     SHOW_FULL_PATHS = 0
@@ -21,7 +21,7 @@ class ShowFilepathOption(int, enum.Enum):
     DEFAULT = SHOW_RELATIVE_PATHS
 
 
-class TagClickActionOption(int, enum.Enum):
+class TagClickActionOption(enum.IntEnum):
     """Values representing the options for the "tag_click_action" setting."""
 
     OPEN_EDIT = 0
@@ -30,7 +30,7 @@ class TagClickActionOption(int, enum.Enum):
     DEFAULT = OPEN_EDIT
 
 
-class Theme(str, enum.Enum):
+class Theme(enum.StrEnum):
     COLOR_BG_DARK = "#65000000"
     COLOR_BG_LIGHT = "#22000000"
     COLOR_DARK_LABEL = "#DD000000"
@@ -49,7 +49,7 @@ class OpenStatus(enum.IntEnum):
     CORRUPTED = 2
 
 
-class MacroID(enum.Enum):
+class MacroID(enum.StrEnum):
     AUTOFILL = "autofill"
     SIDECAR = "sidecar"
     BUILD_URL = "build_url"

--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
+import enum
 import mimetypes
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 
 import structlog
@@ -23,7 +23,7 @@ FILETYPE_EQUIVALENTS = [
 ]
 
 
-class MediaType(str, Enum):
+class MediaType(enum.StrEnum):
     """Names of media types."""
 
     ADOBE_PHOTOSHOP = "adobe_photoshop"

--- a/src/tagstudio/core/query_lang/ast.py
+++ b/src/tagstudio/core/query_lang/ast.py
@@ -24,7 +24,7 @@ class ConstraintType(Enum):
             "filetype": ConstraintType.FileType,
             "path": ConstraintType.Path,
             "special": ConstraintType.Special,
-        }.get(text.lower(), None)
+        }.get(text.lower())
 
 
 class AST:

--- a/src/tagstudio/core/utils/types.py
+++ b/src/tagstudio/core/utils/types.py
@@ -2,12 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
-from typing import TypeVar
-
-T = TypeVar("T")
-
-
-def unwrap(optional: T | None, default: T | None = None) -> T:
+def unwrap[T](optional: T | None, default: T | None = None) -> T:
     if optional is not None:
         return optional
     if default is not None:

--- a/src/tagstudio/qt/mixed/field_containers.py
+++ b/src/tagstudio/qt/mixed/field_containers.py
@@ -447,7 +447,7 @@ class FieldContainers(QWidget):
             inner_widget.set_tags(tags)
 
             inner_widget.on_update.connect(
-                lambda: (self.update_from_entry(self.cached_entries[0].id, update_badges=True))
+                lambda: self.update_from_entry(self.cached_entries[0].id, update_badges=True)
             )
         else:
             text = "<i>Mixed Data</i>"

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -366,8 +366,8 @@ class QtDriver(DriverMixin, QObject):
         self.tag_manager_panel = PanelModal(
             widget=TagDatabasePanel(self, self.lib),
             title=Translations["tag_manager.title"],
-            done_callback=lambda checked=False: (
-                self.main_window.preview_panel.set_selection(self.selected, update_preview=False)
+            done_callback=lambda checked=False: self.main_window.preview_panel.set_selection(
+                self.selected, update_preview=False
             ),
             has_save=False,
         )


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: (c) TagStudio Contributors -->
<!-- SPDX-License-Identifier: GPL-3.0-only -->

### Summary

This PR bumps ruff to version 0.15.17 (latest as of writing) and makes the related changes to files affected by the updated rules.

Previously we were pinned to a pretty old version of ruff, so old to the point where I was getting strange interactions with the VS Code extension behaving strangely because it was differing to the old version inside the project. Suffice it to say that this should be bumped regardless. 

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
