### PR TITLE
fix(ui): fix accent color issues on Windows

### DIFF
--- a/src/tagstudio/qt/models/palette.py
+++ b/src/tagstudio/qt/models/palette.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
+import platform
 import traceback
 from enum import IntEnum
 from typing import Any
 
 import structlog
-from PySide6.QtGui import QPalette
+from PySide6.QtGui import QColor, QPalette
 
 from tagstudio.core.library.alchemy.enums import TagColorEnum
 from tagstudio.core.utils.singleton import Singleton
@@ -17,22 +18,26 @@ logger = structlog.get_logger(__name__)
 
 class Palette(metaclass=Singleton):
     _palette: QPalette | None = None
-    _accent: str | None = None
 
     @staticmethod
     def set_palette(palette: QPalette) -> None:
         Palette._palette = palette
 
     @staticmethod
-    def accent() -> str:
+    def accent() -> QColor:
+        # NOTE: As of PySide 6.8.0.1, the QPalette.ColorRole.Accent role no longer works on Windows.
+        # The QPalette.ColorRole.Highlight does for some reason, but is faded on macOS.
+
         if not Palette._palette:
             logger.error("[Style] No QPalette set!")
-            return get_ui_color(ColorType.PRIMARY, UiColor.BLUE)
-        if not Palette._accent:
-            Palette._accent = (
-                f"rgba{QPalette.color(Palette._palette, QPalette.ColorRole.Accent).toTuple()}"
-            )
-        return Palette._accent
+            return QColor.fromString(get_ui_color(ColorType.PRIMARY, UiColor.BLUE))
+        role = (
+            QPalette.ColorRole.Highlight
+            if platform.system() == "Windows"
+            else QPalette.ColorRole.Accent
+        )
+
+        return QPalette.color(Palette._palette, role)
 
 
 class ColorType(IntEnum):

--- a/src/tagstudio/qt/ts_qt.py
+++ b/src/tagstudio/qt/ts_qt.py
@@ -321,6 +321,13 @@ class QtDriver(DriverMixin, QObject):
             pal.setColor(
                 QPalette.ColorGroup.Inactive, QPalette.ColorRole.ButtonText, QColor("#666666")
             )
+        # BUG: PySide isn't properly setting the link colors on Windows, so this is a fallback.
+        if platform.system() == "Windows":
+            pal.setColor(
+                QPalette.ColorGroup.Normal,
+                QPalette.ColorRole.Link,
+                QColor.fromString(get_ui_color(ColorType.PRIMARY, UiColor.BLUE)),
+            )
         Palette.set_palette(pal)
         self.app.setPalette(pal)
 

--- a/src/tagstudio/qt/views/stylesheets/stylesheets.py
+++ b/src/tagstudio/qt/views/stylesheets/stylesheets.py
@@ -74,7 +74,7 @@ def button_style() -> str:
         outline: none;
         border: solid;
         border-width: 2px;
-        border-color: {Palette.accent()};
+        border-color: rgba{Palette.accent().toTuple()};
         padding: 0px 8px;
     }}
     QPushButton::disabled{{
@@ -108,7 +108,7 @@ def line_edit_style_main() -> str:
     QLineEdit::focus{{
         border-style: solid;
         border-width: 2px;
-        border-color: {Palette.accent()};
+        border-color: rgba{Palette.accent().toTuple()};
         padding: 0px 2px;
     }}
     QLineEdit::disabled{{
@@ -412,7 +412,7 @@ def tag_remove_button_style(
 
 def widget_underline_style() -> str:
     return f"""
-        background: {Palette.accent()};
+        background: rgba{Palette.accent().toTuple()};
         border-radius: 2px;
     """
 
@@ -475,7 +475,7 @@ def autofill_scroll_top_focus_style(object_name: str = "") -> str:
         border-top-right-radius: 6px;
         border: solid;
         border-width: 2px 2px 0px 2px;
-        border-color: {Palette.accent()};
+        border-color: rgba{Palette.accent().toTuple()};
         }}
     """
 
@@ -498,7 +498,7 @@ def autofill_line_edit_style() -> str:
         padding: 4px 4px;
         border: solid;
         border-width: 2px;
-        border-color: {Palette.accent()};
+        border-color: rgba{Palette.accent().toTuple()};
         }}
     """
 
@@ -524,7 +524,7 @@ def autofill_line_edit_top_style() -> str:
         padding: 4px 4px;
         border: solid;
         border-width: 0px 2px 2px 2px;
-        border-color: {Palette.accent()};
+        border-color: rgba{Palette.accent().toTuple()};
         }}
     """
 

--- a/src/tagstudio/qt/views/thumb_button.py
+++ b/src/tagstudio/qt/views/thumb_button.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
-import sys
 from typing import override
 
 from PySide6 import QtCore
@@ -13,10 +12,11 @@ from PySide6.QtGui import (
     QPainter,
     QPainterPath,
     QPaintEvent,
-    QPalette,
     QPen,
 )
 from PySide6.QtWidgets import QPushButton, QWidget
+
+from tagstudio.qt.models.palette import Palette
 
 
 class ThumbButton(QPushButton):
@@ -25,30 +25,9 @@ class ThumbButton(QPushButton):
         self.thumb_size: tuple[int, int] = thumb_size
         self.hovered = False
         self.selected = False
+        self.select_color = Palette.accent()
 
-        # NOTE: As of PySide 6.8.0.1, the QPalette.ColorRole.Accent role no longer works on Windows.
-        # The QPalette.ColorRole.AlternateBase does for some reason, but not on macOS.
-        self.select_color: QColor
-        if sys.platform == "win32":
-            self.select_color = QPalette.color(
-                self.palette(),
-                QPalette.ColorGroup.Active,
-                QPalette.ColorRole.AlternateBase,
-            )
-            self.select_color.setHsl(
-                self.select_color.hslHue(),
-                self.select_color.hslSaturation(),
-                max(self.select_color.lightness(), 100),
-                255,
-            )
-        else:
-            self.select_color = QPalette.color(
-                self.palette(),
-                QPalette.ColorGroup.Active,
-                QPalette.ColorRole.Accent,
-            )
-
-        self.select_color_faded: QColor = QColor(self.select_color)
+        self.select_color_faded = Palette.accent()
         self.select_color_faded.setHsl(
             self.select_color_faded.hslHue(),
             self.select_color_faded.hslSaturation(),
@@ -56,26 +35,7 @@ class ThumbButton(QPushButton):
             127,
         )
 
-        self.hover_color: QColor
-        if sys.platform == "win32":
-            self.hover_color = QPalette.color(
-                self.palette(),
-                QPalette.ColorGroup.Active,
-                QPalette.ColorRole.AlternateBase,
-            )
-            self.hover_color.setHsl(
-                self.hover_color.hslHue(),
-                self.hover_color.hslSaturation(),
-                max(self.hover_color.lightness(), 100),
-                255,
-            )
-        else:
-            self.hover_color = QPalette.color(
-                self.palette(),
-                QPalette.ColorGroup.Active,
-                QPalette.ColorRole.Accent,
-            )
-
+        self.hover_color = Palette.accent()
         self.hover_color.setHsl(
             self.hover_color.hslHue(),
             self.hover_color.hslSaturation(),


### PR DESCRIPTION
### Summary
Fixes several issues with accent colors on Windows:
- Accent colors were oversaturated in the thumbnail grid
- Accent colors did not show for suggest boxes and other custom widgets
- URLs displayed as gray

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [x] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
