### PR TITLE
fix: make tagstudio python package executable

### DIFF
--- a/src/tagstudio/__main__.py
+++ b/src/tagstudio/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tagstudio/__main__.py
+++ b/src/tagstudio/__main__.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) TagStudio Contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+
 from .main import main
 
 if __name__ == "__main__":

--- a/src/tagstudio/__main__.py
+++ b/src/tagstudio/__main__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
-from .main import main
+from tagstudio.main import main
 
 if __name__ == "__main__":
     main()

--- a/src/tagstudio/main.py
+++ b/src/tagstudio/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: (c) TagStudio Contributors
 # SPDX-License-Identifier: GPL-3.0-only
 


### PR DESCRIPTION
### Summary

Originally proposed in #912, but the author closed it.
So I reimplemented it here since I don't know whether they want their changes to be used.
Allows using `python -m tagstudio` to launch tagstudio.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
