### PR TITLE
fix: escape filename in glob matching while relinking entries

### DIFF
--- a/src/tagstudio/core/library/alchemy/registries/unlinked_registry.py
+++ b/src/tagstudio/core/library/alchemy/registries/unlinked_registry.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import structlog
-from wcmatch import pathlib
+from wcmatch import glob, pathlib
 
 from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.models import Entry
@@ -54,7 +54,7 @@ class UnlinkedRegistry:
         # NOTE: ignore_to_glob() is needed for wcmatch, not ripgrep.
         ignore_patterns = ignore_to_glob(Ignore.get_patterns(library_dir))
         for path in pathlib.Path(str(library_dir)).glob(
-            f"***/{match_entry.path.name}",
+            patterns=f"***/{glob.escape(match_entry.path.name)}",
             flags=PATH_GLOB_FLAGS,
             exclude=ignore_patterns,
         ):


### PR DESCRIPTION
### Summary
Fixes #1491 by escaping the unlinked entry filename before glob matching. Should also fix any other undocumented cases where glob characters in filenames were causing issues with entry relinking.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [x] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
