### PR TITLE
fix(nix): add pyright to devshell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: (c) TagStudio Contributors
 # SPDX-License-Identifier: GPL-3.0-only
 
-
 {
   lib,
   pkgs,
@@ -78,10 +77,10 @@ pkgs.mkShellNoCC {
     coreutils
     uv
 
+    pyright
     ruff
   ];
   buildInputs = [
-    pkgs.pyright
     python3Wrapped
   ]
   ++ (with pkgs; [

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -81,6 +81,7 @@ pkgs.mkShellNoCC {
     ruff
   ];
   buildInputs = [
+    pkgs.pyright
     python3Wrapped
   ]
   ++ (with pkgs; [


### PR DESCRIPTION
### Summary

If you don't have pyright installed on the system, the commit hook in the dev shell will fail.
This PR adds pyright to the devshell to fix that issue.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
