### PR TITLE
fix: include renderers in pyinstaller build

### DIFF
--- a/scripts/tagstudio.spec
+++ b/scripts/tagstudio.spec
@@ -13,6 +13,7 @@ from tomllib import load
 from PyInstaller.building.api import COLLECT, EXE, PYZ
 from PyInstaller.building.build_main import Analysis
 from PyInstaller.building.osx import BUNDLE
+from PyInstaller.utils.hooks import collect_submodules
 
 parser = ArgumentParser()
 # HACK: Without this, the script will fail if empty arguments are passed.
@@ -45,7 +46,7 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=datafiles,
-    hiddenimports=[],
+    hiddenimports=collect_submodules("tagstudio.previews.renderers"),
     hookspath=[],
     hooksconfig={},
     excludes=[],


### PR DESCRIPTION
### Summary

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[Contributing](https://docs.tagstud.io/contributing) page on our documentation site,
or in the project's [CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/docs/contributing.md) file.

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

Fixes file renderers not being included in Pyinstaller builds, causing file previews to not render, and new thumbnails to not be generated.

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

- Platforms Tested:
    - [ ] Windows x86
    - [ ] Windows ARM
    - [ ] macOS x86
    - [ ] macOS ARM
    - [x] Linux x86
    - [ ] Linux ARM
      <!-- If an unspecified platform was tested, please add it here -->
- Tested For:
    - [x] Basic functionality
    - [x] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
      <!-- If other important criteria was tested for, please add it here -->
