### PR TITLE
fix(ui): only update inspector once per thumbnail click

### DIFF
--- a/src/tagstudio/qt/mixed/item_thumb.py
+++ b/src/tagstudio/qt/mixed/item_thumb.py
@@ -311,17 +311,6 @@ class ItemThumb(FlowWidget):
                 else None
             )
         )
-
-        self.thumb_button.clicked.connect(
-            lambda: (
-                self.toggle_item_selection()
-                if (
-                    QGuiApplication.keyboardModifiers() != Qt.KeyboardModifier.ControlModifier
-                    and self.thumb_button.selected
-                )
-                else None
-            )
-        )
         self.set_mode(mode)
 
     @property


### PR DESCRIPTION
### Summary

Only update the inspector panel once per file click. Selection speed is noticeably faster. Fixes #1486. 

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
