### PR TITLE
fix: prevent segfaults after progress bar tasks

### DIFF
--- a/src/tagstudio/qt/utils/custom_runnable.py
+++ b/src/tagstudio/qt/utils/custom_runnable.py
@@ -2,17 +2,23 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 
+from collections.abc import Callable
+from typing import override
+
 from PySide6.QtCore import QObject, QRunnable, Signal
 
 
 class CustomRunnable(QRunnable, QObject):  # pyright: ignore[reportUnsafeMultipleInheritance]
     done = Signal()
 
-    def __init__(self, function) -> None:
+    def __init__(self, function: Callable[..., None]) -> None:
         QRunnable.__init__(self)
         QObject.__init__(self)
+        self.setAutoDelete(False)
         self.function = function
 
+    @override
     def run(self):
         self.function()
         self.done.emit()
+        self.deleteLater()


### PR DESCRIPTION
### Summary
(Should) fix #1489 by not letting Qt garbage collect the `CustomRunnable` class before its done signal can emit. Also adds some type hints and a decorator since I'm in the neighborhood and need a treat after this nightmare of a bug.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
