### PR TITLE
fix: fix "search for tag" function in tag manager

### DIFF
--- a/src/tagstudio/qt/controllers/preview_panel_controller.py
+++ b/src/tagstudio/qt/controllers/preview_panel_controller.py
@@ -11,6 +11,7 @@ from tagstudio.core.library.alchemy.library import Library
 from tagstudio.qt.controllers.field_template_search_panel_controller import FieldTemplateSearchModal
 from tagstudio.qt.controllers.tag_search_panel_controller import TagSearchModal
 from tagstudio.qt.previews.vendored.ffmpeg import FFMPEG_CMD, FFPROBE_CMD
+from tagstudio.qt.translations import Translations
 from tagstudio.qt.views.preview_panel_view import PreviewPanelView
 
 if typing.TYPE_CHECKING:
@@ -22,7 +23,10 @@ class PreviewPanel(PreviewPanelView):
         super().__init__(library, driver)
 
         self.__add_field_modal = FieldTemplateSearchModal(self.lib, is_field_template_chooser=True)
-        self.__add_tag_modal = TagSearchModal(self.lib, is_tag_chooser=True)
+        self.__add_tag_modal = TagSearchModal(
+            self.lib, title=Translations["tag.add.plural"], is_tag_chooser=True
+        )
+        self.__add_tag_modal.tsp.set_driver(driver)
         self._thumb.check_ffmpeg.connect(self._toggle_ffmpeg_warning)
 
     @typing.override

--- a/src/tagstudio/qt/controllers/tag_search_panel_controller.py
+++ b/src/tagstudio/qt/controllers/tag_search_panel_controller.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
-from typing import TYPE_CHECKING, override
+from typing import override
 from warnings import catch_warnings
 
 import structlog
@@ -19,10 +19,6 @@ from tagstudio.qt.views.panel_modal import PanelModal, PanelWidget
 from tagstudio.qt.views.tag_search_panel_view import TagSearchPanelView
 
 logger = structlog.get_logger(__name__)
-
-# Only import for type checking/autocompletion, will not be imported at runtime.
-if TYPE_CHECKING:
-    pass
 
 
 class TagSearchModal(PanelModal):
@@ -176,10 +172,13 @@ class TagSearchPanel(SearchPanel[Tag]):
         # Connect search action
         if self._driver is not None:
             tag_widget.search_for_tag_action.triggered.connect(
-                lambda tag_id=item.id: self.search_for_tag(tag_id)
+                lambda checked=False, tag_id=item.id: self.search_for_tag(tag_id)
             )
             tag_widget.search_for_tag_action.setEnabled(True)
         else:
+            logger.warning(
+                "[TagSearchPanel] No driver was set for this TagSearchPanel. Was this on purpose?"
+            )
             tag_widget.search_for_tag_action.setEnabled(False)
 
     @override

--- a/src/tagstudio/qt/controllers/tag_search_panel_controller.py
+++ b/src/tagstudio/qt/controllers/tag_search_panel_controller.py
@@ -27,6 +27,7 @@ class TagSearchModal(PanelModal):
     def __init__(
         self,
         library: Library,
+        title: str,
         exclude: list[int] | None = None,
         is_tag_chooser: bool = True,
         has_save: bool = False,
@@ -38,8 +39,8 @@ class TagSearchModal(PanelModal):
             view=TagSearchPanelView(is_tag_chooser),
         )
         super().__init__(
-            self.tsp,
-            Translations["tag.add.plural"],
+            widget=self.tsp,
+            title=title,
             is_savable=has_save,
         )
 

--- a/src/tagstudio/qt/mixed/build_tag.py
+++ b/src/tagstudio/qt/mixed/build_tag.py
@@ -176,7 +176,9 @@ class BuildTagPanel(PanelWidget):
         if tag is not None:
             exclude_ids.append(tag.id)
 
-        self.add_tag_modal = TagSearchModal(self.lib, exclude_ids)
+        self.add_tag_modal = TagSearchModal(
+            self.lib, title=Translations["tag.add.plural"], exclude=exclude_ids
+        )
         self.add_tag_modal.tsp.item_chosen.connect(lambda x: self._add_parent_tag_callback(x))
         self.parent_tags_add_button.clicked.connect(self.add_tag_modal.show)
 

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -59,7 +59,7 @@ from tagstudio.qt.controllers.field_template_search_panel_controller import Fiel
 from tagstudio.qt.controllers.fix_ignored_modal_controller import FixIgnoredEntriesModal
 from tagstudio.qt.controllers.ignore_modal_controller import IgnoreModal
 from tagstudio.qt.controllers.library_info_window_controller import LibraryInfoWindow
-from tagstudio.qt.controllers.tag_search_panel_controller import TagSearchModal, TagSearchPanel
+from tagstudio.qt.controllers.tag_search_panel_controller import TagSearchModal
 from tagstudio.qt.controllers.update_available_message_box import UpdateAvailableMessageBox
 from tagstudio.qt.global_settings import DEFAULT_GLOBAL_SETTINGS_PATH, GlobalSettings, Theme
 from tagstudio.qt.mixed.about_modal import AboutModal
@@ -85,7 +85,6 @@ from tagstudio.qt.views.main_window import MainWindow
 from tagstudio.qt.views.panel_modal import PanelModal
 from tagstudio.qt.views.splash import SplashScreen
 from tagstudio.qt.views.stylesheets.stylesheets import header
-from tagstudio.qt.views.tag_search_panel_view import TagSearchPanelView
 
 BADGE_TAGS = {
     BadgeType.FAVORITE: TAG_FAVORITE,
@@ -352,15 +351,10 @@ class QtDriver(DriverMixin, QObject):
                 self.app.setDesktopFileName("tagstudio")
 
         # Initialize the Tag Manager panel
-        self.tag_manager_panel = PanelModal(
-            widget=TagSearchPanel(
-                self.lib,
-                is_tag_chooser=False,
-                view=TagSearchPanelView(is_tag_chooser=False),
-            ),
-            title=Translations["tag_manager.title"],
-            is_savable=False,
-        )
+        self.tag_manager_panel = TagSearchModal(self.lib, is_tag_chooser=False)
+        self.tag_manager_panel.title_widget.setText(Translations["tag_manager.title"])
+        self.tag_manager_panel.tsp.set_driver(self)
+
         self.tag_manager_panel.done.connect(
             lambda checked=False: self.main_window.preview_panel.set_selection(
                 self.selected, update_preview=False
@@ -386,7 +380,7 @@ class QtDriver(DriverMixin, QObject):
             )
         )
 
-        # Initialize the Tag Search panel
+        # Initialize the "Add Tag" panel
         self.add_tag_modal = TagSearchModal(self.lib, is_tag_chooser=True)
         self.add_tag_modal.tsp.set_driver(self)
         self.add_tag_modal.tsp.item_chosen.connect(

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -351,8 +351,11 @@ class QtDriver(DriverMixin, QObject):
                 self.app.setDesktopFileName("tagstudio")
 
         # Initialize the Tag Manager panel
-        self.tag_manager_panel = TagSearchModal(self.lib, is_tag_chooser=False)
-        self.tag_manager_panel.title_widget.setText(Translations["tag_manager.title"])
+        self.tag_manager_panel = TagSearchModal(
+            self.lib,
+            title=Translations["tag_manager.title"],
+            is_tag_chooser=False,
+        )
         self.tag_manager_panel.tsp.set_driver(self)
 
         self.tag_manager_panel.done.connect(
@@ -381,7 +384,9 @@ class QtDriver(DriverMixin, QObject):
         )
 
         # Initialize the "Add Tag" panel
-        self.add_tag_modal = TagSearchModal(self.lib, is_tag_chooser=True)
+        self.add_tag_modal = TagSearchModal(
+            self.lib, title=Translations["tag.add.plural"], is_tag_chooser=True
+        )
         self.add_tag_modal.tsp.set_driver(self)
         self.add_tag_modal.tsp.item_chosen.connect(
             lambda chosen_tag: (
@@ -853,7 +858,7 @@ class QtDriver(DriverMixin, QObject):
         self.modal = PanelModal(
             panel,
             Translations["tag.new"],
-            Translations["tag.add"],
+            Translations["tag.create"],
             is_savable=True,
         )
 


### PR DESCRIPTION
### Summary
Fixes #1404 by setting the driver reference for the tag manager.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
