### PR TITLE
fix: fix new aliases not saving on new tags

### DIFF
--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -1728,6 +1728,8 @@ class Library:
                     session.flush()
 
                 if aliases is not None:
+                    for a in aliases:
+                        a.tag_id = tag.id
                     self.update_aliases(tag, aliases, session)
                     session.flush()
 


### PR DESCRIPTION
### Summary

Fixes #1449 by setting the newly assigned tag ID to aliases before adding the aliases to the DB.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
