### PR TITLE
fix(deps): replace optional dependencies with dependency groups

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system .[mkdocs]
+          uv pip install --system . --group mkdocs
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system .[pyright,pytest]
+          uv pip install --system . --group pyright --group pytest
 
       - name: Execute Pyright
         uses: jordemort/action-pyright@v1

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -26,7 +26,7 @@ jobs:
         name: Install Python dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system .[pytest]
+          uv pip install --system . --group pytest
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system .[pyinstaller]
+          uv pip install --system . --group pyinstaller
 
       - name: Execute PyInstaller
         run: |
@@ -76,7 +76,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system .[pyinstaller]
+          uv pip install --system . --group pyinstaller
 
       - name: Execute PyInstaller
         run: |
@@ -117,7 +117,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade uv
-          uv pip install --system .[pyinstaller]
+          uv pip install --system . --group pyinstaller
 
       - name: Execute PyInstaller
         run: |

--- a/contrib/.envrc-uv
+++ b/contrib/.envrc-uv
@@ -26,7 +26,7 @@ source "${venv}"/bin/activate
 
 if [ ! -f "${venv}"/pyproject.toml ] || ! diff --brief pyproject.toml "${venv}"/pyproject.toml >/dev/null; then
     printf '%s\n' 'Installing dependencies, pyproject.toml changed...' >&2
-    uv pip install --quiet --editable '.[dev]'
+    uv pip install --quiet --editable . --group all
     cp pyproject.toml "${venv}"/pyproject.toml
 fi
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -57,7 +57,7 @@ To install the required dependencies, you can use a dependency manager such as [
 If using [uv](https://docs.astral.sh/uv), you can install the dependencies for TagStudio with the following command:
 
 ```sh
-uv pip install -e ".[dev]"
+uv pip install -e . --group all
 ```
 
 TagStudio should now be runnable using the `tagstudio` command.
@@ -109,7 +109,7 @@ If you choose to manually set up a virtual environment and install dependencies 
 3.  Use the following PIP command to create an editable installation and install the required development dependencies:
 
     ```sh
-    pip install -e ".[dev]"
+    pip install -e . --group all
     ```
 
 4.  TagStudio should now be runnable using the `tagstudio` command.
@@ -161,7 +161,7 @@ The entry point for TagStudio is `src/tagstudio/main.py`. You can target this fi
 
 [Ruff](https://github.com/astral-sh/ruff) is a Python linter and code formatter that helps enforce a consistent formatting style across our codebase.
 
-Ruff is installed alongside the `pip install -e ".[dev]"` command, but is also available as a VS Code [extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff), PyCharm [plugin](https://plugins.jetbrains.com/plugin/20574-ruff), and [more](https://docs.astral.sh/ruff/integrations/).
+Ruff is installed alongside the `pip install -e . --group all` command, but is also available as a VS Code [extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff), PyCharm [plugin](https://plugins.jetbrains.com/plugin/20574-ruff), and [more](https://docs.astral.sh/ruff/integrations/).
 
 ```sh title="Lint Code"
 ruff check
@@ -180,7 +180,7 @@ Ruff should automatically discover the configuration options inside the [pyproje
 
 [Pyright](https://github.com/microsoft/pyright) is a static type checker for Python that helps enforce type strictness and prevent easy-to-miss errors across our codebase.
 
-Pyright is installed alongside the `pip install -e ".[dev]"` command, but is also available as VS Code extensions (see the [Pyright](https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright), [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), and [basedpyright](https://marketplace.visualstudio.com/items?itemName=detachhead.basedpyright) extensions), a PyCharm [setting](https://www.jetbrains.com/help/pycharm/lsp-tools.html#pyright), or in the form of forks such as [basedpyright](https://docs.basedpyright.com/latest/).
+Pyright is installed alongside the `pip install -e . --group all` command, but is also available as VS Code extensions (see the [Pyright](https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright), [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), and [basedpyright](https://marketplace.visualstudio.com/items?itemName=detachhead.basedpyright) extensions), a PyCharm [setting](https://www.jetbrains.com/help/pycharm/lsp-tools.html#pyright), or in the form of forks such as [basedpyright](https://docs.basedpyright.com/latest/).
 
 ```sh title="Run Checks"
 pyright
@@ -192,7 +192,7 @@ Pyright/basedpyright should automatically discover the configuration options ins
 
 [Pytest](https://github.com/pytest-dev/pytest) runs our Python code against the tests inside the [`tests/`](https://github.com/TagStudioDev/TagStudio/tree/main/tests) directory.
 
-Pytest is installed alongside the `pip install -e ".[dev]"` command.
+Pytest is installed alongside the `pip install -e . --group all` command.
 
 ```sh title="Run Tests"
 pytest tests/

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,7 +54,7 @@ pip install .
 !!! note "Developer Dependencies"
     If you wish to create an editable install with the additional dependencies required for developing TagStudio, use this modified PIP command instead:
     ```sh
-    pip install -e ".[dev]"
+    pip install -e . --group all
     ```
     _See more under "[Developing](developing.md)"_
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: (c) TagStudio Contributors
 # SPDX-License-Identifier: GPL-3.0-only
 
-
 {
   description = "TagStudio";
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -120,7 +120,7 @@ pkgs.mkShellNoCC {
 
       if [ ! -f "''${venv}"/pyproject.toml ] || ! diff --brief pyproject.toml "''${venv}"/pyproject.toml >/dev/null; then
           printf '%s\n' 'Installing dependencies, pyproject.toml changed...' >&2
-          uv pip install --quiet --editable '.[mkdocs,mypy,pre-commit,pytest]'
+          uv pip install --quiet --editable . --group docs --group extra --group test
           cp pyproject.toml "''${venv}"/pyproject.toml
       fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,28 @@ dependencies = [
     "semver~=3.0.4",
 ]
 
-[project.optional-dependencies]
-dev = ["tagstudio[mkdocs,pyright,pre-commit,pyinstaller,pytest,ruff]"]
+[project.gui-scripts]
+tagstudio = "tagstudio.main:main"
+
+[dependency-groups]
+all = [
+    { include-group = "check" },
+    { include-group = "build" },
+    { include-group = "docs" },
+    { include-group = "extra" },
+]
+check = [{ include-group = "lint" }, { include-group = "test" }]
+
+build = [{ include-group = "pyinstaller" }]
+docs = [{ include-group = "mkdocs" }]
+extra = [{ include-group = "pre-commit" }]
+lint = [{ include-group = "pyright" }, { include-group = "ruff" }]
+test = [{ include-group = "pytest" }]
+
 mkdocs = ["mkdocs-material[imaging]>=9.7", "mkdocs-redirects~=1.2"]
-pyright = ["pyright~=1.1.409"]
 pre-commit = ["pre-commit~=4.2"]
 pyinstaller = ["Pyinstaller~=6.21"]
+pyright = ["pyright~=1.1.409"]
 pytest = [
     "pytest==9.0.3",
     "pytest-cov==6.1.1",
@@ -57,12 +73,8 @@ pytest = [
 ]
 ruff = ["ruff==0.15.17"]
 
-[project.gui-scripts]
-tagstudio = "tagstudio.main:main"
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/tagstudio"]
-
 
 [tool.pytest.ini_options]
 qt_api = "pyside6"


### PR DESCRIPTION
### Summary

Definition: https://packaging.python.org/en/latest/specifications/dependency-groups

The optional dependency table (`[project.optional-dependencies]`) is supposed to be user-facing for installs of TagStudio. Meanwhile, the replacement dependency groups is explicitly meant for extra development tools, so lets use that.

This does mean the command for a full development environment has changed from:
```sh
pip install -e '.[dev]'
```

To:
```sh
pip install -e . --group all
```

The documentation has been adjusted for a quick replacement, but probably should have more information on a later time.

This does matter outside pedanticism by preparing for us to use optional dependencies for its intended use, notably some dependencies we rely on can and should be made optional (looking at you Valve Source). This also allows tools to be better grouped and inherited.

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
