### PR TITLE
refactor: library scanning

### DIFF
--- a/src/tagstudio/core/library/refresh.py
+++ b/src/tagstudio/core/library/refresh.py
@@ -134,23 +134,29 @@ def _scan_with_ripgrep(scan_dir: Path, ignore_patterns: list[str]) -> Iterator[P
         ],
         cwd=scan_dir,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
         text=True,
     )
 
     assert process.stdout is not None
 
+    completed = False
+    return_code: int | None = None
     try:
         for line in process.stdout:
             yield scan_dir / line.rstrip("\n")
+        completed = True
     finally:
-        stderr = process.stderr.read() if process.stderr else ""
         process.stdout.close()
+
+        if not completed and process.poll() is None:
+            process.terminate()
+
         return_code = process.wait()
         compiled_ignore_path.unlink(missing_ok=True)
 
     if return_code != 0:
-        raise RuntimeError(f"ripgrep scan failed with exit code {return_code}: {stderr}")
+        logger.error(f"[Refresh] ripgrep scan failed with exit code {return_code}")
 
 
 def _scan_with_internal_scanner(scan_dir: Path, ignore_patterns: list[str]) -> Iterator[Path]:

--- a/src/tagstudio/core/library/refresh.py
+++ b/src/tagstudio/core/library/refresh.py
@@ -3,6 +3,7 @@
 
 
 import shutil
+import subprocess
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime as dt
@@ -15,7 +16,6 @@ from wcmatch import pathlib
 from tagstudio.core.library.alchemy.library import Library
 from tagstudio.core.library.alchemy.models import Entry
 from tagstudio.core.library.ignore import PATH_GLOB_FLAGS, Ignore, ignore_to_glob
-from tagstudio.core.utils.silent_subprocess import silent_run  # pyright: ignore
 
 logger = structlog.get_logger(__name__)
 
@@ -49,159 +49,118 @@ class RefreshTracker:
             index = end
         self.files_not_in_library = []
 
-    def refresh_dir(self, library_dir: Path, force_internal_tools: bool = False) -> Iterator[int]:
+    def refresh_dir(self, force_internal_tools: bool = False) -> Iterator[int]:
         """Scan a directory for files, and add those relative filenames to internal variables.
 
         Args:
-            library_dir (Path): The library directory.
             force_internal_tools (bool): Option to force the use of internal tools for scanning
                 (i.e. wcmatch) instead of using tools found on the system (i.e. ripgrep).
         """
         if self.library.library_dir is None:
             raise ValueError("No library directory set.")
 
-        ignore_patterns = Ignore.get_patterns(library_dir)
-
-        if force_internal_tools:
-            return self.__wc_add(library_dir, ignore_to_glob(ignore_patterns))
-
-        dir_list: list[str] | None = self.__get_dir_list(library_dir, ignore_patterns)
-
-        # Use ripgrep if it was found and working, else fallback to wcmatch.
-        if dir_list is not None:
-            return self.__rg_add(library_dir, dir_list)
-        else:
-            return self.__wc_add(library_dir, ignore_to_glob(ignore_patterns))
-
-    def __get_dir_list(self, library_dir: Path, ignore_patterns: list[str]) -> list[str] | None:
-        """Use ripgrep to return a list of matched directories and files.
-
-        Return `None` if ripgrep not found on system.
-        """
-        rg_path = shutil.which("rg")
-        # Use ripgrep if found on system
-        if rg_path is not None:
-            logger.info("[Refresh: Using ripgrep for scanning]")
-
-            compiled_ignore_path = library_dir / ".TagStudio" / ".compiled_ignore"
-
-            # Write compiled ignore patterns (built-in + user) to a temp file to pass to ripgrep
-            with open(compiled_ignore_path, "w") as pattern_file:
-                pattern_file.write("\n".join(ignore_patterns))
-
-            result = silent_run(
-                " ".join(
-                    [
-                        "rg",
-                        "--files",
-                        "--follow",
-                        "--hidden",
-                        "--ignore-file",
-                        f'"{str(compiled_ignore_path)}"',
-                    ]
-                ),
-                cwd=library_dir,
-                capture_output=True,
-                shell=True,
-                encoding="UTF-8",
-            )
-            compiled_ignore_path.unlink()
-
-            if result.stderr:
-                logger.error(result.stderr)
-
-            return result.stdout.splitlines()  # pyright: ignore [reportReturnType]
-
-        logger.warning("[Refresh: ripgrep not found on system]")
-        return None
-
-    def __rg_add(self, library_dir: Path, dir_list: list[str]) -> Iterator[int]:
-        start_time_total = time()
-        start_time_loop = time()
-        dir_file_count = 0
+        scanning_time_start = time()
+        yield_output_loop_start = time()
+        total_files_discovered: int = 0
 
         known_paths = {Path(path) for path in self.library.get_paths()}
         self.files_not_in_library = []
 
-        for r in dir_list:
-            f = pathlib.Path(r)
-
-            end_time_loop = time()
+        for path in scan_for_files(self.library.library_dir, force_internal_tools):
             # Yield output every 1/30 of a second
-            if (end_time_loop - start_time_loop) > 0.034:
-                yield dir_file_count
-                start_time_loop = time()
+            yield_output_loop_end = time()
 
-            # Skip if the file/path is already mapped in the Library
-            if f in self.library.included_files:
-                dir_file_count += 1
-                continue
+            if (yield_output_loop_end - yield_output_loop_start) > 0.034:
+                yield total_files_discovered
+                yield_output_loop_start = time()
 
             # Ignore if the file is a directory
-            if f.is_dir():
+            if path.is_dir():
                 continue
 
-            dir_file_count += 1
-            self.library.included_files.add(f)
+            total_files_discovered += 1
+            relative_path = path.relative_to(self.library.library_dir)
 
-            if f not in known_paths:
-                self.files_not_in_library.append(f)
+            if relative_path not in known_paths:
+                self.files_not_in_library.append(relative_path)
 
-        end_time_total = time()
-        yield dir_file_count
+        scanning_time_end = time()
+        yield total_files_discovered
+
         logger.info(
-            "[Refresh]: Directory scan time",
-            path=library_dir,
-            duration=(end_time_total - start_time_total),
-            files_scanned=dir_file_count,
-            tool_used="ripgrep (system)",
+            "[Refresh] Scan completed",
+            scan_dir=self.library.library_dir,
+            duration=(scanning_time_end - scanning_time_start),
+            files_scanned=total_files_discovered,
         )
 
-    def __wc_add(self, library_dir: Path, ignore_patterns: list[str]) -> Iterator[int]:
-        start_time_total = time()
-        start_time_loop = time()
-        dir_file_count = 0
 
-        known_paths = {Path(path) for path in self.library.get_paths()}
-        self.files_not_in_library = []
+def scan_for_files(scan_dir: Path, force_internal_tools: bool) -> Iterator[Path]:
+    ignore_patterns = Ignore.get_patterns(scan_dir)
 
-        logger.info("[Refresh]: Falling back to wcmatch for scanning")
+    ripgrep_path = shutil.which("rg")
 
-        try:
-            for f in pathlib.Path(str(library_dir)).glob(
+    if ripgrep_path is None or force_internal_tools:
+        yield from _scan_with_internal_scanner(scan_dir, ignore_to_glob(ignore_patterns))
+    else:
+        yield from _scan_with_ripgrep(scan_dir, ignore_patterns)
+
+
+def _scan_with_ripgrep(scan_dir: Path, ignore_patterns: list[str]) -> Iterator[Path]:
+    logger.info("[Refresh] Starting scan", scanner="ripgrep", scan_dir=scan_dir)
+
+    compiled_ignore_path = scan_dir / ".TagStudio" / ".compiled_ignore"
+
+    # Write compiled ignore patterns (built-in + user) to a temp file to pass to ripgrep
+    try:
+        with open(compiled_ignore_path, "w") as pattern_file:
+            pattern_file.write("\n".join(ignore_patterns))
+    except OSError as e:
+        raise FileNotFoundError(
+            f"Unable to write compiled ignore file: {compiled_ignore_path}"
+        ) from e
+
+    if not compiled_ignore_path.is_file():
+        raise FileNotFoundError(f"Compiled ignore file was not created: {compiled_ignore_path}")
+
+    process = subprocess.Popen(
+        [
+            "rg",
+            "--files",
+            "--follow",
+            "--hidden",
+            "--ignore-file",
+            str(compiled_ignore_path),
+        ],
+        cwd=scan_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert process.stdout is not None
+
+    try:
+        for line in process.stdout:
+            yield scan_dir / line.rstrip("\n")
+    finally:
+        stderr = process.stderr.read() if process.stderr else ""
+        process.stdout.close()
+        return_code = process.wait()
+        compiled_ignore_path.unlink(missing_ok=True)
+
+    if return_code != 0:
+        raise RuntimeError(f"ripgrep scan failed with exit code {return_code}: {stderr}")
+
+
+def _scan_with_internal_scanner(scan_dir: Path, ignore_patterns: list[str]) -> Iterator[Path]:
+    logger.info("[Refresh] Starting scan", scanner="internal", scan_dir=scan_dir)
+
+    try:
+        yield from (
+            pathlib.Path(str(scan_dir)).glob(
                 "***/*", flags=PATH_GLOB_FLAGS, exclude=ignore_patterns
-            ):
-                end_time_loop = time()
-                # Yield output every 1/30 of a second
-                if (end_time_loop - start_time_loop) > 0.034:
-                    yield dir_file_count
-                    start_time_loop = time()
-
-                # Skip if the file/path is already mapped in the Library
-                if f in self.library.included_files:
-                    dir_file_count += 1
-                    continue
-
-                # Ignore if the file is a directory
-                if f.is_dir():
-                    continue
-
-                dir_file_count += 1
-                self.library.included_files.add(f)
-
-                relative_path = f.relative_to(library_dir)
-
-                if relative_path not in known_paths:
-                    self.files_not_in_library.append(relative_path)
-        except ValueError:
-            logger.info("[Refresh]: ValueError when refreshing directory with wcmatch!")
-
-        end_time_total = time()
-        yield dir_file_count
-        logger.info(
-            "[Refresh]: Directory scan time",
-            path=library_dir,
-            duration=(end_time_total - start_time_total),
-            files_scanned=dir_file_count,
-            tool_used="wcmatch (internal)",
+            )
         )
+    except ValueError:
+        logger.error("[Refresh] ValueError when scanning directory with internal scanner!")

--- a/src/tagstudio/core/library/refresh.py
+++ b/src/tagstudio/core/library/refresh.py
@@ -133,9 +133,10 @@ def _scan_with_ripgrep(scan_dir: Path, ignore_patterns: list[str]) -> Iterator[P
             str(compiled_ignore_path),
         ],
         cwd=scan_dir,
+        text=True,
+        encoding="utf-8",
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
-        text=True,
     )
 
     assert process.stdout is not None

--- a/src/tagstudio/core/library/refresh.py
+++ b/src/tagstudio/core/library/refresh.py
@@ -119,6 +119,8 @@ class RefreshTracker:
         start_time_total = time()
         start_time_loop = time()
         dir_file_count = 0
+
+        known_paths = {Path(path) for path in self.library.get_paths()}
         self.files_not_in_library = []
 
         for r in dir_list:
@@ -142,7 +144,7 @@ class RefreshTracker:
             dir_file_count += 1
             self.library.included_files.add(f)
 
-            if not self.library.has_entry_with_path(f):
+            if f not in known_paths:
                 self.files_not_in_library.append(f)
 
         end_time_total = time()
@@ -159,6 +161,8 @@ class RefreshTracker:
         start_time_total = time()
         start_time_loop = time()
         dir_file_count = 0
+
+        known_paths = {Path(path) for path in self.library.get_paths()}
         self.files_not_in_library = []
 
         logger.info("[Refresh]: Falling back to wcmatch for scanning")
@@ -187,7 +191,7 @@ class RefreshTracker:
 
                 relative_path = f.relative_to(library_dir)
 
-                if not self.library.has_entry_with_path(relative_path):
+                if relative_path not in known_paths:
                     self.files_not_in_library.append(relative_path)
         except ValueError:
             logger.info("[Refresh]: ValueError when refreshing directory with wcmatch!")

--- a/src/tagstudio/qt/qt_driver.py
+++ b/src/tagstudio/qt/qt_driver.py
@@ -1079,7 +1079,7 @@ class QtDriver(DriverMixin, QObject):
         pw.update_label(Translations["library.refresh.scanning_preparing"])
         pw.show()
 
-        iterator = FunctionIterator(lambda lib=self.lib.library_dir: tracker.refresh_dir(lib))
+        iterator = FunctionIterator(lambda: tracker.refresh_dir())
         iterator.value.connect(
             lambda x: (
                 pw.update_progress(x + 1),

--- a/tests/core/library/test_refresh.py
+++ b/tests/core/library/test_refresh.py
@@ -26,7 +26,7 @@ def test_refresh_new_files(library: Library, exclude_mode: bool):
     (library_dir / IGNORE_NAME).write_text("*.md" if exclude_mode else "*\n!*.md")
 
     # Test if the single file was added
-    list(registry.refresh_dir(library_dir, force_internal_tools=True))
+    list(registry.refresh_dir(force_internal_tools=True))
     assert set(registry.files_not_in_library) == set([Path(IGNORE_NAME), Path("FOO.MD")])
 
 
@@ -43,7 +43,7 @@ def test_refresh_multi_byte_filenames(library: Library):
     (library_dir / "umlaute äöü.txt").touch()
 
     # Test if all files were added with their correct names and without exceptions
-    list(registry.refresh_dir(library_dir))
+    list(registry.refresh_dir())
     assert Path("こんにちは.txt") in registry.files_not_in_library
     assert Path("em–dash.txt") in registry.files_not_in_library
     assert Path("apostrophe’.txt") in registry.files_not_in_library


### PR DESCRIPTION
### Summary

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

- Library scanning is reworked to get a list of all entry paths found in the library *before* scanning, rather than checking for each individual scanned file. This cuts down dramatically on the number of SQL queries created and improves scanning performance.
- Previously, each scanner would be responsible for then also handling and running logic on the scanned files. Now, each scanner is only responsible for producing a list of discovered paths. The logic run on each file is instead placed in `refresh_dir()`, which consumes the files produced by which ever scanner is used.
- The logic behind which scanner is used is moved into `scan_for_files()`. This way, any function that needs to scan for files can just blindly call `scan_for_files()` without needing to determine which scanner should be used, and it will receive an iterator of files.
- Each scanner method has been renamed to be clearer.
  - To help with maintainability, I would recommend *not* shortening names arbitrarily. Good lord, the source code is filled with so many 2 or 3 character names.
- Renamed the `wcmatch` scanner to simply "internal". This better reflects its purpose, and helps if the implementation of the internal scanner ever changes down the line.
- Reworked the implementation of the ripgrep scanner to better process the discovered files *as* they're scanned, rather than scanning them all beforehand and only then processing them.
- Changed how scanning is timed to include the time it takes for the ripgrep scanner to.. scan. Before, it would only track the time it took to *process* the files, excluding the time it took to scan them.
- Made the scanner methods (and `scan_for_files()`) static, as they don't rely on any attributes of `RefreshTracker`. 

### Notes

- This conflicts with #1242. If #1242 is merged first, I can rewrite this PR and rebase it on #1242, since this is a fairly simple PR.
- `ignore_to_glob()` produces a *lot* of redundant, recursive patterns that slow down the internal scanner so much that it's quite literally unusable on my primary library (~65k files, with a large ignore file). I was never able to get it to produce any output on my primary library. It may be worth looking into improving the translation from gitignore-style to glob, or replacing the internal scanner implementation altogether.
- It could be worth having `refresh_dir()` emit more detailed progress, rather than just an `int`.
- `refresh_dir()` is set to only emit output every 1/30th of a second.
  - Is there a reason `refresh_dir()` is the one responsible for enforcing this limit? At least to me personally, it'd make more sense to place the responsibility on the UI for limiting the rate of UI updates. Especially if another, rapidly-updating data source were connected to a progress UI.
  - It may be a good idea to create a general utility method for enforcing an update limit (say, it accepts an iterator, and returns an iterator limited to a certain update limit).
- It could be worth having ripgrep use null separators, rather than new lines, to prevent issues with certain file names.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
