### PR TITLE
feat(ui): translate vertical scrolling to horizontal in suggest boxes

### DIFF
--- a/src/tagstudio/qt/controllers/horizontal_scroll_area.py
+++ b/src/tagstudio/qt/controllers/horizontal_scroll_area.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (c) TagStudio Contributors
+# SPDX-License-Identifier: GPL-3.0-only
+
+
+from typing import override
+
+import structlog
+from PySide6 import QtCore, QtGui
+from PySide6.QtWidgets import QScrollArea
+
+logger = structlog.get_logger(__name__)
+
+
+class HorizontalScrollArea(QScrollArea):
+    """A QScrollArea that translates vertical scrolling to horizontal movement."""
+
+    @override
+    def wheelEvent(self, arg__1: QtGui.QWheelEvent) -> None:
+        angle_y = arg__1.angleDelta().y()
+        pixel_y = arg__1.pixelDelta().y()
+        if angle_y != 0 or pixel_y != 0:
+            translated_event = QtGui.QWheelEvent(
+                arg__1.position(),
+                arg__1.globalPosition(),
+                QtCore.QPoint(pixel_y * -1, 0),
+                QtCore.QPoint(angle_y * -1, 0),
+                arg__1.buttons(),
+                arg__1.modifiers(),
+                arg__1.phase(),
+                arg__1.inverted(),
+            )
+            arg__1.accept()
+            return super().wheelEvent(translated_event)
+        else:
+            return super().wheelEvent(arg__1)

--- a/src/tagstudio/qt/views/suggest_box_view.py
+++ b/src/tagstudio/qt/views/suggest_box_view.py
@@ -4,9 +4,10 @@
 
 import structlog
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QFrame, QHBoxLayout, QScrollArea, QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QSizePolicy, QVBoxLayout, QWidget
 
 from tagstudio.qt.controllers.autofill_line_edit import AutofillLineEdit
+from tagstudio.qt.controllers.horizontal_scroll_area import HorizontalScrollArea
 from tagstudio.qt.views.stylesheets.stylesheets import (
     autofill_line_edit_style,
     autofill_scroll_top_style,
@@ -48,7 +49,7 @@ class SuggestBoxView(QVBoxLayout):
         scroll_area_container_layout.setContentsMargins(0, 0, 0, 0)
         scroll_area_container_layout.setSpacing(0)
         scroll_area_container.setStyleSheet(autofill_scroll_top_style("container"))
-        self.scroll_area = QScrollArea()
+        self.scroll_area = HorizontalScrollArea()
         self.scroll_area.setStyleSheet(scroll_area_style)
         scroll_area_container_layout.addWidget(self.scroll_area)
         self.scroll_area.setWidget(contents)


### PR DESCRIPTION
### Summary
Vertical scroll wheel input is now translated to horizontal movement for suggest boxes, so both methods can be used to scroll through the list of item suggestions.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
