### PR TITLE
feat: render `.pxd` thumbnails.

### DIFF
--- a/docs/preview-support.md
+++ b/docs/preview-support.md
@@ -83,7 +83,7 @@ Audio thumbnails will default to embedded cover art (if any) and fallback to gen
 Preview support for office documents or well-known project file formats varies by the format and whether or not embedded thumbnails are available to be read from. OpenDocument-based files are typically supported.
 
 | Filetype                             | Extensions            | Preview Type                                                               |
-| ------------------------------------ | --------------------- | -------------------------------------------------------------------------- |
+|------------------------------------- |-----------------------|----------------------------------------------------------------------------|
 | Blender                              | `.blend`, `.blend<#>` | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
 | Clip Studio Paint                    | `.clip`               | Embedded thumbnail                                                         |
 | Keynote (Apple iWork)                | `.key`                | Embedded thumbnail                                                         |
@@ -98,6 +98,7 @@ Preview support for office documents or well-known project file formats varies b
 | Paint.NET                            | `.pdn`                | Embedded thumbnail                                                         |
 | PDF                                  | `.pdf`                | First page render                                                          |
 | Photoshop                            | `.psd`                | Flattened image render                                                     |
+| Pixelmator Pro (Apple iWork)         | `.pxd`                | Embedded thumbnail                                                         |
 | PowerPoint (Microsoft Office)        | `.pptx`, `.ppt`       | Embedded thumbnail :material-alert-circle:{ title="If available in file" } |
 
 ### :material-archive: Archives

--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -257,6 +257,7 @@ class MediaCategories:
         ".odt",
         ".pages",
         ".pdf",
+        ".pxd",
         ".rtf",
         ".tex",
         ".wpd",
@@ -336,7 +337,7 @@ class MediaCategories:
         ".webp",
     }
     _INSTALLER_SET: set[str] = {".appx", ".msi", ".msix"}
-    _IWORK_SET: set[str] = {".key", ".numbers", ".pages", ".pxd"}
+    _IWORK_SET: set[str] = {".key", ".numbers", ".pages"}
     _MATERIAL_SET: set[str] = {".mtl"}
     _MDIPACK_SET: set[str] = {".mdp"}
     _MODEL_SET: set[str] = {".3ds", ".fbx", ".obj", ".stl"}

--- a/src/tagstudio/core/media_types.py
+++ b/src/tagstudio/core/media_types.py
@@ -12,14 +12,14 @@ import structlog
 logger = structlog.get_logger(__name__)
 
 FILETYPE_EQUIVALENTS = [
-    set(["aif", "aiff", "aifc"]),
-    set(["html", "htm", "xhtml", "shtml", "dhtml"]),
-    set(["jfif", "jpeg_large", "jpeg", "jpg_large", "jpg"]),
-    set(["json", "jsonc", "json5"]),
-    set(["md", "markdown", "mkd", "rmd"]),
-    set(["tar.gz", "tgz"]),
-    set(["xml", "xul"]),
-    set(["yaml", "yml"]),
+    {"aif", "aiff", "aifc"},
+    {"html", "htm", "xhtml", "shtml", "dhtml"},
+    {"jfif", "jpeg_large", "jpeg", "jpg_large", "jpg"},
+    {"json", "jsonc", "json5"},
+    {"md", "markdown", "mkd", "rmd"},
+    {"tar.gz", "tgz"},
+    {"xml", "xul"},
+    {"yaml", "yml"},
 ]
 
 
@@ -75,7 +75,7 @@ class MediaCategory:
         extensions (set[str]): The set of file extensions associated with this category.
             Includes leading ".", all lowercase, and does not need to be unique to this category.
 
-        is_iana (bool): Represents whether or not this is an IANA registered category.
+        is_iana (bool): Represents whether this is an IANA registered category.
     """
 
     media_type: MediaType
@@ -336,7 +336,7 @@ class MediaCategories:
         ".webp",
     }
     _INSTALLER_SET: set[str] = {".appx", ".msi", ".msix"}
-    _IWORK_SET: set[str] = {".key", ".pages", ".numbers"}
+    _IWORK_SET: set[str] = {".key", ".numbers", ".pages", ".pxd"}
     _MATERIAL_SET: set[str] = {".mtl"}
     _MDIPACK_SET: set[str] = {".mdp"}
     _MODEL_SET: set[str] = {".3ds", ".fbx", ".obj", ".stl"}

--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -1218,8 +1218,8 @@ class ThumbRenderer(QObject):
         return im
 
     @staticmethod
-    def _iwork_thumb(filepath: Path) -> Image.Image | None:
-        """Render a thumbnail for an Apple iWork (Pages, Numbers, Keynote, Pixelmator) file.
+    def _apple_embedded_thumb(filepath: Path) -> Image.Image | None:
+        """Extract and render an apple embedded thumbnail (iWork, Apple Creative Studio).
 
         Args:
             filepath (Path): The path of the file.
@@ -1317,10 +1317,10 @@ class ThumbRenderer(QObject):
             page_size *= size / page_size.height()
         else:
             page_size *= size / page_size.width()
-        # Enlarge image for antialiasing
+        # Enlarge image for anti-aliasing
         scale_factor = 2.5
         page_size *= scale_factor
-        # Render image with no antialiasing for speed
+        # Render image with no anti-aliasing for speed
         render_options: QPdfDocumentRenderOptions = QPdfDocumentRenderOptions()
         render_options.setRenderFlags(
             QPdfDocumentRenderOptions.RenderFlag.TextAliased
@@ -1868,8 +1868,11 @@ class ThumbRenderer(QObject):
                 ):
                     image = self._open_doc_thumb(_filepath)
                 # Apple iWork Suite ============================================
-                elif MediaCategories.is_ext_in_category(ext, MediaCategories.IWORK_TYPES):
-                    image = self._iwork_thumb(_filepath)
+                elif (
+                    MediaCategories.is_ext_in_category(ext, MediaCategories.IWORK_TYPES)
+                    or ext == ".pxd"
+                ):
+                    image = self._apple_embedded_thumb(_filepath)
                 # Plain Text ===================================================
                 elif MediaCategories.is_ext_in_category(
                     ext, MediaCategories.PLAINTEXT_TYPES, mime_fallback=True

--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -623,7 +623,7 @@ class ThumbRenderer(QObject):
             image (Image.Image): The image to apply the edge to.
             edge (tuple[Image.Image, Image.Image]): The edge images to apply.
                 Item 0 is the inner highlight, and item 1 is the outer shadow.
-            faded (bool): Whether or not to apply a faded version of the edge.
+            faded (bool): Whether to apply a faded version of the edge.
                 Used for light themes.
         """
         opacity: float = 1.0 if not faded else 0.8
@@ -847,7 +847,7 @@ class ThumbRenderer(QObject):
 
     @staticmethod
     def _krita_thumb(filepath: Path) -> Image.Image | None:
-        """Extract and render a thumbnail for an Krita file.
+        """Extract and render a thumbnail for a Krita file.
 
         Args:
             filepath (Path): The path of the file.
@@ -1219,13 +1219,17 @@ class ThumbRenderer(QObject):
 
     @staticmethod
     def _iwork_thumb(filepath: Path) -> Image.Image | None:
-        """Extract and render a thumbnail for an Apple iWork (Pages, Numbers, Keynote) file.
+        """Render a thumbnail for an Apple iWork (Pages, Numbers, Keynote, Pixelmator) file.
 
         Args:
             filepath (Path): The path of the file.
         """
-        preview_thumb_dir = "preview.jpg"
-        quicklook_thumb_dir = "QuickLook/Thumbnail.jpg"
+        thumb_files: list[str] = [
+            "preview.jpg",
+            "QuickLook/Preview.heic",
+            "QuickLook/Thumbnail.jpg",
+            "QuickLook/Thumbnail.heic",
+        ]
         im: Image.Image | None = None
 
         def get_image(path: str) -> Image.Image | None:
@@ -1240,10 +1244,9 @@ class ThumbRenderer(QObject):
                 thumb: Image.Image | None = None
 
                 # Check if the file exists in the zip
-                if preview_thumb_dir in zip_file.namelist():
-                    thumb = get_image(preview_thumb_dir)
-                elif quicklook_thumb_dir in zip_file.namelist():
-                    thumb = get_image(quicklook_thumb_dir)
+                for thumb_file in thumb_files:
+                    if thumb_file in zip_file.namelist():
+                        thumb = get_image(thumb_file)
                 else:
                     logger.error("Couldn't render thumbnail", filepath=filepath)
 
@@ -1317,7 +1320,7 @@ class ThumbRenderer(QObject):
         # Enlarge image for antialiasing
         scale_factor = 2.5
         page_size *= scale_factor
-        # Render image with no anti-aliasing for speed
+        # Render image with no antialiasing for speed
         render_options: QPdfDocumentRenderOptions = QPdfDocumentRenderOptions()
         render_options.setRenderFlags(
             QPdfDocumentRenderOptions.RenderFlag.TextAliased

--- a/src/tagstudio/qt/previews/renderer.py
+++ b/src/tagstudio/qt/previews/renderer.py
@@ -1247,6 +1247,7 @@ class ThumbRenderer(QObject):
                 for thumb_file in thumb_files:
                     if thumb_file in zip_file.namelist():
                         thumb = get_image(thumb_file)
+                        break
                 else:
                     logger.error("Couldn't render thumbnail", filepath=filepath)
 


### PR DESCRIPTION
### Summary
Add support for rendering `.pxd` thumbnails.
Fixes https://github.com/TagStudioDev/TagStudio/issues/1409.

As mentioned in the issue, `.pxd` files store their thumbnails in the `QuickLook` folder, similar to the other iWork files, they just use `.heic` images instead of `.jpg`.
`Preview.heic` is checked before `Thumbnail.heic` since its resolution is a bit higher (2000x2000 instead of 1024x1024).

#### Before
<img width="1312" height="765" alt="before" src="https://github.com/user-attachments/assets/88b7141c-7e46-4587-991c-3b6b6c720a5c" />

#### After
<img width="1319" height="770" alt="after" src="https://github.com/user-attachments/assets/e8e8d1cb-65a2-4ab9-baf4-65575e2230b2" />

#### File used for testing
[sample.pxd.txt](https://github.com/user-attachments/files/29579857/sample.pxd.txt) from https://github.com/TagStudioDev/TagStudio/issues/1409.
<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
