### PR TITLE
feat: on click edit tag

### DIFF
--- a/src/tagstudio/qt/controllers/tag_search_panel_controller.py
+++ b/src/tagstudio/qt/controllers/tag_search_panel_controller.py
@@ -169,9 +169,14 @@ class TagSearchPanel(SearchPanel[Tag]):
         # Connect callbacks
         tag_widget.on_edit.connect(lambda edit_tag=item: self.on_item_edit(edit_tag))
         tag_widget.on_remove.connect(lambda remove_tag=item: self._on_item_remove(remove_tag))
-        tag_widget.bg_button.clicked.connect(
-            lambda checked=False, tag=item: self._on_item_chosen(tag)
-        )
+        if self.is_chooser:
+            tag_widget.bg_button.clicked.connect(
+                lambda checked=False, tag=item: self._on_item_chosen(tag)
+            )
+        else:
+            tag_widget.bg_button.clicked.connect(
+                lambda checked=False, edit_tag=item: self.on_item_edit(edit_tag)
+            )
 
         # Connect search action
         if self._driver is not None:


### PR DESCRIPTION
### Summary

Adds left click to open the tag editor in the Tag Manager panel as requested in #426. Unlike #987 the editor only opens when in the Tag Manager.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
