### PR TITLE
fix: avoid reusing singleton field template instances across libraries

### DIFF
--- a/src/tagstudio/core/library/alchemy/constants.py
+++ b/src/tagstudio/core/library/alchemy/constants.py
@@ -39,13 +39,23 @@ SELECT tag_id FROM ChildTags;
 """)
 
 
-DEFAULT_FIELD_TEMPLATES = (
-    TextFieldTemplate(name="Title"),
-    TextFieldTemplate(name="Author"),
-    TextFieldTemplate(name="Artist"),
-    TextFieldTemplate(name="URL"),
-    TextFieldTemplate(name="Description", is_multiline=True),
-    TextFieldTemplate(name="Notes", is_multiline=True),
-    TextFieldTemplate(name="Comments", is_multiline=True),
-    DatetimeFieldTemplate(name="Date"),
-)
+def default_field_templates() -> tuple[TextFieldTemplate | DatetimeFieldTemplate, ...]:
+    """Build a fresh set of default field template instances.
+
+    These must be constructed anew on every call rather than shared as module-level
+    singletons. SQLAlchemy instances remember their persistent identity once they've been
+    added and flushed to a session; reusing the same instances across multiple `Library`
+    (and therefore multiple database engines/sessions) causes every `Library` after the
+    first to silently skip inserting these rows, since SQLAlchemy assumes they already
+    exist.
+    """
+    return (
+        TextFieldTemplate(name="Title"),
+        TextFieldTemplate(name="Author"),
+        TextFieldTemplate(name="Artist"),
+        TextFieldTemplate(name="URL"),
+        TextFieldTemplate(name="Description", is_multiline=True),
+        TextFieldTemplate(name="Notes", is_multiline=True),
+        TextFieldTemplate(name="Comments", is_multiline=True),
+        DatetimeFieldTemplate(name="Date"),
+    )

--- a/src/tagstudio/core/library/alchemy/library.py
+++ b/src/tagstudio/core/library/alchemy/library.py
@@ -65,10 +65,10 @@ from tagstudio.core.library.alchemy.constants import (
     DB_VERSION,
     DB_VERSION_CURRENT_KEY,
     DB_VERSION_INITIAL_KEY,
-    DEFAULT_FIELD_TEMPLATES,
     JSON_FILENAME,
     SQL_FILENAME,
     TAG_CHILDREN_QUERY,
+    default_field_templates,
 )
 from tagstudio.core.library.alchemy.db import Base as ModelBase
 from tagstudio.core.library.alchemy.enums import MAX_SQL_VARIABLES, BrowsingState, SortingModeEnum
@@ -461,7 +461,7 @@ class Library:
             session.flush()
 
             # Add default field templates
-            for template in DEFAULT_FIELD_TEMPLATES:
+            for template in default_field_templates():
                 session.add(template)
             session.flush()
 

--- a/src/tagstudio/core/library/alchemy/migrations.py
+++ b/src/tagstudio/core/library/alchemy/migrations.py
@@ -18,7 +18,7 @@ from tagstudio.core.library.alchemy.constants import (
     DB_VERSION,
     DB_VERSION_CURRENT_KEY,
     DB_VERSION_INITIAL_KEY,
-    DEFAULT_FIELD_TEMPLATES,
+    default_field_templates,
 )
 from tagstudio.core.library.alchemy.fields import LEGACY_FIELD_MAP, DatetimeField, TextField
 from tagstudio.core.library.alchemy.joins import TagParent
@@ -468,7 +468,7 @@ class MigrationTo200(DBMigration):
 
         # Add default field templates
         logger.info(fmt_log("Adding default field templates..."))
-        for template in DEFAULT_FIELD_TEMPLATES:
+        for template in default_field_templates():
             session.add(template)
         session.flush()
 


### PR DESCRIPTION
### Summary
DEFAULT_FIELD_TEMPLATES in constants.py is a tuple of pre-built TextFieldTemplate/DatetimeFieldTemplate instances, reused as-is whenever a library is created (Library.create_library(), MigrationTo200). Once SQLAlchemy flushes those instances to a session, it remembers them as persistent. So any library created after the first one in the same process gets skipped entirely and silently ends up with no default field templates.

Fix: replace the shared tuple with a default_field_templates() function that builds fresh instances each call, and update both calls accordingly.

Mostly invisible in normal single-library app usage, but affects anything creating multiple libraries per process (e.g. the test suite).

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [X] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [ ] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [X] Basic functionality
    - [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
